### PR TITLE
Fix to harris sch6

### DIFF
--- a/coreir_compute/harris_sch6_compute.json
+++ b/coreir_compute/harris_sch6_compute.json
@@ -8,28 +8,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_792_793_794":{
+          "bitand_771_772_773":{
             "modref":"corebit.and"
           },
-          "bitand_794_795_796":{
+          "bitand_773_774_775":{
             "modref":"corebit.and"
           },
-          "bitand_796_797_798":{
+          "bitand_775_776_777":{
             "modref":"corebit.and"
           },
-          "bitand_798_799_800":{
+          "bitand_777_778_779":{
             "modref":"corebit.and"
           },
-          "bitand_800_801_802":{
+          "bitand_779_780_781":{
             "modref":"corebit.and"
           },
-          "bitand_802_803_804":{
+          "bitand_781_782_783":{
             "modref":"corebit.and"
           },
-          "bitand_804_805_806":{
+          "bitand_783_784_785":{
             "modref":"corebit.and"
           },
-          "bitand_806_808_809":{
+          "bitand_785_787_788":{
             "modref":"corebit.and"
           },
           "const_p0_0":{
@@ -37,7 +37,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__807":{
+          "const_p1__786":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -47,86 +47,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_8092550":{
+          "mux_7882550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_807_cim_stencil_2_808":{
+          "sle_786_cim_stencil_2_787":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_1_cim_stencil_2_792":{
+          "slt_cim_stencil_1_cim_stencil_2_771":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_3_cim_stencil_2_793":{
+          "slt_cim_stencil_3_cim_stencil_2_772":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_4_cim_stencil_2_795":{
+          "slt_cim_stencil_4_cim_stencil_2_774":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_5_cim_stencil_2_797":{
+          "slt_cim_stencil_5_cim_stencil_2_776":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_6_cim_stencil_2_799":{
+          "slt_cim_stencil_6_cim_stencil_2_778":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_7_cim_stencil_2_801":{
+          "slt_cim_stencil_7_cim_stencil_2_780":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_8_cim_stencil_2_803":{
+          "slt_cim_stencil_8_cim_stencil_2_782":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_9_cim_stencil_2_805":{
+          "slt_cim_stencil_9_cim_stencil_2_784":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_1_cim_stencil_2_792.out","bitand_792_793_794.in0"],
-          ["slt_cim_stencil_3_cim_stencil_2_793.out","bitand_792_793_794.in1"],
-          ["bitand_794_795_796.in0","bitand_792_793_794.out"],
-          ["slt_cim_stencil_4_cim_stencil_2_795.out","bitand_794_795_796.in1"],
-          ["bitand_796_797_798.in0","bitand_794_795_796.out"],
-          ["slt_cim_stencil_5_cim_stencil_2_797.out","bitand_796_797_798.in1"],
-          ["bitand_798_799_800.in0","bitand_796_797_798.out"],
-          ["slt_cim_stencil_6_cim_stencil_2_799.out","bitand_798_799_800.in1"],
-          ["bitand_800_801_802.in0","bitand_798_799_800.out"],
-          ["slt_cim_stencil_7_cim_stencil_2_801.out","bitand_800_801_802.in1"],
-          ["bitand_802_803_804.in0","bitand_800_801_802.out"],
-          ["slt_cim_stencil_8_cim_stencil_2_803.out","bitand_802_803_804.in1"],
-          ["bitand_804_805_806.in0","bitand_802_803_804.out"],
-          ["slt_cim_stencil_9_cim_stencil_2_805.out","bitand_804_805_806.in1"],
-          ["bitand_806_808_809.in0","bitand_804_805_806.out"],
-          ["sle_807_cim_stencil_2_808.out","bitand_806_808_809.in1"],
-          ["mux_8092550.sel","bitand_806_808_809.out"],
-          ["mux_8092550.in0","const_p0_0.out"],
-          ["sle_807_cim_stencil_2_808.in0","const_p1__807.out"],
-          ["mux_8092550.in1","const_p255_255.out"],
-          ["self.out_cim_output_stencil","mux_8092550.out"],
-          ["slt_cim_stencil_1_cim_stencil_2_792.in0","self.in0_cim_stencil.0"],
-          ["sle_807_cim_stencil_2_808.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_1_cim_stencil_2_792.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_793.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_4_cim_stencil_2_795.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_5_cim_stencil_2_797.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_6_cim_stencil_2_799.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_7_cim_stencil_2_801.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_8_cim_stencil_2_803.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_9_cim_stencil_2_805.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_793.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_4_cim_stencil_2_795.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_5_cim_stencil_2_797.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_6_cim_stencil_2_799.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_7_cim_stencil_2_801.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_8_cim_stencil_2_803.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_9_cim_stencil_2_805.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_1_cim_stencil_2_771.out","bitand_771_772_773.in0"],
+          ["slt_cim_stencil_3_cim_stencil_2_772.out","bitand_771_772_773.in1"],
+          ["bitand_773_774_775.in0","bitand_771_772_773.out"],
+          ["slt_cim_stencil_4_cim_stencil_2_774.out","bitand_773_774_775.in1"],
+          ["bitand_775_776_777.in0","bitand_773_774_775.out"],
+          ["slt_cim_stencil_5_cim_stencil_2_776.out","bitand_775_776_777.in1"],
+          ["bitand_777_778_779.in0","bitand_775_776_777.out"],
+          ["slt_cim_stencil_6_cim_stencil_2_778.out","bitand_777_778_779.in1"],
+          ["bitand_779_780_781.in0","bitand_777_778_779.out"],
+          ["slt_cim_stencil_7_cim_stencil_2_780.out","bitand_779_780_781.in1"],
+          ["bitand_781_782_783.in0","bitand_779_780_781.out"],
+          ["slt_cim_stencil_8_cim_stencil_2_782.out","bitand_781_782_783.in1"],
+          ["bitand_783_784_785.in0","bitand_781_782_783.out"],
+          ["slt_cim_stencil_9_cim_stencil_2_784.out","bitand_783_784_785.in1"],
+          ["bitand_785_787_788.in0","bitand_783_784_785.out"],
+          ["sle_786_cim_stencil_2_787.out","bitand_785_787_788.in1"],
+          ["mux_7882550.sel","bitand_785_787_788.out"],
+          ["mux_7882550.in0","const_p0_0.out"],
+          ["sle_786_cim_stencil_2_787.in0","const_p1__786.out"],
+          ["mux_7882550.in1","const_p255_255.out"],
+          ["self.out_cim_output_stencil","mux_7882550.out"],
+          ["slt_cim_stencil_1_cim_stencil_2_771.in0","self.in0_cim_stencil.0"],
+          ["sle_786_cim_stencil_2_787.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_1_cim_stencil_2_771.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_772.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_4_cim_stencil_2_774.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_5_cim_stencil_2_776.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_6_cim_stencil_2_778.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_7_cim_stencil_2_780.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_8_cim_stencil_2_782.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_9_cim_stencil_2_784.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_772.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_4_cim_stencil_2_774.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_5_cim_stencil_2_776.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_6_cim_stencil_2_778.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_7_cim_stencil_2_780.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_8_cim_stencil_2_782.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_9_cim_stencil_2_784.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_output_stencil_1":{
@@ -135,28 +135,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_866_867_868":{
+          "bitand_845_846_847":{
             "modref":"corebit.and"
           },
-          "bitand_868_869_870":{
+          "bitand_847_848_849":{
             "modref":"corebit.and"
           },
-          "bitand_870_871_872":{
+          "bitand_849_850_851":{
             "modref":"corebit.and"
           },
-          "bitand_872_873_874":{
+          "bitand_851_852_853":{
             "modref":"corebit.and"
           },
-          "bitand_874_875_876":{
+          "bitand_853_854_855":{
             "modref":"corebit.and"
           },
-          "bitand_876_877_878":{
+          "bitand_855_856_857":{
             "modref":"corebit.and"
           },
-          "bitand_878_879_880":{
+          "bitand_857_858_859":{
             "modref":"corebit.and"
           },
-          "bitand_880_882_883":{
+          "bitand_859_861_862":{
             "modref":"corebit.and"
           },
           "const_p0_0$1":{
@@ -164,7 +164,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__881":{
+          "const_p1__860":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -174,86 +174,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_8832550":{
+          "mux_8622550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_881_cim_stencil_11_882":{
+          "sle_860_cim_stencil_11_861":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_10_cim_stencil_11_866":{
+          "slt_cim_stencil_10_cim_stencil_11_845":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_12_cim_stencil_11_867":{
+          "slt_cim_stencil_12_cim_stencil_11_846":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_13_cim_stencil_11_869":{
+          "slt_cim_stencil_13_cim_stencil_11_848":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_14_cim_stencil_11_871":{
+          "slt_cim_stencil_14_cim_stencil_11_850":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_15_cim_stencil_11_873":{
+          "slt_cim_stencil_15_cim_stencil_11_852":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_16_cim_stencil_11_875":{
+          "slt_cim_stencil_16_cim_stencil_11_854":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_17_cim_stencil_11_877":{
+          "slt_cim_stencil_17_cim_stencil_11_856":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_18_cim_stencil_11_879":{
+          "slt_cim_stencil_18_cim_stencil_11_858":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_10_cim_stencil_11_866.out","bitand_866_867_868.in0"],
-          ["slt_cim_stencil_12_cim_stencil_11_867.out","bitand_866_867_868.in1"],
-          ["bitand_868_869_870.in0","bitand_866_867_868.out"],
-          ["slt_cim_stencil_13_cim_stencil_11_869.out","bitand_868_869_870.in1"],
-          ["bitand_870_871_872.in0","bitand_868_869_870.out"],
-          ["slt_cim_stencil_14_cim_stencil_11_871.out","bitand_870_871_872.in1"],
-          ["bitand_872_873_874.in0","bitand_870_871_872.out"],
-          ["slt_cim_stencil_15_cim_stencil_11_873.out","bitand_872_873_874.in1"],
-          ["bitand_874_875_876.in0","bitand_872_873_874.out"],
-          ["slt_cim_stencil_16_cim_stencil_11_875.out","bitand_874_875_876.in1"],
-          ["bitand_876_877_878.in0","bitand_874_875_876.out"],
-          ["slt_cim_stencil_17_cim_stencil_11_877.out","bitand_876_877_878.in1"],
-          ["bitand_878_879_880.in0","bitand_876_877_878.out"],
-          ["slt_cim_stencil_18_cim_stencil_11_879.out","bitand_878_879_880.in1"],
-          ["bitand_880_882_883.in0","bitand_878_879_880.out"],
-          ["sle_881_cim_stencil_11_882.out","bitand_880_882_883.in1"],
-          ["mux_8832550.sel","bitand_880_882_883.out"],
-          ["mux_8832550.in0","const_p0_0$1.out"],
-          ["sle_881_cim_stencil_11_882.in0","const_p1__881.out"],
-          ["mux_8832550.in1","const_p255_255$1.out"],
-          ["self.out_cim_output_stencil","mux_8832550.out"],
-          ["slt_cim_stencil_10_cim_stencil_11_866.in0","self.in0_cim_stencil.0"],
-          ["sle_881_cim_stencil_11_882.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_10_cim_stencil_11_866.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_12_cim_stencil_11_867.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_13_cim_stencil_11_869.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_14_cim_stencil_11_871.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_15_cim_stencil_11_873.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_16_cim_stencil_11_875.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_17_cim_stencil_11_877.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_18_cim_stencil_11_879.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_12_cim_stencil_11_867.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_13_cim_stencil_11_869.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_14_cim_stencil_11_871.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_15_cim_stencil_11_873.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_16_cim_stencil_11_875.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_17_cim_stencil_11_877.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_18_cim_stencil_11_879.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_10_cim_stencil_11_845.out","bitand_845_846_847.in0"],
+          ["slt_cim_stencil_12_cim_stencil_11_846.out","bitand_845_846_847.in1"],
+          ["bitand_847_848_849.in0","bitand_845_846_847.out"],
+          ["slt_cim_stencil_13_cim_stencil_11_848.out","bitand_847_848_849.in1"],
+          ["bitand_849_850_851.in0","bitand_847_848_849.out"],
+          ["slt_cim_stencil_14_cim_stencil_11_850.out","bitand_849_850_851.in1"],
+          ["bitand_851_852_853.in0","bitand_849_850_851.out"],
+          ["slt_cim_stencil_15_cim_stencil_11_852.out","bitand_851_852_853.in1"],
+          ["bitand_853_854_855.in0","bitand_851_852_853.out"],
+          ["slt_cim_stencil_16_cim_stencil_11_854.out","bitand_853_854_855.in1"],
+          ["bitand_855_856_857.in0","bitand_853_854_855.out"],
+          ["slt_cim_stencil_17_cim_stencil_11_856.out","bitand_855_856_857.in1"],
+          ["bitand_857_858_859.in0","bitand_855_856_857.out"],
+          ["slt_cim_stencil_18_cim_stencil_11_858.out","bitand_857_858_859.in1"],
+          ["bitand_859_861_862.in0","bitand_857_858_859.out"],
+          ["sle_860_cim_stencil_11_861.out","bitand_859_861_862.in1"],
+          ["mux_8622550.sel","bitand_859_861_862.out"],
+          ["mux_8622550.in0","const_p0_0$1.out"],
+          ["sle_860_cim_stencil_11_861.in0","const_p1__860.out"],
+          ["mux_8622550.in1","const_p255_255$1.out"],
+          ["self.out_cim_output_stencil","mux_8622550.out"],
+          ["slt_cim_stencil_10_cim_stencil_11_845.in0","self.in0_cim_stencil.0"],
+          ["sle_860_cim_stencil_11_861.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_10_cim_stencil_11_845.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_12_cim_stencil_11_846.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_13_cim_stencil_11_848.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_14_cim_stencil_11_850.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_15_cim_stencil_11_852.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_16_cim_stencil_11_854.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_17_cim_stencil_11_856.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_18_cim_stencil_11_858.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_12_cim_stencil_11_846.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_13_cim_stencil_11_848.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_14_cim_stencil_11_850.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_15_cim_stencil_11_852.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_16_cim_stencil_11_854.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_17_cim_stencil_11_856.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_18_cim_stencil_11_858.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_stencil":{
@@ -264,89 +264,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_704_705_710":{
+          "add_683_684_689":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_711_712_713":{
+          "ashr_690_691_692":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_2_703_704":{
+          "ashr_lgxx_stencil_2_682_683":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_2_703_707":{
+          "ashr_lgxy_stencil_2_682_686":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_2_703_705":{
+          "ashr_lgyy_stencil_2_682_684":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__712":{
+          "const_p4__691":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__703":{
+          "const_p6__682":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__703$1":{
+          "const_p6__682$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__703$2":{
+          "const_p6__682$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_704_705_706":{
+          "mul_683_684_685":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_707_707_708":{
+          "mul_686_686_687":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_710_710_711":{
+          "mul_689_689_690":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_706_708_709":{
+          "sub_685_687_688":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_709_713_714":{
+          "sub_688_692_693":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_2_703_704.out","add_704_705_710.in0"],
-          ["ashr_lgyy_stencil_2_703_705.out","add_704_705_710.in1"],
-          ["mul_710_710_711.in0","add_704_705_710.out"],
-          ["mul_710_710_711.in1","add_704_705_710.out"],
-          ["mul_710_710_711.out","ashr_711_712_713.in0"],
-          ["const_p4__712.out","ashr_711_712_713.in1"],
-          ["sub_709_713_714.in1","ashr_711_712_713.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_703_704.in0"],
-          ["const_p6__703.out","ashr_lgxx_stencil_2_703_704.in1"],
-          ["mul_704_705_706.in0","ashr_lgxx_stencil_2_703_704.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_703_707.in0"],
-          ["const_p6__703$2.out","ashr_lgxy_stencil_2_703_707.in1"],
-          ["mul_707_707_708.in0","ashr_lgxy_stencil_2_703_707.out"],
-          ["mul_707_707_708.in1","ashr_lgxy_stencil_2_703_707.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_703_705.in0"],
-          ["const_p6__703$1.out","ashr_lgyy_stencil_2_703_705.in1"],
-          ["mul_704_705_706.in1","ashr_lgyy_stencil_2_703_705.out"],
-          ["sub_706_708_709.in0","mul_704_705_706.out"],
-          ["sub_706_708_709.in1","mul_707_707_708.out"],
-          ["sub_709_713_714.out","self.out_cim_stencil"],
-          ["sub_709_713_714.in0","sub_706_708_709.out"]
+          ["ashr_lgxx_stencil_2_682_683.out","add_683_684_689.in0"],
+          ["ashr_lgyy_stencil_2_682_684.out","add_683_684_689.in1"],
+          ["mul_689_689_690.in0","add_683_684_689.out"],
+          ["mul_689_689_690.in1","add_683_684_689.out"],
+          ["mul_689_689_690.out","ashr_690_691_692.in0"],
+          ["const_p4__691.out","ashr_690_691_692.in1"],
+          ["sub_688_692_693.in1","ashr_690_691_692.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_682_683.in0"],
+          ["const_p6__682.out","ashr_lgxx_stencil_2_682_683.in1"],
+          ["mul_683_684_685.in0","ashr_lgxx_stencil_2_682_683.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_682_686.in0"],
+          ["const_p6__682$2.out","ashr_lgxy_stencil_2_682_686.in1"],
+          ["mul_686_686_687.in0","ashr_lgxy_stencil_2_682_686.out"],
+          ["mul_686_686_687.in1","ashr_lgxy_stencil_2_682_686.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_682_684.in0"],
+          ["const_p6__682$1.out","ashr_lgyy_stencil_2_682_684.in1"],
+          ["mul_683_684_685.in1","ashr_lgyy_stencil_2_682_684.out"],
+          ["sub_685_687_688.in0","mul_683_684_685.out"],
+          ["sub_685_687_688.in1","mul_686_686_687.out"],
+          ["sub_688_692_693.out","self.out_cim_stencil"],
+          ["sub_688_692_693.in0","sub_685_687_688.out"]
         ]
       },
       "hcompute_cim_stencil_1":{
@@ -357,457 +357,289 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_745_746_751":{
+          "add_724_725_730":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_752_753_754":{
+          "ashr_731_732_733":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_3_744_745":{
+          "ashr_lgxx_stencil_3_723_724":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_3_744_748":{
+          "ashr_lgxy_stencil_3_723_727":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_3_744_746":{
+          "ashr_lgyy_stencil_3_723_725":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__753":{
+          "const_p4__732":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__744":{
+          "const_p6__723":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__744$1":{
+          "const_p6__723$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__744$2":{
+          "const_p6__723$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_745_746_747":{
+          "mul_724_725_726":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_748_748_749":{
+          "mul_727_727_728":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_751_751_752":{
+          "mul_730_730_731":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_747_749_750":{
+          "sub_726_728_729":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_750_754_755":{
+          "sub_729_733_734":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_3_744_745.out","add_745_746_751.in0"],
-          ["ashr_lgyy_stencil_3_744_746.out","add_745_746_751.in1"],
-          ["mul_751_751_752.in0","add_745_746_751.out"],
-          ["mul_751_751_752.in1","add_745_746_751.out"],
-          ["mul_751_751_752.out","ashr_752_753_754.in0"],
-          ["const_p4__753.out","ashr_752_753_754.in1"],
-          ["sub_750_754_755.in1","ashr_752_753_754.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_3_744_745.in0"],
-          ["const_p6__744.out","ashr_lgxx_stencil_3_744_745.in1"],
-          ["mul_745_746_747.in0","ashr_lgxx_stencil_3_744_745.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_3_744_748.in0"],
-          ["const_p6__744$2.out","ashr_lgxy_stencil_3_744_748.in1"],
-          ["mul_748_748_749.in0","ashr_lgxy_stencil_3_744_748.out"],
-          ["mul_748_748_749.in1","ashr_lgxy_stencil_3_744_748.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_3_744_746.in0"],
-          ["const_p6__744$1.out","ashr_lgyy_stencil_3_744_746.in1"],
-          ["mul_745_746_747.in1","ashr_lgyy_stencil_3_744_746.out"],
-          ["sub_747_749_750.in0","mul_745_746_747.out"],
-          ["sub_747_749_750.in1","mul_748_748_749.out"],
-          ["sub_750_754_755.out","self.out_cim_stencil"],
-          ["sub_750_754_755.in0","sub_747_749_750.out"]
+          ["ashr_lgxx_stencil_3_723_724.out","add_724_725_730.in0"],
+          ["ashr_lgyy_stencil_3_723_725.out","add_724_725_730.in1"],
+          ["mul_730_730_731.in0","add_724_725_730.out"],
+          ["mul_730_730_731.in1","add_724_725_730.out"],
+          ["mul_730_730_731.out","ashr_731_732_733.in0"],
+          ["const_p4__732.out","ashr_731_732_733.in1"],
+          ["sub_729_733_734.in1","ashr_731_732_733.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_3_723_724.in0"],
+          ["const_p6__723.out","ashr_lgxx_stencil_3_723_724.in1"],
+          ["mul_724_725_726.in0","ashr_lgxx_stencil_3_723_724.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_3_723_727.in0"],
+          ["const_p6__723$2.out","ashr_lgxy_stencil_3_723_727.in1"],
+          ["mul_727_727_728.in0","ashr_lgxy_stencil_3_723_727.out"],
+          ["mul_727_727_728.in1","ashr_lgxy_stencil_3_723_727.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_3_723_725.in0"],
+          ["const_p6__723$1.out","ashr_lgyy_stencil_3_723_725.in1"],
+          ["mul_724_725_726.in1","ashr_lgyy_stencil_3_723_725.out"],
+          ["sub_726_728_729.in0","mul_724_725_726.out"],
+          ["sub_726_728_729.in1","mul_727_727_728.out"],
+          ["sub_729_733_734.out","self.out_cim_stencil"],
+          ["sub_729_733_734.in0","sub_726_728_729.out"]
         ]
       },
-      "hcompute_grad_x_stencil":{
+      "hcompute_grad_x_unclamp_stencil":{
         "type":["Record",[
-          ["out_grad_x_stencil",["Array",16,"Bit"]],
+          ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__267":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_grad_x_unclamp_stencil","const_p0__267.out"]
+        ]
+      },
+      "hcompute_grad_x_unclamp_stencil_1":{
+        "type":["Record",[
+          ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__272":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_grad_x_unclamp_stencil","const_p0__272.out"]
+        ]
+      },
+      "hcompute_grad_x_unclamp_stencil_2":{
+        "type":["Record",[
+          ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_grad_x_unclamp_stencil_1_277_278":{
+          "add_grad_x_unclamp_stencil_1_288_289":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_padded16_global_wrapper_stencil_1_276_277":{
+          "add_padded16_global_wrapper_stencil_1_287_288":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_padded16_global_wrapper_stencil_2_275_276":{
+          "add_padded16_global_wrapper_stencil_2_286_287":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__285":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hff01"]}
-          },
-          "const_p255__283":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
-          },
-          "const_p2__274":{
+          "const_p2__285":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "const_p2__274$1":{
+          "const_p2__285$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "mul_padded16_global_wrapper_stencil_3_274_275":{
+          "mul_padded16_global_wrapper_stencil_3_285_286":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_5_274_280":{
+          "mul_padded16_global_wrapper_stencil_5_285_291":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_284_285_286":{
-            "genref":"commonlib.smax",
-            "genargs":{"width":["Int",16]}
-          },
-          "smin_282_283_284":{
-            "genref":"commonlib.smin",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_278_padded16_global_wrapper_stencil_4_279":{
+          "sub_289_padded16_global_wrapper_stencil_4_290":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_279_280_281":{
+          "sub_290_291_292":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_281_padded16_global_wrapper_stencil_6_282":{
+          "sub_292_padded16_global_wrapper_stencil_6_293":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_277_278.in0"],
-          ["add_padded16_global_wrapper_stencil_1_276_277.out","add_grad_x_unclamp_stencil_1_277_278.in1"],
-          ["sub_278_padded16_global_wrapper_stencil_4_279.in0","add_grad_x_unclamp_stencil_1_277_278.out"],
-          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_1_276_277.in0"],
-          ["add_padded16_global_wrapper_stencil_2_275_276.out","add_padded16_global_wrapper_stencil_1_276_277.in1"],
-          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_2_275_276.in0"],
-          ["mul_padded16_global_wrapper_stencil_3_274_275.out","add_padded16_global_wrapper_stencil_2_275_276.in1"],
-          ["smax_284_285_286.in1","const_n255__285.out"],
-          ["smin_282_283_284.in1","const_p255__283.out"],
-          ["mul_padded16_global_wrapper_stencil_5_274_280.in1","const_p2__274$1.out"],
-          ["mul_padded16_global_wrapper_stencil_3_274_275.in1","const_p2__274.out"],
-          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_274_275.in0"],
-          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_274_280.in0"],
-          ["sub_279_280_281.in1","mul_padded16_global_wrapper_stencil_5_274_280.out"],
-          ["sub_278_padded16_global_wrapper_stencil_4_279.in1","self.in1_padded16_global_wrapper_stencil.3"],
-          ["sub_281_padded16_global_wrapper_stencil_6_282.in1","self.in1_padded16_global_wrapper_stencil.5"],
-          ["smax_284_285_286.out","self.out_grad_x_stencil"],
-          ["smin_282_283_284.out","smax_284_285_286.in0"],
-          ["sub_281_padded16_global_wrapper_stencil_6_282.out","smin_282_283_284.in0"],
-          ["sub_279_280_281.in0","sub_278_padded16_global_wrapper_stencil_4_279.out"],
-          ["sub_281_padded16_global_wrapper_stencil_6_282.in0","sub_279_280_281.out"]
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_288_289.in0"],
+          ["add_padded16_global_wrapper_stencil_1_287_288.out","add_grad_x_unclamp_stencil_1_288_289.in1"],
+          ["sub_289_padded16_global_wrapper_stencil_4_290.in0","add_grad_x_unclamp_stencil_1_288_289.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_1_287_288.in0"],
+          ["add_padded16_global_wrapper_stencil_2_286_287.out","add_padded16_global_wrapper_stencil_1_287_288.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_2_286_287.in0"],
+          ["mul_padded16_global_wrapper_stencil_3_285_286.out","add_padded16_global_wrapper_stencil_2_286_287.in1"],
+          ["mul_padded16_global_wrapper_stencil_5_285_291.in1","const_p2__285$1.out"],
+          ["mul_padded16_global_wrapper_stencil_3_285_286.in1","const_p2__285.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_285_286.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_285_291.in0"],
+          ["sub_290_291_292.in1","mul_padded16_global_wrapper_stencil_5_285_291.out"],
+          ["sub_289_padded16_global_wrapper_stencil_4_290.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_292_padded16_global_wrapper_stencil_6_293.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_292_padded16_global_wrapper_stencil_6_293.out","self.out_grad_x_unclamp_stencil"],
+          ["sub_290_291_292.in0","sub_289_padded16_global_wrapper_stencil_4_290.out"],
+          ["sub_292_padded16_global_wrapper_stencil_6_293.in0","sub_290_291_292.out"]
         ]
       },
-      "hcompute_grad_x_stencil_1":{
+      "hcompute_grad_y_unclamp_stencil":{
         "type":["Record",[
-          ["out_grad_x_stencil",["Array",16,"Bit"]],
-          ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
+          ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "add_grad_x_unclamp_stencil_2_329_330":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_padded16_global_wrapper_stencil_7_328_329":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_padded16_global_wrapper_stencil_8_327_328":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "const_n255__337":{
+          "const_p0__413":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hff01"]}
-          },
-          "const_p255__335":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
-          },
-          "const_p2__326":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          },
-          "const_p2__326$1":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          },
-          "mul_padded16_global_wrapper_stencil_11_326_332":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_9_326_327":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "smax_336_337_338":{
-            "genref":"commonlib.smax",
-            "genargs":{"width":["Int",16]}
-          },
-          "smin_334_335_336":{
-            "genref":"commonlib.smin",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_330_padded16_global_wrapper_stencil_10_331":{
-            "genref":"coreir.sub",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_331_332_333":{
-            "genref":"coreir.sub",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_333_padded16_global_wrapper_stencil_12_334":{
-            "genref":"coreir.sub",
-            "genargs":{"width":["Int",16]}
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_2_329_330.in0"],
-          ["add_padded16_global_wrapper_stencil_7_328_329.out","add_grad_x_unclamp_stencil_2_329_330.in1"],
-          ["sub_330_padded16_global_wrapper_stencil_10_331.in0","add_grad_x_unclamp_stencil_2_329_330.out"],
-          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_328_329.in0"],
-          ["add_padded16_global_wrapper_stencil_8_327_328.out","add_padded16_global_wrapper_stencil_7_328_329.in1"],
-          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_327_328.in0"],
-          ["mul_padded16_global_wrapper_stencil_9_326_327.out","add_padded16_global_wrapper_stencil_8_327_328.in1"],
-          ["smax_336_337_338.in1","const_n255__337.out"],
-          ["smin_334_335_336.in1","const_p255__335.out"],
-          ["mul_padded16_global_wrapper_stencil_11_326_332.in1","const_p2__326$1.out"],
-          ["mul_padded16_global_wrapper_stencil_9_326_327.in1","const_p2__326.out"],
-          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_326_332.in0"],
-          ["sub_331_332_333.in1","mul_padded16_global_wrapper_stencil_11_326_332.out"],
-          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_326_327.in0"],
-          ["sub_330_padded16_global_wrapper_stencil_10_331.in1","self.in1_padded16_global_wrapper_stencil.0"],
-          ["sub_333_padded16_global_wrapper_stencil_12_334.in1","self.in1_padded16_global_wrapper_stencil.2"],
-          ["smax_336_337_338.out","self.out_grad_x_stencil"],
-          ["smin_334_335_336.out","smax_336_337_338.in0"],
-          ["sub_333_padded16_global_wrapper_stencil_12_334.out","smin_334_335_336.in0"],
-          ["sub_331_332_333.in0","sub_330_padded16_global_wrapper_stencil_10_331.out"],
-          ["sub_333_padded16_global_wrapper_stencil_12_334.in0","sub_331_332_333.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__413.out"]
         ]
       },
-      "hcompute_grad_y_stencil":{
+      "hcompute_grad_y_unclamp_stencil_1":{
         "type":["Record",[
-          ["out_grad_y_stencil",["Array",16,"Bit"]],
+          ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__418":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_grad_y_unclamp_stencil","const_p0__418.out"]
+        ]
+      },
+      "hcompute_grad_y_unclamp_stencil_2":{
+        "type":["Record",[
+          ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_grad_y_unclamp_stencil_1_453_454":{
+          "add_grad_y_unclamp_stencil_1_433_434":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_padded16_global_wrapper_stencil_13_454_455":{
+          "add_padded16_global_wrapper_stencil_7_434_435":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_padded16_global_wrapper_stencil_14_452_453":{
+          "add_padded16_global_wrapper_stencil_8_432_433":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__462":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hff01"]}
-          },
-          "const_p255__460":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
-          },
-          "const_p2__451":{
+          "const_p2__431":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "const_p2__451$1":{
+          "const_p2__431$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "mul_padded16_global_wrapper_stencil_15_451_452":{
+          "mul_padded16_global_wrapper_stencil_11_431_437":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_17_451_457":{
+          "mul_padded16_global_wrapper_stencil_9_431_432":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_461_462_463":{
-            "genref":"commonlib.smax",
-            "genargs":{"width":["Int",16]}
-          },
-          "smin_459_460_461":{
-            "genref":"commonlib.smin",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_455_padded16_global_wrapper_stencil_16_456":{
+          "sub_435_padded16_global_wrapper_stencil_10_436":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_456_457_458":{
+          "sub_436_437_438":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_458_padded16_global_wrapper_stencil_18_459":{
+          "sub_438_padded16_global_wrapper_stencil_12_439":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_453_454.in0"],
-          ["add_padded16_global_wrapper_stencil_14_452_453.out","add_grad_y_unclamp_stencil_1_453_454.in1"],
-          ["add_padded16_global_wrapper_stencil_13_454_455.in1","add_grad_y_unclamp_stencil_1_453_454.out"],
-          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_13_454_455.in0"],
-          ["sub_455_padded16_global_wrapper_stencil_16_456.in0","add_padded16_global_wrapper_stencil_13_454_455.out"],
-          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_14_452_453.in0"],
-          ["mul_padded16_global_wrapper_stencil_15_451_452.out","add_padded16_global_wrapper_stencil_14_452_453.in1"],
-          ["smax_461_462_463.in1","const_n255__462.out"],
-          ["smin_459_460_461.in1","const_p255__460.out"],
-          ["mul_padded16_global_wrapper_stencil_17_451_457.in1","const_p2__451$1.out"],
-          ["mul_padded16_global_wrapper_stencil_15_451_452.in1","const_p2__451.out"],
-          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_15_451_452.in0"],
-          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_17_451_457.in0"],
-          ["sub_456_457_458.in1","mul_padded16_global_wrapper_stencil_17_451_457.out"],
-          ["sub_455_padded16_global_wrapper_stencil_16_456.in1","self.in1_padded16_global_wrapper_stencil.3"],
-          ["sub_458_padded16_global_wrapper_stencil_18_459.in1","self.in1_padded16_global_wrapper_stencil.5"],
-          ["smax_461_462_463.out","self.out_grad_y_stencil"],
-          ["smin_459_460_461.out","smax_461_462_463.in0"],
-          ["sub_458_padded16_global_wrapper_stencil_18_459.out","smin_459_460_461.in0"],
-          ["sub_456_457_458.in0","sub_455_padded16_global_wrapper_stencil_16_456.out"],
-          ["sub_458_padded16_global_wrapper_stencil_18_459.in0","sub_456_457_458.out"]
-        ]
-      },
-      "hcompute_grad_y_stencil_1":{
-        "type":["Record",[
-          ["out_grad_y_stencil",["Array",16,"Bit"]],
-          ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
-        ]],
-        "instances":{
-          "add_grad_y_unclamp_stencil_2_505_506":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_padded16_global_wrapper_stencil_19_506_507":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_padded16_global_wrapper_stencil_20_504_505":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "const_n255__514":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hff01"]}
-          },
-          "const_p255__512":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
-          },
-          "const_p2__503":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          },
-          "const_p2__503$1":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          },
-          "mul_padded16_global_wrapper_stencil_21_503_504":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_23_503_509":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "smax_513_514_515":{
-            "genref":"commonlib.smax",
-            "genargs":{"width":["Int",16]}
-          },
-          "smin_511_512_513":{
-            "genref":"commonlib.smin",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_507_padded16_global_wrapper_stencil_22_508":{
-            "genref":"coreir.sub",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_508_509_510":{
-            "genref":"coreir.sub",
-            "genargs":{"width":["Int",16]}
-          },
-          "sub_510_padded16_global_wrapper_stencil_24_511":{
-            "genref":"coreir.sub",
-            "genargs":{"width":["Int",16]}
-          }
-        },
-        "connections":[
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_2_505_506.in0"],
-          ["add_padded16_global_wrapper_stencil_20_504_505.out","add_grad_y_unclamp_stencil_2_505_506.in1"],
-          ["add_padded16_global_wrapper_stencil_19_506_507.in1","add_grad_y_unclamp_stencil_2_505_506.out"],
-          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_19_506_507.in0"],
-          ["sub_507_padded16_global_wrapper_stencil_22_508.in0","add_padded16_global_wrapper_stencil_19_506_507.out"],
-          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_20_504_505.in0"],
-          ["mul_padded16_global_wrapper_stencil_21_503_504.out","add_padded16_global_wrapper_stencil_20_504_505.in1"],
-          ["smax_513_514_515.in1","const_n255__514.out"],
-          ["smin_511_512_513.in1","const_p255__512.out"],
-          ["mul_padded16_global_wrapper_stencil_23_503_509.in1","const_p2__503$1.out"],
-          ["mul_padded16_global_wrapper_stencil_21_503_504.in1","const_p2__503.out"],
-          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_21_503_504.in0"],
-          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_23_503_509.in0"],
-          ["sub_508_509_510.in1","mul_padded16_global_wrapper_stencil_23_503_509.out"],
-          ["sub_507_padded16_global_wrapper_stencil_22_508.in1","self.in1_padded16_global_wrapper_stencil.3"],
-          ["sub_510_padded16_global_wrapper_stencil_24_511.in1","self.in1_padded16_global_wrapper_stencil.5"],
-          ["smax_513_514_515.out","self.out_grad_y_stencil"],
-          ["smin_511_512_513.out","smax_513_514_515.in0"],
-          ["sub_510_padded16_global_wrapper_stencil_24_511.out","smin_511_512_513.in0"],
-          ["sub_508_509_510.in0","sub_507_padded16_global_wrapper_stencil_22_508.out"],
-          ["sub_510_padded16_global_wrapper_stencil_24_511.in0","sub_508_509_510.out"]
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_433_434.in0"],
+          ["add_padded16_global_wrapper_stencil_8_432_433.out","add_grad_y_unclamp_stencil_1_433_434.in1"],
+          ["add_padded16_global_wrapper_stencil_7_434_435.in1","add_grad_y_unclamp_stencil_1_433_434.out"],
+          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_434_435.in0"],
+          ["sub_435_padded16_global_wrapper_stencil_10_436.in0","add_padded16_global_wrapper_stencil_7_434_435.out"],
+          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_432_433.in0"],
+          ["mul_padded16_global_wrapper_stencil_9_431_432.out","add_padded16_global_wrapper_stencil_8_432_433.in1"],
+          ["mul_padded16_global_wrapper_stencil_11_431_437.in1","const_p2__431$1.out"],
+          ["mul_padded16_global_wrapper_stencil_9_431_432.in1","const_p2__431.out"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_431_437.in0"],
+          ["sub_436_437_438.in1","mul_padded16_global_wrapper_stencil_11_431_437.out"],
+          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_431_432.in0"],
+          ["sub_435_padded16_global_wrapper_stencil_10_436.in1","self.in1_padded16_global_wrapper_stencil.0"],
+          ["sub_438_padded16_global_wrapper_stencil_12_439.in1","self.in1_padded16_global_wrapper_stencil.2"],
+          ["sub_438_padded16_global_wrapper_stencil_12_439.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_436_437_438.in0","sub_435_padded16_global_wrapper_stencil_10_436.out"],
+          ["sub_438_padded16_global_wrapper_stencil_12_439.in0","sub_436_437_438.out"]
         ]
       },
       "hcompute_hw_output_stencil":{
@@ -833,14 +665,14 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__389":{
+          "const_p0__363":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__389.out"]
+          ["self.out_lgxx_stencil","const_p0__363.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
@@ -848,14 +680,14 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__394":{
+          "const_p0__368":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__394.out"]
+          ["self.out_lgxx_stencil","const_p0__368.out"]
         ]
       },
       "hcompute_lgxx_stencil_2":{
@@ -865,63 +697,63 @@
           ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_412_413":{
+          "add_lgxx_stencil_1_386_387":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_1_413_414":{
+          "add_lxx_stencil_1_387_388":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_2_411_412":{
+          "add_lxx_stencil_2_385_386":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_3_410_411":{
+          "add_lxx_stencil_3_384_385":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_4_409_410":{
+          "add_lxx_stencil_4_383_384":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_5_408_409":{
+          "add_lxx_stencil_5_382_383":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_6_407_408":{
+          "add_lxx_stencil_6_381_382":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_7_406_407":{
+          "add_lxx_stencil_7_380_381":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_8_lxx_stencil_9_406":{
+          "add_lxx_stencil_8_lxx_stencil_9_380":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_412_413.in0"],
-          ["add_lxx_stencil_2_411_412.out","add_lgxx_stencil_1_412_413.in1"],
-          ["add_lxx_stencil_1_413_414.in1","add_lgxx_stencil_1_412_413.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_413_414.in0"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_1_413_414.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_411_412.in0"],
-          ["add_lxx_stencil_3_410_411.out","add_lxx_stencil_2_411_412.in1"],
-          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_410_411.in0"],
-          ["add_lxx_stencil_4_409_410.out","add_lxx_stencil_3_410_411.in1"],
-          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_409_410.in0"],
-          ["add_lxx_stencil_5_408_409.out","add_lxx_stencil_4_409_410.in1"],
-          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_408_409.in0"],
-          ["add_lxx_stencil_6_407_408.out","add_lxx_stencil_5_408_409.in1"],
-          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_407_408.in0"],
-          ["add_lxx_stencil_7_406_407.out","add_lxx_stencil_6_407_408.in1"],
-          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_406_407.in0"],
-          ["add_lxx_stencil_8_lxx_stencil_9_406.out","add_lxx_stencil_7_406_407.in1"],
-          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_406.in0"],
-          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_406.in1"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_386_387.in0"],
+          ["add_lxx_stencil_2_385_386.out","add_lgxx_stencil_1_386_387.in1"],
+          ["add_lxx_stencil_1_387_388.in1","add_lgxx_stencil_1_386_387.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_387_388.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_1_387_388.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_385_386.in0"],
+          ["add_lxx_stencil_3_384_385.out","add_lxx_stencil_2_385_386.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_384_385.in0"],
+          ["add_lxx_stencil_4_383_384.out","add_lxx_stencil_3_384_385.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_383_384.in0"],
+          ["add_lxx_stencil_5_382_383.out","add_lxx_stencil_4_383_384.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_382_383.in0"],
+          ["add_lxx_stencil_6_381_382.out","add_lxx_stencil_5_382_383.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_381_382.in0"],
+          ["add_lxx_stencil_7_380_381.out","add_lxx_stencil_6_381_382.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_380_381.in0"],
+          ["add_lxx_stencil_8_lxx_stencil_9_380.out","add_lxx_stencil_7_380_381.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_380.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_380.in1"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -929,14 +761,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__568":{
+          "const_p0__523":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__568.out"]
+          ["self.out_lgxy_stencil","const_p0__523.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
@@ -944,14 +776,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__573":{
+          "const_p0__528":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__573.out"]
+          ["self.out_lgxy_stencil","const_p0__528.out"]
         ]
       },
       "hcompute_lgxy_stencil_2":{
@@ -961,63 +793,63 @@
           ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_591_592":{
+          "add_lgxy_stencil_1_546_547":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_1_592_593":{
+          "add_lxy_stencil_1_547_548":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_2_590_591":{
+          "add_lxy_stencil_2_545_546":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_3_589_590":{
+          "add_lxy_stencil_3_544_545":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_4_588_589":{
+          "add_lxy_stencil_4_543_544":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_5_587_588":{
+          "add_lxy_stencil_5_542_543":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_6_586_587":{
+          "add_lxy_stencil_6_541_542":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_7_585_586":{
+          "add_lxy_stencil_7_540_541":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_8_lxy_stencil_9_585":{
+          "add_lxy_stencil_8_lxy_stencil_9_540":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_591_592.in0"],
-          ["add_lxy_stencil_2_590_591.out","add_lgxy_stencil_1_591_592.in1"],
-          ["add_lxy_stencil_1_592_593.in1","add_lgxy_stencil_1_591_592.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_592_593.in0"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_1_592_593.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_590_591.in0"],
-          ["add_lxy_stencil_3_589_590.out","add_lxy_stencil_2_590_591.in1"],
-          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_589_590.in0"],
-          ["add_lxy_stencil_4_588_589.out","add_lxy_stencil_3_589_590.in1"],
-          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_588_589.in0"],
-          ["add_lxy_stencil_5_587_588.out","add_lxy_stencil_4_588_589.in1"],
-          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_587_588.in0"],
-          ["add_lxy_stencil_6_586_587.out","add_lxy_stencil_5_587_588.in1"],
-          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_586_587.in0"],
-          ["add_lxy_stencil_7_585_586.out","add_lxy_stencil_6_586_587.in1"],
-          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_585_586.in0"],
-          ["add_lxy_stencil_8_lxy_stencil_9_585.out","add_lxy_stencil_7_585_586.in1"],
-          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_585.in0"],
-          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_585.in1"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_546_547.in0"],
+          ["add_lxy_stencil_2_545_546.out","add_lgxy_stencil_1_546_547.in1"],
+          ["add_lxy_stencil_1_547_548.in1","add_lgxy_stencil_1_546_547.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_547_548.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_1_547_548.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_545_546.in0"],
+          ["add_lxy_stencil_3_544_545.out","add_lxy_stencil_2_545_546.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_544_545.in0"],
+          ["add_lxy_stencil_4_543_544.out","add_lxy_stencil_3_544_545.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_543_544.in0"],
+          ["add_lxy_stencil_5_542_543.out","add_lxy_stencil_4_543_544.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_542_543.in0"],
+          ["add_lxy_stencil_6_541_542.out","add_lxy_stencil_5_542_543.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_541_542.in0"],
+          ["add_lxy_stencil_7_540_541.out","add_lxy_stencil_6_541_542.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_540_541.in0"],
+          ["add_lxy_stencil_8_lxy_stencil_9_540.out","add_lxy_stencil_7_540_541.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_540.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_540.in1"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -1025,14 +857,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__642":{
+          "const_p0__621":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__642.out"]
+          ["self.out_lgyy_stencil","const_p0__621.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
@@ -1040,14 +872,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__647":{
+          "const_p0__626":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__647.out"]
+          ["self.out_lgyy_stencil","const_p0__626.out"]
         ]
       },
       "hcompute_lgyy_stencil_2":{
@@ -1057,236 +889,421 @@
           ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_665_666":{
+          "add_lgyy_stencil_1_644_645":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_1_666_667":{
+          "add_lyy_stencil_1_645_646":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_2_664_665":{
+          "add_lyy_stencil_2_643_644":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_3_663_664":{
+          "add_lyy_stencil_3_642_643":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_4_662_663":{
+          "add_lyy_stencil_4_641_642":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_5_661_662":{
+          "add_lyy_stencil_5_640_641":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_6_660_661":{
+          "add_lyy_stencil_6_639_640":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_7_659_660":{
+          "add_lyy_stencil_7_638_639":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_8_lyy_stencil_9_659":{
+          "add_lyy_stencil_8_lyy_stencil_9_638":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_665_666.in0"],
-          ["add_lyy_stencil_2_664_665.out","add_lgyy_stencil_1_665_666.in1"],
-          ["add_lyy_stencil_1_666_667.in1","add_lgyy_stencil_1_665_666.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_666_667.in0"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_1_666_667.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_664_665.in0"],
-          ["add_lyy_stencil_3_663_664.out","add_lyy_stencil_2_664_665.in1"],
-          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_663_664.in0"],
-          ["add_lyy_stencil_4_662_663.out","add_lyy_stencil_3_663_664.in1"],
-          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_662_663.in0"],
-          ["add_lyy_stencil_5_661_662.out","add_lyy_stencil_4_662_663.in1"],
-          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_661_662.in0"],
-          ["add_lyy_stencil_6_660_661.out","add_lyy_stencil_5_661_662.in1"],
-          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_660_661.in0"],
-          ["add_lyy_stencil_7_659_660.out","add_lyy_stencil_6_660_661.in1"],
-          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_659_660.in0"],
-          ["add_lyy_stencil_8_lyy_stencil_9_659.out","add_lyy_stencil_7_659_660.in1"],
-          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_659.in0"],
-          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_659.in1"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_644_645.in0"],
+          ["add_lyy_stencil_2_643_644.out","add_lgyy_stencil_1_644_645.in1"],
+          ["add_lyy_stencil_1_645_646.in1","add_lgyy_stencil_1_644_645.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_645_646.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_1_645_646.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_643_644.in0"],
+          ["add_lyy_stencil_3_642_643.out","add_lyy_stencil_2_643_644.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_642_643.in0"],
+          ["add_lyy_stencil_4_641_642.out","add_lyy_stencil_3_642_643.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_641_642.in0"],
+          ["add_lyy_stencil_5_640_641.out","add_lyy_stencil_4_641_642.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_640_641.in0"],
+          ["add_lyy_stencil_6_639_640.out","add_lyy_stencil_5_640_641.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_639_640.in0"],
+          ["add_lyy_stencil_7_638_639.out","add_lyy_stencil_6_639_640.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_638_639.in0"],
+          ["add_lyy_stencil_8_lyy_stencil_9_638.out","add_lyy_stencil_7_638_639.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_638.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_638.in1"]
         ]
       },
       "hcompute_lxx_stencil":{
         "type":["Record",[
           ["out_lxx_stencil",["Array",16,"Bit"]],
-          ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]]
+          ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_367_368_369":{
+          "ashr_325_326_327":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__368":{
+          "const_n255__323":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_p255__321":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p7__326":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_x_stencil_1_grad_x_stencil_1_367":{
+          "mul_324_324_325":{
             "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_322_323_324":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_x_unclamp_stencil_2_321_322":{
+            "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_1_grad_x_stencil_1_367.out","ashr_367_368_369.in0"],
-          ["const_p7__368.out","ashr_367_368_369.in1"],
-          ["self.out_lxx_stencil","ashr_367_368_369.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_367.in0"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_367.in1"]
+          ["mul_324_324_325.out","ashr_325_326_327.in0"],
+          ["const_p7__326.out","ashr_325_326_327.in1"],
+          ["self.out_lxx_stencil","ashr_325_326_327.out"],
+          ["smax_322_323_324.in1","const_n255__323.out"],
+          ["smin_grad_x_unclamp_stencil_2_321_322.in1","const_p255__321.out"],
+          ["smax_322_323_324.out","mul_324_324_325.in0"],
+          ["smax_322_323_324.out","mul_324_324_325.in1"],
+          ["smin_grad_x_unclamp_stencil_2_321_322.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_2_321_322.out","smax_322_323_324.in0"]
         ]
       },
       "hcompute_lxx_stencil_1":{
         "type":["Record",[
           ["out_lxx_stencil",["Array",16,"Bit"]],
-          ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]]
+          ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_379_380_381":{
+          "ashr_349_350_351":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__380":{
+          "const_n255__347":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_p255__345":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p7__350":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_x_stencil_2_grad_x_stencil_2_379":{
+          "mul_348_348_349":{
             "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_346_347_348":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_x_unclamp_stencil_3_345_346":{
+            "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_2_grad_x_stencil_2_379.out","ashr_379_380_381.in0"],
-          ["const_p7__380.out","ashr_379_380_381.in1"],
-          ["self.out_lxx_stencil","ashr_379_380_381.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_x_stencil_2_379.in0"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_x_stencil_2_379.in1"]
+          ["mul_348_348_349.out","ashr_349_350_351.in0"],
+          ["const_p7__350.out","ashr_349_350_351.in1"],
+          ["self.out_lxx_stencil","ashr_349_350_351.out"],
+          ["smax_346_347_348.in1","const_n255__347.out"],
+          ["smin_grad_x_unclamp_stencil_3_345_346.in1","const_p255__345.out"],
+          ["smax_346_347_348.out","mul_348_348_349.in0"],
+          ["smax_346_347_348.out","mul_348_348_349.in1"],
+          ["smin_grad_x_unclamp_stencil_3_345_346.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_3_345_346.out","smax_346_347_348.in0"]
         ]
       },
       "hcompute_lxy_stencil":{
         "type":["Record",[
           ["out_lxy_stencil",["Array",16,"Bit"]],
-          ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
+          ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
+          ["in1_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_544_545_546":{
+          "ashr_475_476_477":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__545":{
+          "const_n255__471":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_n255__471$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_p255__469":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p255__469$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p7__476":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_x_stencil_3_grad_y_stencil_1_544":{
+          "mul_472_474_475":{
             "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_470_471_472":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_473_471_474":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_x_unclamp_stencil_4_469_470":{
+            "genref":"commonlib.smin",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_y_unclamp_stencil_2_469_473":{
+            "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_3_grad_y_stencil_1_544.out","ashr_544_545_546.in0"],
-          ["const_p7__545.out","ashr_544_545_546.in1"],
-          ["self.out_lxy_stencil","ashr_544_545_546.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_3_grad_y_stencil_1_544.in0"],
-          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_3_grad_y_stencil_1_544.in1"]
+          ["mul_472_474_475.out","ashr_475_476_477.in0"],
+          ["const_p7__476.out","ashr_475_476_477.in1"],
+          ["self.out_lxy_stencil","ashr_475_476_477.out"],
+          ["smax_473_471_474.in1","const_n255__471$1.out"],
+          ["smax_470_471_472.in1","const_n255__471.out"],
+          ["smin_grad_y_unclamp_stencil_2_469_473.in1","const_p255__469$1.out"],
+          ["smin_grad_x_unclamp_stencil_4_469_470.in1","const_p255__469.out"],
+          ["smax_470_471_472.out","mul_472_474_475.in0"],
+          ["smax_473_471_474.out","mul_472_474_475.in1"],
+          ["smin_grad_x_unclamp_stencil_4_469_470.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_2_469_473.in0","self.in1_grad_y_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_4_469_470.out","smax_470_471_472.in0"],
+          ["smin_grad_y_unclamp_stencil_2_469_473.out","smax_473_471_474.in0"]
         ]
       },
       "hcompute_lxy_stencil_1":{
         "type":["Record",[
           ["out_lxy_stencil",["Array",16,"Bit"]],
-          ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
+          ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
+          ["in1_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_557_558_559":{
+          "ashr_506_507_508":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__558":{
+          "const_n255__502":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_n255__502$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_p255__500":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p255__500$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p7__507":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_x_stencil_4_grad_y_stencil_2_557":{
+          "mul_503_505_506":{
             "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_501_502_503":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_504_502_505":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_x_unclamp_stencil_5_500_501":{
+            "genref":"commonlib.smin",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_y_unclamp_stencil_3_500_504":{
+            "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_4_grad_y_stencil_2_557.out","ashr_557_558_559.in0"],
-          ["const_p7__558.out","ashr_557_558_559.in1"],
-          ["self.out_lxy_stencil","ashr_557_558_559.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_4_grad_y_stencil_2_557.in0"],
-          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_4_grad_y_stencil_2_557.in1"]
+          ["mul_503_505_506.out","ashr_506_507_508.in0"],
+          ["const_p7__507.out","ashr_506_507_508.in1"],
+          ["self.out_lxy_stencil","ashr_506_507_508.out"],
+          ["smax_504_502_505.in1","const_n255__502$1.out"],
+          ["smax_501_502_503.in1","const_n255__502.out"],
+          ["smin_grad_y_unclamp_stencil_3_500_504.in1","const_p255__500$1.out"],
+          ["smin_grad_x_unclamp_stencil_5_500_501.in1","const_p255__500.out"],
+          ["smax_501_502_503.out","mul_503_505_506.in0"],
+          ["smax_504_502_505.out","mul_503_505_506.in1"],
+          ["smin_grad_x_unclamp_stencil_5_500_501.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_3_500_504.in0","self.in1_grad_y_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_5_500_501.out","smax_501_502_503.in0"],
+          ["smin_grad_y_unclamp_stencil_3_500_504.out","smax_504_502_505.in0"]
         ]
       },
       "hcompute_lyy_stencil":{
         "type":["Record",[
           ["out_lyy_stencil",["Array",16,"Bit"]],
-          ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
+          ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_620_621_622":{
+          "ashr_583_584_585":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__621":{
+          "const_n255__581":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_p255__579":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p7__584":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_y_stencil_3_grad_y_stencil_3_620":{
+          "mul_582_582_583":{
             "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_580_581_582":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_y_unclamp_stencil_4_579_580":{
+            "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_y_stencil_3_grad_y_stencil_3_620.out","ashr_620_621_622.in0"],
-          ["const_p7__621.out","ashr_620_621_622.in1"],
-          ["self.out_lyy_stencil","ashr_620_621_622.out"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_3_grad_y_stencil_3_620.in0"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_3_grad_y_stencil_3_620.in1"]
+          ["mul_582_582_583.out","ashr_583_584_585.in0"],
+          ["const_p7__584.out","ashr_583_584_585.in1"],
+          ["self.out_lyy_stencil","ashr_583_584_585.out"],
+          ["smax_580_581_582.in1","const_n255__581.out"],
+          ["smin_grad_y_unclamp_stencil_4_579_580.in1","const_p255__579.out"],
+          ["smax_580_581_582.out","mul_582_582_583.in0"],
+          ["smax_580_581_582.out","mul_582_582_583.in1"],
+          ["smin_grad_y_unclamp_stencil_4_579_580.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_4_579_580.out","smax_580_581_582.in0"]
         ]
       },
       "hcompute_lyy_stencil_1":{
         "type":["Record",[
           ["out_lyy_stencil",["Array",16,"Bit"]],
-          ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
+          ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_632_633_634":{
+          "ashr_607_608_609":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__633":{
+          "const_n255__605":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'hff01"]}
+          },
+          "const_p255__603":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h00ff"]}
+          },
+          "const_p7__608":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_y_stencil_4_grad_y_stencil_4_632":{
+          "mul_606_606_607":{
             "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "smax_604_605_606":{
+            "genref":"commonlib.smax",
+            "genargs":{"width":["Int",16]}
+          },
+          "smin_grad_y_unclamp_stencil_5_603_604":{
+            "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_y_stencil_4_grad_y_stencil_4_632.out","ashr_632_633_634.in0"],
-          ["const_p7__633.out","ashr_632_633_634.in1"],
-          ["self.out_lyy_stencil","ashr_632_633_634.out"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_4_grad_y_stencil_4_632.in0"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_4_grad_y_stencil_4_632.in1"]
+          ["mul_606_606_607.out","ashr_607_608_609.in0"],
+          ["const_p7__608.out","ashr_607_608_609.in1"],
+          ["self.out_lyy_stencil","ashr_607_608_609.out"],
+          ["smax_604_605_606.in1","const_n255__605.out"],
+          ["smin_grad_y_unclamp_stencil_5_603_604.in1","const_p255__603.out"],
+          ["smax_604_605_606.out","mul_606_606_607.in0"],
+          ["smax_604_605_606.out","mul_606_606_607.in1"],
+          ["smin_grad_y_unclamp_stencil_5_603_604.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_5_603_604.out","smax_604_605_606.in0"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{
+        "type":["Record",[
+          ["out_padded16_global_wrapper_stencil",["Array",16,"Bit"]],
+          ["in0_padded16_stencil",["Array",1,["Array",16,"BitIn"]]]
+        ]],
+        "connections":[
+          ["self.out_padded16_global_wrapper_stencil","self.in0_padded16_stencil.0"]
+        ]
+      },
+      "hcompute_padded16_global_wrapper_stencil_1":{
         "type":["Record",[
           ["out_padded16_global_wrapper_stencil",["Array",16,"Bit"]],
           ["in0_padded16_stencil",["Array",1,["Array",16,"BitIn"]]]

--- a/example_progs.cpp
+++ b/example_progs.cpp
@@ -4960,66 +4960,67 @@ prog harris_sch6() {
 
 ////producing padded16_global_wrapper.stencil
   auto padded16_global_wrapper_s0_y = prg.add_loop("padded16_global_wrapper_s0_y", -3, 61);
-  auto padded16_global_wrapper_s0_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x", -3, 61);
+  auto padded16_global_wrapper_s0_x_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x_x", 0, 32);
 
-//store is: padded16_global_wrapper.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y) = padded16.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y)
-  auto hcompute_padded16_global_wrapper_stencil = padded16_global_wrapper_s0_x->add_op("op_hcompute_padded16_global_wrapper_stencil");
+//store is: padded16_global_wrapper.stencil(((padded16_global_wrapper_s0_x_x*2) + -3), padded16_global_wrapper_s0_y) = padded16.stencil(((padded16_global_wrapper_s0_x_x*2) + -3), padded16_global_wrapper_s0_y)
+  auto hcompute_padded16_global_wrapper_stencil = padded16_global_wrapper_s0_x_x->add_op("op_hcompute_padded16_global_wrapper_stencil");
   hcompute_padded16_global_wrapper_stencil->add_function("hcompute_padded16_global_wrapper_stencil");
-  hcompute_padded16_global_wrapper_stencil->add_load("padded16_stencil", "padded16_global_wrapper_s0_y", "padded16_global_wrapper_s0_x");
+  hcompute_padded16_global_wrapper_stencil->add_load("padded16_stencil", "padded16_global_wrapper_s0_y", "((padded16_global_wrapper_s0_x_x*2) + -3)");
   prg.buffer_port_widths["padded16_global_wrapper_stencil"] = 16;
-  hcompute_padded16_global_wrapper_stencil->add_store("padded16_global_wrapper_stencil", "padded16_global_wrapper_s0_y", "padded16_global_wrapper_s0_x");
+  hcompute_padded16_global_wrapper_stencil->add_store("padded16_global_wrapper_stencil", "padded16_global_wrapper_s0_y", "((padded16_global_wrapper_s0_x_x*2) + -3)");
+
+//store is: padded16_global_wrapper.stencil(((padded16_global_wrapper_s0_x_x*2) + -2), padded16_global_wrapper_s0_y) = padded16.stencil(((padded16_global_wrapper_s0_x_x*2) + -2), padded16_global_wrapper_s0_y)
+  auto hcompute_padded16_global_wrapper_stencil_1 = padded16_global_wrapper_s0_x_x->add_op("op_hcompute_padded16_global_wrapper_stencil_1");
+  hcompute_padded16_global_wrapper_stencil_1->add_function("hcompute_padded16_global_wrapper_stencil_1");
+  hcompute_padded16_global_wrapper_stencil_1->add_load("padded16_stencil", "padded16_global_wrapper_s0_y", "((padded16_global_wrapper_s0_x_x*2) + -2)");
+  hcompute_padded16_global_wrapper_stencil_1->add_store("padded16_global_wrapper_stencil", "padded16_global_wrapper_s0_y", "((padded16_global_wrapper_s0_x_x*2) + -2)");
 
 //consuming padded16_global_wrapper.stencil
-////producing grad_x.stencil
-  auto grad_x_s0_y = prg.add_loop("grad_x_s0_y", -2, 60);
-  auto grad_x_s0_x_x = grad_x_s0_y->add_loop("grad_x_s0_x_x", 0, 31);
+////producing grad_x_unclamp.stencil
+  auto grad_x_unclamp_s0_y = prg.add_loop("grad_x_unclamp_s0_y", -2, 60);
+  auto grad_x_unclamp_s0_x_x = grad_x_unclamp_s0_y->add_loop("grad_x_unclamp_s0_x_x", 0, 31);
 
-//consuming grad_x_unclamp.stencil
-
-//store is: grad_x.stencil(((grad_x_s0_x_x*2) + -2), grad_x_s0_y) = max(min(((((grad_x_unclamp.stencil(((grad_x_s0_x_x*2) + -2), grad_x_s0_y) + (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -3), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -3), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -3), (grad_x_s0_y + 1))), (int16)255), (int16)-255)
-  auto hcompute_grad_x_stencil = grad_x_s0_x_x->add_op("op_hcompute_grad_x_stencil");
-  hcompute_grad_x_stencil->add_function("hcompute_grad_x_stencil");
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s0_x_x*2) + -2), grad_x_unclamp_s0_y) = (int16)0
+  auto hcompute_grad_x_unclamp_stencil = grad_x_unclamp_s0_x_x->add_op("op_hcompute_grad_x_unclamp_stencil");
+  hcompute_grad_x_unclamp_stencil->add_function("hcompute_grad_x_unclamp_stencil");
   prg.buffer_port_widths["grad_x_unclamp_stencil"] = 16;
-  hcompute_grad_x_stencil->add_load("grad_x_unclamp_stencil", "grad_x_s0_y", "((grad_x_s0_x_x*2) + -2)");
-  hcompute_grad_x_stencil->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "((grad_x_s0_x_x*2) + -1)");
-  hcompute_grad_x_stencil->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "((grad_x_s0_x_x*2) + -1)");
-  hcompute_grad_x_stencil->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "((grad_x_s0_x_x*2) + -1)");
-  hcompute_grad_x_stencil->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "((grad_x_s0_x_x*2) + -3)");
-  hcompute_grad_x_stencil->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "((grad_x_s0_x_x*2) + -3)");
-  hcompute_grad_x_stencil->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "((grad_x_s0_x_x*2) + -3)");
-  prg.buffer_port_widths["grad_x_stencil"] = 16;
-  hcompute_grad_x_stencil->add_store("grad_x_stencil", "grad_x_s0_y", "((grad_x_s0_x_x*2) + -2)");
+  hcompute_grad_x_unclamp_stencil->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s0_y", "((grad_x_unclamp_s0_x_x*2) + -2)");
+
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s0_x_x*2) + -1), grad_x_unclamp_s0_y) = (int16)0
+  auto hcompute_grad_x_unclamp_stencil_1 = grad_x_unclamp_s0_x_x->add_op("op_hcompute_grad_x_unclamp_stencil_1");
+  hcompute_grad_x_unclamp_stencil_1->add_function("hcompute_grad_x_unclamp_stencil_1");
+  hcompute_grad_x_unclamp_stencil_1->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s0_y", "((grad_x_unclamp_s0_x_x*2) + -1)");
+  auto grad_x_unclamp_s1_y = prg.add_loop("grad_x_unclamp_s1_y", -2, 60);
+  auto grad_x_unclamp_s1_x = grad_x_unclamp_s1_y->add_loop("grad_x_unclamp_s1_x", -2, 60);
+
+//store is: grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + 1)))
+  auto hcompute_grad_x_unclamp_stencil_2 = grad_x_unclamp_s1_x->add_op("op_hcompute_grad_x_unclamp_stencil_2");
+  hcompute_grad_x_unclamp_stencil_2->add_function("hcompute_grad_x_unclamp_stencil_2");
+  hcompute_grad_x_unclamp_stencil_2->add_load("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "grad_x_unclamp_s1_x");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "(grad_x_unclamp_s1_x + 1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "(grad_x_unclamp_s1_x + 1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "(grad_x_unclamp_s1_x + 1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "(grad_x_unclamp_s1_x + -1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "(grad_x_unclamp_s1_x + -1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "(grad_x_unclamp_s1_x + -1)");
+  hcompute_grad_x_unclamp_stencil_2->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "grad_x_unclamp_s1_x");
 
 //consuming grad_x_unclamp.stencil
-
-//store is: grad_x.stencil(((grad_x_s0_x_x*2) + -1), grad_x_s0_y) = max(min(((((grad_x_unclamp.stencil(((grad_x_s0_x_x*2) + -1), grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x_x*2), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x_x*2), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x_x*2), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -2), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -2), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -2), (grad_x_s0_y + 1))), (int16)255), (int16)-255)
-  auto hcompute_grad_x_stencil_1 = grad_x_s0_x_x->add_op("op_hcompute_grad_x_stencil_1");
-  hcompute_grad_x_stencil_1->add_function("hcompute_grad_x_stencil_1");
-  hcompute_grad_x_stencil_1->add_load("grad_x_unclamp_stencil", "grad_x_s0_y", "((grad_x_s0_x_x*2) + -1)");
-  hcompute_grad_x_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "((grad_x_s0_x_x*2) + -2)");
-  hcompute_grad_x_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "((grad_x_s0_x_x*2) + -2)");
-  hcompute_grad_x_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "((grad_x_s0_x_x*2) + -2)");
-  hcompute_grad_x_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x_x*2)");
-  hcompute_grad_x_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x_x*2)");
-  hcompute_grad_x_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x_x*2)");
-  hcompute_grad_x_stencil_1->add_store("grad_x_stencil", "grad_x_s0_y", "((grad_x_s0_x_x*2) + -1)");
-
-//consuming grad_x.stencil
 ////producing lxx.stencil
   auto lxx_s0_y = prg.add_loop("lxx_s0_y", -2, 60);
   auto lxx_s0_x_x = lxx_s0_y->add_loop("lxx_s0_x_x", 0, 31);
 
-//store is: lxx.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y) = ((grad_x.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y)*grad_x.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y))/(int16)128)
+//store is: lxx.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255))/(int16)128)
   auto hcompute_lxx_stencil = lxx_s0_x_x->add_op("op_hcompute_lxx_stencil");
   hcompute_lxx_stencil->add_function("hcompute_lxx_stencil");
-  hcompute_lxx_stencil->add_load("grad_x_stencil", "lxx_s0_y", "((lxx_s0_x_x*2) + -2)");
+  hcompute_lxx_stencil->add_load("grad_x_unclamp_stencil", "lxx_s0_y", "((lxx_s0_x_x*2) + -2)");
   prg.buffer_port_widths["lxx_stencil"] = 16;
   hcompute_lxx_stencil->add_store("lxx_stencil", "lxx_s0_y", "((lxx_s0_x_x*2) + -2)");
 
-//store is: lxx.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y) = ((grad_x.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y)*grad_x.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y))/(int16)128)
+//store is: lxx.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)255), (int16)-255)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)255), (int16)-255))/(int16)128)
   auto hcompute_lxx_stencil_1 = lxx_s0_x_x->add_op("op_hcompute_lxx_stencil_1");
   hcompute_lxx_stencil_1->add_function("hcompute_lxx_stencil_1");
-  hcompute_lxx_stencil_1->add_load("grad_x_stencil", "lxx_s0_y", "((lxx_s0_x_x*2) + -1)");
+  hcompute_lxx_stencil_1->add_load("grad_x_unclamp_stencil", "lxx_s0_y", "((lxx_s0_x_x*2) + -1)");
   hcompute_lxx_stencil_1->add_store("lxx_stencil", "lxx_s0_y", "((lxx_s0_x_x*2) + -1)");
 
 //consuming lxx.stencil
@@ -5056,58 +5057,53 @@ prog harris_sch6() {
   hcompute_lgxx_stencil_2->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
 
 //consuming lgxx.stencil
-////producing grad_y.stencil
-  auto grad_y_s0_y = prg.add_loop("grad_y_s0_y", -2, 60);
-  auto grad_y_s0_x_x = grad_y_s0_y->add_loop("grad_y_s0_x_x", 0, 31);
+////producing grad_y_unclamp.stencil
+  auto grad_y_unclamp_s0_y = prg.add_loop("grad_y_unclamp_s0_y", -2, 60);
+  auto grad_y_unclamp_s0_x_x = grad_y_unclamp_s0_y->add_loop("grad_y_unclamp_s0_x_x", 0, 31);
 
-//consuming grad_y_unclamp.stencil
-
-//store is: grad_y.stencil(((grad_y_s0_x_x*2) + -2), grad_y_s0_y) = max(min(((((padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -3), (grad_y_s0_y + -1)) + (grad_y_unclamp.stencil(((grad_y_s0_x_x*2) + -2), grad_y_s0_y) + (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + -1)) + (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -3), (grad_y_s0_y + 1))) - (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + 1))*(int16)2)) - padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + 1))), (int16)255), (int16)-255)
-  auto hcompute_grad_y_stencil = grad_y_s0_x_x->add_op("op_hcompute_grad_y_stencil");
-  hcompute_grad_y_stencil->add_function("hcompute_grad_y_stencil");
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -2), grad_y_unclamp_s0_y) = (int16)0
+  auto hcompute_grad_y_unclamp_stencil = grad_y_unclamp_s0_x_x->add_op("op_hcompute_grad_y_unclamp_stencil");
+  hcompute_grad_y_unclamp_stencil->add_function("hcompute_grad_y_unclamp_stencil");
   prg.buffer_port_widths["grad_y_unclamp_stencil"] = 16;
-  hcompute_grad_y_stencil->add_load("grad_y_unclamp_stencil", "grad_y_s0_y", "((grad_y_s0_x_x*2) + -2)");
-  hcompute_grad_y_stencil->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "((grad_y_s0_x_x*2) + -3)");
-  hcompute_grad_y_stencil->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "((grad_y_s0_x_x*2) + -1)");
-  hcompute_grad_y_stencil->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "((grad_y_s0_x_x*2) + -2)");
-  hcompute_grad_y_stencil->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "((grad_y_s0_x_x*2) + -3)");
-  hcompute_grad_y_stencil->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "((grad_y_s0_x_x*2) + -2)");
-  hcompute_grad_y_stencil->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "((grad_y_s0_x_x*2) + -1)");
-  prg.buffer_port_widths["grad_y_stencil"] = 16;
-  hcompute_grad_y_stencil->add_store("grad_y_stencil", "grad_y_s0_y", "((grad_y_s0_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s0_y", "((grad_y_unclamp_s0_x_x*2) + -2)");
+
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -1), grad_y_unclamp_s0_y) = (int16)0
+  auto hcompute_grad_y_unclamp_stencil_1 = grad_y_unclamp_s0_x_x->add_op("op_hcompute_grad_y_unclamp_stencil_1");
+  hcompute_grad_y_unclamp_stencil_1->add_function("hcompute_grad_y_unclamp_stencil_1");
+  hcompute_grad_y_unclamp_stencil_1->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s0_y", "((grad_y_unclamp_s0_x_x*2) + -1)");
+  auto grad_y_unclamp_s1_y = prg.add_loop("grad_y_unclamp_s1_y", -2, 60);
+  auto grad_y_unclamp_s1_x = grad_y_unclamp_s1_y->add_loop("grad_y_unclamp_s1_x", -2, 60);
+
+//store is: grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) = ((((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + -1)) + (grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + 1))) - (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + 1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + 1)))
+  auto hcompute_grad_y_unclamp_stencil_2 = grad_y_unclamp_s1_x->add_op("op_hcompute_grad_y_unclamp_stencil_2");
+  hcompute_grad_y_unclamp_stencil_2->add_function("hcompute_grad_y_unclamp_stencil_2");
+  hcompute_grad_y_unclamp_stencil_2->add_load("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "grad_y_unclamp_s1_x");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "(grad_y_unclamp_s1_x + -1)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "grad_y_unclamp_s1_x");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "(grad_y_unclamp_s1_x + 1)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "(grad_y_unclamp_s1_x + -1)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "(grad_y_unclamp_s1_x + 1)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "grad_y_unclamp_s1_x");
+  hcompute_grad_y_unclamp_stencil_2->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "grad_y_unclamp_s1_x");
 
 //consuming grad_y_unclamp.stencil
-
-//store is: grad_y.stencil(((grad_y_s0_x_x*2) + -1), grad_y_s0_y) = max(min(((((padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + -1)) + (grad_y_unclamp.stencil(((grad_y_s0_x_x*2) + -1), grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x_x*2), (grad_y_s0_y + -1)) + (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + 1))) - (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + 1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x_x*2), (grad_y_s0_y + 1))), (int16)255), (int16)-255)
-  auto hcompute_grad_y_stencil_1 = grad_y_s0_x_x->add_op("op_hcompute_grad_y_stencil_1");
-  hcompute_grad_y_stencil_1->add_function("hcompute_grad_y_stencil_1");
-  hcompute_grad_y_stencil_1->add_load("grad_y_unclamp_stencil", "grad_y_s0_y", "((grad_y_s0_x_x*2) + -1)");
-  hcompute_grad_y_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "((grad_y_s0_x_x*2) + -2)");
-  hcompute_grad_y_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "(grad_y_s0_x_x*2)");
-  hcompute_grad_y_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "((grad_y_s0_x_x*2) + -1)");
-  hcompute_grad_y_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "((grad_y_s0_x_x*2) + -2)");
-  hcompute_grad_y_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "((grad_y_s0_x_x*2) + -1)");
-  hcompute_grad_y_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "(grad_y_s0_x_x*2)");
-  hcompute_grad_y_stencil_1->add_store("grad_y_stencil", "grad_y_s0_y", "((grad_y_s0_x_x*2) + -1)");
-
-//consuming grad_y.stencil
 ////producing lxy.stencil
   auto lxy_s0_y = prg.add_loop("lxy_s0_y", -2, 60);
   auto lxy_s0_x_x = lxy_s0_y->add_loop("lxy_s0_x_x", 0, 31);
 
-//store is: lxy.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y) = ((grad_x.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y)*grad_y.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y))/(int16)128)
+//store is: lxy.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)255), (int16)-255))/(int16)128)
   auto hcompute_lxy_stencil = lxy_s0_x_x->add_op("op_hcompute_lxy_stencil");
   hcompute_lxy_stencil->add_function("hcompute_lxy_stencil");
-  hcompute_lxy_stencil->add_load("grad_x_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -2)");
-  hcompute_lxy_stencil->add_load("grad_y_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -2)");
+  hcompute_lxy_stencil->add_load("grad_x_unclamp_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -2)");
+  hcompute_lxy_stencil->add_load("grad_y_unclamp_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -2)");
   prg.buffer_port_widths["lxy_stencil"] = 16;
   hcompute_lxy_stencil->add_store("lxy_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -2)");
 
-//store is: lxy.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y) = ((grad_x.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y)*grad_y.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y))/(int16)128)
+//store is: lxy.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255))/(int16)128)
   auto hcompute_lxy_stencil_1 = lxy_s0_x_x->add_op("op_hcompute_lxy_stencil_1");
   hcompute_lxy_stencil_1->add_function("hcompute_lxy_stencil_1");
-  hcompute_lxy_stencil_1->add_load("grad_x_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -1)");
-  hcompute_lxy_stencil_1->add_load("grad_y_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -1)");
+  hcompute_lxy_stencil_1->add_load("grad_x_unclamp_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -1)");
+  hcompute_lxy_stencil_1->add_load("grad_y_unclamp_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -1)");
   hcompute_lxy_stencil_1->add_store("lxy_stencil", "lxy_s0_y", "((lxy_s0_x_x*2) + -1)");
 
 //consuming lxy.stencil
@@ -5148,17 +5144,17 @@ prog harris_sch6() {
   auto lyy_s0_y = prg.add_loop("lyy_s0_y", -2, 60);
   auto lyy_s0_x_x = lyy_s0_y->add_loop("lyy_s0_x_x", 0, 31);
 
-//store is: lyy.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y) = ((grad_y.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y)*grad_y.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y))/(int16)128)
+//store is: lyy.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)255), (int16)-255))/(int16)128)
   auto hcompute_lyy_stencil = lyy_s0_x_x->add_op("op_hcompute_lyy_stencil");
   hcompute_lyy_stencil->add_function("hcompute_lyy_stencil");
-  hcompute_lyy_stencil->add_load("grad_y_stencil", "lyy_s0_y", "((lyy_s0_x_x*2) + -2)");
+  hcompute_lyy_stencil->add_load("grad_y_unclamp_stencil", "lyy_s0_y", "((lyy_s0_x_x*2) + -2)");
   prg.buffer_port_widths["lyy_stencil"] = 16;
   hcompute_lyy_stencil->add_store("lyy_stencil", "lyy_s0_y", "((lyy_s0_x_x*2) + -2)");
 
-//store is: lyy.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y) = ((grad_y.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y)*grad_y.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y))/(int16)128)
+//store is: lyy.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)255), (int16)-255))/(int16)128)
   auto hcompute_lyy_stencil_1 = lyy_s0_x_x->add_op("op_hcompute_lyy_stencil_1");
   hcompute_lyy_stencil_1->add_function("hcompute_lyy_stencil_1");
-  hcompute_lyy_stencil_1->add_load("grad_y_stencil", "lyy_s0_y", "((lyy_s0_x_x*2) + -1)");
+  hcompute_lyy_stencil_1->add_load("grad_y_unclamp_stencil", "lyy_s0_y", "((lyy_s0_x_x*2) + -1)");
   hcompute_lyy_stencil_1->add_store("lyy_stencil", "lyy_s0_y", "((lyy_s0_x_x*2) + -1)");
 
 //consuming lyy.stencil

--- a/harris_sch6_compute.h
+++ b/harris_sch6_compute.h
@@ -3,15 +3,34 @@
 #include "clockwork_standard_compute_units.h"
 
 
-//store is: padded16_global_wrapper.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y) = padded16.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y)
+//store is: padded16_global_wrapper.stencil(((padded16_global_wrapper_s0_x_x*2) + -3), padded16_global_wrapper_s0_y) = padded16.stencil(((padded16_global_wrapper_s0_x_x*2) + -3), padded16_global_wrapper_s0_y)
 hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stencil) {
   int16_t _padded16_stencil_1 = (int16_t) padded16_stencil.extract<0, 15>();
 
   return _padded16_stencil_1;
 }
 
-//store is: grad_x.stencil(((grad_x_s0_x_x*2) + -2), grad_x_s0_y) = max(min(((((grad_x_unclamp.stencil(((grad_x_s0_x_x*2) + -2), grad_x_s0_y) + (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -3), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -3), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -3), (grad_x_s0_y + 1))), (int16)255), (int16)-255)
-hw_uint<16> hcompute_grad_x_stencil(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
+//store is: padded16_global_wrapper.stencil(((padded16_global_wrapper_s0_x_x*2) + -2), padded16_global_wrapper_s0_y) = padded16.stencil(((padded16_global_wrapper_s0_x_x*2) + -2), padded16_global_wrapper_s0_y)
+hw_uint<16> hcompute_padded16_global_wrapper_stencil_1(hw_uint<16>& padded16_stencil) {
+  int16_t _padded16_stencil_2 = (int16_t) padded16_stencil.extract<0, 15>();
+
+  return _padded16_stencil_2;
+}
+
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s0_x_x*2) + -2), grad_x_unclamp_s0_y) = (int16)0
+hw_uint<16> hcompute_grad_x_unclamp_stencil() {
+  int16_t _266 = (int16_t)(0);
+  return _266;
+}
+
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s0_x_x*2) + -1), grad_x_unclamp_s0_y) = (int16)0
+hw_uint<16> hcompute_grad_x_unclamp_stencil_1() {
+  int16_t _271 = (int16_t)(0);
+  return _271;
+}
+
+//store is: grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + 1)))
+hw_uint<16> hcompute_grad_x_unclamp_stencil_2(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_1 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
   int16_t _padded16_global_wrapper_stencil_1 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
@@ -21,79 +40,56 @@ hw_uint<16> hcompute_grad_x_stencil(hw_uint<16>& grad_x_unclamp_stencil, hw_uint
   int16_t _padded16_global_wrapper_stencil_5 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
   int16_t _padded16_global_wrapper_stencil_6 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
 
-  int16_t _261 = (int16_t)(2);
-  int16_t _262 = _padded16_global_wrapper_stencil_3 * _261;
-  int16_t _263 = _padded16_global_wrapper_stencil_2 + _262;
-  int16_t _264 = _padded16_global_wrapper_stencil_1 + _263;
-  int16_t _265 = _grad_x_unclamp_stencil_1 + _264;
-  int16_t _266 = _265 - _padded16_global_wrapper_stencil_4;
-  int16_t _267 = _padded16_global_wrapper_stencil_5 * _261;
-  int16_t _268 = _266 - _267;
-  int16_t _269 = _268 - _padded16_global_wrapper_stencil_6;
-  int16_t _270 = (int16_t)(255);
-  int16_t _271 = min(_269, _270);
-  int16_t _272 = (int16_t)(-255);
-  int16_t _273 = max(_271, _272);
-  return _273;
+  int16_t _276 = (int16_t)(2);
+  int16_t _277 = _padded16_global_wrapper_stencil_3 * _276;
+  int16_t _278 = _padded16_global_wrapper_stencil_2 + _277;
+  int16_t _279 = _padded16_global_wrapper_stencil_1 + _278;
+  int16_t _280 = _grad_x_unclamp_stencil_1 + _279;
+  int16_t _281 = _280 - _padded16_global_wrapper_stencil_4;
+  int16_t _282 = _padded16_global_wrapper_stencil_5 * _276;
+  int16_t _283 = _281 - _282;
+  int16_t _284 = _283 - _padded16_global_wrapper_stencil_6;
+  return _284;
 }
 
-//store is: grad_x.stencil(((grad_x_s0_x_x*2) + -1), grad_x_s0_y) = max(min(((((grad_x_unclamp.stencil(((grad_x_s0_x_x*2) + -1), grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x_x*2), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x_x*2), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x_x*2), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -2), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -2), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_s0_x_x*2) + -2), (grad_x_s0_y + 1))), (int16)255), (int16)-255)
-hw_uint<16> hcompute_grad_x_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
+//store is: lxx.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
-  int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
-  int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-
-  int16_t _313 = (int16_t)(2);
-  int16_t _314 = _padded16_global_wrapper_stencil_9 * _313;
-  int16_t _315 = _padded16_global_wrapper_stencil_8 + _314;
-  int16_t _316 = _padded16_global_wrapper_stencil_7 + _315;
-  int16_t _317 = _grad_x_unclamp_stencil_2 + _316;
-  int16_t _318 = _317 - _padded16_global_wrapper_stencil_10;
-  int16_t _319 = _padded16_global_wrapper_stencil_11 * _313;
-  int16_t _320 = _318 - _319;
-  int16_t _321 = _320 - _padded16_global_wrapper_stencil_12;
-  int16_t _322 = (int16_t)(255);
-  int16_t _323 = min(_321, _322);
-  int16_t _324 = (int16_t)(-255);
-  int16_t _325 = max(_323, _324);
-  return _325;
+  int16_t _314 = (int16_t)(255);
+  int16_t _315 = min(_grad_x_unclamp_stencil_2, _314);
+  int16_t _316 = (int16_t)(-255);
+  int16_t _317 = max(_315, _316);
+  int16_t _318 = _317 * _317;
+  int16_t _319 = (int16_t)(7);
+  int16_t _320 = _318 >> _319;
+  return _320;
 }
 
-//store is: lxx.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y) = ((grad_x.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y)*grad_x.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y))/(int16)128)
-hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_stencil) {
-  int16_t _grad_x_stencil_1 = (int16_t) grad_x_stencil.extract<0, 15>();
+//store is: lxx.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)255), (int16)-255)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lxx_stencil_1(hw_uint<16>& grad_x_unclamp_stencil) {
+  int16_t _grad_x_unclamp_stencil_3 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _364 = _grad_x_stencil_1 * _grad_x_stencil_1;
-  int16_t _365 = (int16_t)(7);
-  int16_t _366 = _364 >> _365;
-  return _366;
-}
-
-//store is: lxx.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y) = ((grad_x.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y)*grad_x.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y))/(int16)128)
-hw_uint<16> hcompute_lxx_stencil_1(hw_uint<16>& grad_x_stencil) {
-  int16_t _grad_x_stencil_2 = (int16_t) grad_x_stencil.extract<0, 15>();
-
-  int16_t _376 = _grad_x_stencil_2 * _grad_x_stencil_2;
-  int16_t _377 = (int16_t)(7);
-  int16_t _378 = _376 >> _377;
-  return _378;
+  int16_t _338 = (int16_t)(255);
+  int16_t _339 = min(_grad_x_unclamp_stencil_3, _338);
+  int16_t _340 = (int16_t)(-255);
+  int16_t _341 = max(_339, _340);
+  int16_t _342 = _341 * _341;
+  int16_t _343 = (int16_t)(7);
+  int16_t _344 = _342 >> _343;
+  return _344;
 }
 
 //store is: lgxx.stencil(((lgxx_s0_x_x*2) + -1), lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _388 = (int16_t)(0);
-  return _388;
+  int16_t _362 = (int16_t)(0);
+  return _362;
 }
 
 //store is: lgxx.stencil((lgxx_s0_x_x*2), lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil_1() {
-  int16_t _393 = (int16_t)(0);
-  return _393;
+  int16_t _367 = (int16_t)(0);
+  return _367;
 }
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + -1)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + -1), lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + 1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + 1)) + lxx.stencil(lgxx_s1_x, (lgxx_s1_y + 1)))))))))))
@@ -110,106 +106,99 @@ hw_uint<16> hcompute_lgxx_stencil_2(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx
   int16_t _lxx_stencil_8 = (int16_t) lxx_stencil.extract<112, 127>();
   int16_t _lxx_stencil_9 = (int16_t) lxx_stencil.extract<128, 143>();
 
-  int16_t _397 = _lxx_stencil_8 + _lxx_stencil_9;
-  int16_t _398 = _lxx_stencil_7 + _397;
-  int16_t _399 = _lxx_stencil_6 + _398;
-  int16_t _400 = _lxx_stencil_5 + _399;
-  int16_t _401 = _lxx_stencil_4 + _400;
-  int16_t _402 = _lxx_stencil_3 + _401;
-  int16_t _403 = _lxx_stencil_2 + _402;
-  int16_t _404 = _lgxx_stencil_1 + _403;
-  int16_t _405 = _lxx_stencil_1 + _404;
-  return _405;
+  int16_t _371 = _lxx_stencil_8 + _lxx_stencil_9;
+  int16_t _372 = _lxx_stencil_7 + _371;
+  int16_t _373 = _lxx_stencil_6 + _372;
+  int16_t _374 = _lxx_stencil_5 + _373;
+  int16_t _375 = _lxx_stencil_4 + _374;
+  int16_t _376 = _lxx_stencil_3 + _375;
+  int16_t _377 = _lxx_stencil_2 + _376;
+  int16_t _378 = _lgxx_stencil_1 + _377;
+  int16_t _379 = _lxx_stencil_1 + _378;
+  return _379;
 }
 
-//store is: grad_y.stencil(((grad_y_s0_x_x*2) + -2), grad_y_s0_y) = max(min(((((padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -3), (grad_y_s0_y + -1)) + (grad_y_unclamp.stencil(((grad_y_s0_x_x*2) + -2), grad_y_s0_y) + (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + -1)) + (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -3), (grad_y_s0_y + 1))) - (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + 1))*(int16)2)) - padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + 1))), (int16)255), (int16)-255)
-hw_uint<16> hcompute_grad_y_stencil(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -2), grad_y_unclamp_s0_y) = (int16)0
+hw_uint<16> hcompute_grad_y_unclamp_stencil() {
+  int16_t _412 = (int16_t)(0);
+  return _412;
+}
+
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -1), grad_y_unclamp_s0_y) = (int16)0
+hw_uint<16> hcompute_grad_y_unclamp_stencil_1() {
+  int16_t _417 = (int16_t)(0);
+  return _417;
+}
+
+//store is: grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) = ((((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + -1)) + (grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + 1))) - (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + 1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + 1)))
+hw_uint<16> hcompute_grad_y_unclamp_stencil_2(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_y_unclamp_stencil_1 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _padded16_global_wrapper_stencil_13 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
-  int16_t _padded16_global_wrapper_stencil_14 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
-  int16_t _padded16_global_wrapper_stencil_15 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_16 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_17 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_18 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
+  int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
+  int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
+  int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
+  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
 
-  int16_t _438 = (int16_t)(2);
-  int16_t _439 = _padded16_global_wrapper_stencil_15 * _438;
-  int16_t _440 = _padded16_global_wrapper_stencil_14 + _439;
-  int16_t _441 = _grad_y_unclamp_stencil_1 + _440;
-  int16_t _442 = _padded16_global_wrapper_stencil_13 + _441;
-  int16_t _443 = _442 - _padded16_global_wrapper_stencil_16;
-  int16_t _444 = _padded16_global_wrapper_stencil_17 * _438;
-  int16_t _445 = _443 - _444;
-  int16_t _446 = _445 - _padded16_global_wrapper_stencil_18;
-  int16_t _447 = (int16_t)(255);
-  int16_t _448 = min(_446, _447);
-  int16_t _449 = (int16_t)(-255);
-  int16_t _450 = max(_448, _449);
-  return _450;
+  int16_t _422 = (int16_t)(2);
+  int16_t _423 = _padded16_global_wrapper_stencil_9 * _422;
+  int16_t _424 = _padded16_global_wrapper_stencil_8 + _423;
+  int16_t _425 = _grad_y_unclamp_stencil_1 + _424;
+  int16_t _426 = _padded16_global_wrapper_stencil_7 + _425;
+  int16_t _427 = _426 - _padded16_global_wrapper_stencil_10;
+  int16_t _428 = _padded16_global_wrapper_stencil_11 * _422;
+  int16_t _429 = _427 - _428;
+  int16_t _430 = _429 - _padded16_global_wrapper_stencil_12;
+  return _430;
 }
 
-//store is: grad_y.stencil(((grad_y_s0_x_x*2) + -1), grad_y_s0_y) = max(min(((((padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + -1)) + (grad_y_unclamp.stencil(((grad_y_s0_x_x*2) + -1), grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x_x*2), (grad_y_s0_y + -1)) + (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -2), (grad_y_s0_y + 1))) - (padded16_global_wrapper.stencil(((grad_y_s0_x_x*2) + -1), (grad_y_s0_y + 1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x_x*2), (grad_y_s0_y + 1))), (int16)255), (int16)-255)
-hw_uint<16> hcompute_grad_y_stencil_1(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
+//store is: lxy.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<16>& grad_y_unclamp_stencil) {
+  int16_t _grad_x_unclamp_stencil_4 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
+
   int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _padded16_global_wrapper_stencil_19 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
-  int16_t _padded16_global_wrapper_stencil_20 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
-  int16_t _padded16_global_wrapper_stencil_21 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_22 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_23 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_24 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-
-  int16_t _490 = (int16_t)(2);
-  int16_t _491 = _padded16_global_wrapper_stencil_21 * _490;
-  int16_t _492 = _padded16_global_wrapper_stencil_20 + _491;
-  int16_t _493 = _grad_y_unclamp_stencil_2 + _492;
-  int16_t _494 = _padded16_global_wrapper_stencil_19 + _493;
-  int16_t _495 = _494 - _padded16_global_wrapper_stencil_22;
-  int16_t _496 = _padded16_global_wrapper_stencil_23 * _490;
-  int16_t _497 = _495 - _496;
-  int16_t _498 = _497 - _padded16_global_wrapper_stencil_24;
-  int16_t _499 = (int16_t)(255);
-  int16_t _500 = min(_498, _499);
-  int16_t _501 = (int16_t)(-255);
-  int16_t _502 = max(_500, _501);
-  return _502;
+  int16_t _460 = (int16_t)(255);
+  int16_t _461 = min(_grad_x_unclamp_stencil_4, _460);
+  int16_t _462 = (int16_t)(-255);
+  int16_t _463 = max(_461, _462);
+  int16_t _464 = min(_grad_y_unclamp_stencil_2, _460);
+  int16_t _465 = max(_464, _462);
+  int16_t _466 = _463 * _465;
+  int16_t _467 = (int16_t)(7);
+  int16_t _468 = _466 >> _467;
+  return _468;
 }
 
-//store is: lxy.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y) = ((grad_x.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y)*grad_y.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y))/(int16)128)
-hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_stencil, hw_uint<16>& grad_y_stencil) {
-  int16_t _grad_x_stencil_3 = (int16_t) grad_x_stencil.extract<0, 15>();
+//store is: lxy.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lxy_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<16>& grad_y_unclamp_stencil) {
+  int16_t _grad_x_unclamp_stencil_5 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _grad_y_stencil_1 = (int16_t) grad_y_stencil.extract<0, 15>();
+  int16_t _grad_y_unclamp_stencil_3 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _541 = _grad_x_stencil_3 * _grad_y_stencil_1;
-  int16_t _542 = (int16_t)(7);
-  int16_t _543 = _541 >> _542;
-  return _543;
-}
-
-//store is: lxy.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y) = ((grad_x.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y)*grad_y.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y))/(int16)128)
-hw_uint<16> hcompute_lxy_stencil_1(hw_uint<16>& grad_x_stencil, hw_uint<16>& grad_y_stencil) {
-  int16_t _grad_x_stencil_4 = (int16_t) grad_x_stencil.extract<0, 15>();
-
-  int16_t _grad_y_stencil_2 = (int16_t) grad_y_stencil.extract<0, 15>();
-
-  int16_t _554 = _grad_x_stencil_4 * _grad_y_stencil_2;
-  int16_t _555 = (int16_t)(7);
-  int16_t _556 = _554 >> _555;
-  return _556;
+  int16_t _491 = (int16_t)(255);
+  int16_t _492 = min(_grad_x_unclamp_stencil_5, _491);
+  int16_t _493 = (int16_t)(-255);
+  int16_t _494 = max(_492, _493);
+  int16_t _495 = min(_grad_y_unclamp_stencil_3, _491);
+  int16_t _496 = max(_495, _493);
+  int16_t _497 = _494 * _496;
+  int16_t _498 = (int16_t)(7);
+  int16_t _499 = _497 >> _498;
+  return _499;
 }
 
 //store is: lgxy.stencil(((lgxy_s0_x_x*2) + -1), lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _567 = (int16_t)(0);
-  return _567;
+  int16_t _522 = (int16_t)(0);
+  return _522;
 }
 
 //store is: lgxy.stencil((lgxy_s0_x_x*2), lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil_1() {
-  int16_t _572 = (int16_t)(0);
-  return _572;
+  int16_t _527 = (int16_t)(0);
+  return _527;
 }
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + -1)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + -1), lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + 1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + 1)) + lxy.stencil(lgxy_s1_x, (lgxy_s1_y + 1)))))))))))
@@ -226,48 +215,56 @@ hw_uint<16> hcompute_lgxy_stencil_2(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy
   int16_t _lxy_stencil_8 = (int16_t) lxy_stencil.extract<112, 127>();
   int16_t _lxy_stencil_9 = (int16_t) lxy_stencil.extract<128, 143>();
 
-  int16_t _576 = _lxy_stencil_8 + _lxy_stencil_9;
-  int16_t _577 = _lxy_stencil_7 + _576;
-  int16_t _578 = _lxy_stencil_6 + _577;
-  int16_t _579 = _lxy_stencil_5 + _578;
-  int16_t _580 = _lxy_stencil_4 + _579;
-  int16_t _581 = _lxy_stencil_3 + _580;
-  int16_t _582 = _lxy_stencil_2 + _581;
-  int16_t _583 = _lgxy_stencil_1 + _582;
-  int16_t _584 = _lxy_stencil_1 + _583;
-  return _584;
+  int16_t _531 = _lxy_stencil_8 + _lxy_stencil_9;
+  int16_t _532 = _lxy_stencil_7 + _531;
+  int16_t _533 = _lxy_stencil_6 + _532;
+  int16_t _534 = _lxy_stencil_5 + _533;
+  int16_t _535 = _lxy_stencil_4 + _534;
+  int16_t _536 = _lxy_stencil_3 + _535;
+  int16_t _537 = _lxy_stencil_2 + _536;
+  int16_t _538 = _lgxy_stencil_1 + _537;
+  int16_t _539 = _lxy_stencil_1 + _538;
+  return _539;
 }
 
-//store is: lyy.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y) = ((grad_y.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y)*grad_y.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y))/(int16)128)
-hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_stencil) {
-  int16_t _grad_y_stencil_3 = (int16_t) grad_y_stencil.extract<0, 15>();
+//store is: lyy.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
+  int16_t _grad_y_unclamp_stencil_4 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _617 = _grad_y_stencil_3 * _grad_y_stencil_3;
-  int16_t _618 = (int16_t)(7);
-  int16_t _619 = _617 >> _618;
-  return _619;
+  int16_t _572 = (int16_t)(255);
+  int16_t _573 = min(_grad_y_unclamp_stencil_4, _572);
+  int16_t _574 = (int16_t)(-255);
+  int16_t _575 = max(_573, _574);
+  int16_t _576 = _575 * _575;
+  int16_t _577 = (int16_t)(7);
+  int16_t _578 = _576 >> _577;
+  return _578;
 }
 
-//store is: lyy.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y) = ((grad_y.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y)*grad_y.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y))/(int16)128)
-hw_uint<16> hcompute_lyy_stencil_1(hw_uint<16>& grad_y_stencil) {
-  int16_t _grad_y_stencil_4 = (int16_t) grad_y_stencil.extract<0, 15>();
+//store is: lyy.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lyy_stencil_1(hw_uint<16>& grad_y_unclamp_stencil) {
+  int16_t _grad_y_unclamp_stencil_5 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _629 = _grad_y_stencil_4 * _grad_y_stencil_4;
-  int16_t _630 = (int16_t)(7);
-  int16_t _631 = _629 >> _630;
-  return _631;
+  int16_t _596 = (int16_t)(255);
+  int16_t _597 = min(_grad_y_unclamp_stencil_5, _596);
+  int16_t _598 = (int16_t)(-255);
+  int16_t _599 = max(_597, _598);
+  int16_t _600 = _599 * _599;
+  int16_t _601 = (int16_t)(7);
+  int16_t _602 = _600 >> _601;
+  return _602;
 }
 
 //store is: lgyy.stencil(((lgyy_s0_x_x*2) + -1), lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _641 = (int16_t)(0);
-  return _641;
+  int16_t _620 = (int16_t)(0);
+  return _620;
 }
 
 //store is: lgyy.stencil((lgyy_s0_x_x*2), lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil_1() {
-  int16_t _646 = (int16_t)(0);
-  return _646;
+  int16_t _625 = (int16_t)(0);
+  return _625;
 }
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + -1)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + -1), lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + 1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + 1)) + lyy.stencil(lgyy_s1_x, (lgyy_s1_y + 1)))))))))))
@@ -284,16 +281,16 @@ hw_uint<16> hcompute_lgyy_stencil_2(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy
   int16_t _lyy_stencil_8 = (int16_t) lyy_stencil.extract<112, 127>();
   int16_t _lyy_stencil_9 = (int16_t) lyy_stencil.extract<128, 143>();
 
-  int16_t _650 = _lyy_stencil_8 + _lyy_stencil_9;
-  int16_t _651 = _lyy_stencil_7 + _650;
-  int16_t _652 = _lyy_stencil_6 + _651;
-  int16_t _653 = _lyy_stencil_5 + _652;
-  int16_t _654 = _lyy_stencil_4 + _653;
-  int16_t _655 = _lyy_stencil_3 + _654;
-  int16_t _656 = _lyy_stencil_2 + _655;
-  int16_t _657 = _lgyy_stencil_1 + _656;
-  int16_t _658 = _lyy_stencil_1 + _657;
-  return _658;
+  int16_t _629 = _lyy_stencil_8 + _lyy_stencil_9;
+  int16_t _630 = _lyy_stencil_7 + _629;
+  int16_t _631 = _lyy_stencil_6 + _630;
+  int16_t _632 = _lyy_stencil_5 + _631;
+  int16_t _633 = _lyy_stencil_4 + _632;
+  int16_t _634 = _lyy_stencil_3 + _633;
+  int16_t _635 = _lyy_stencil_2 + _634;
+  int16_t _636 = _lgyy_stencil_1 + _635;
+  int16_t _637 = _lyy_stencil_1 + _636;
+  return _637;
 }
 
 //store is: cim.stencil(((cim_s0_x_x*2) + -1), cim_s0_y) = ((((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)*(lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)) - ((lgxy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)*(lgxy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64))) - ((((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64) + (lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64))*((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64) + (lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)))/(int16)16))
@@ -304,19 +301,19 @@ hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_st
 
   int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _691 = (int16_t)(6);
-  int16_t _692 = _lgxx_stencil_2 >> _691;
-  int16_t _693 = _lgyy_stencil_2 >> _691;
-  int16_t _694 = _692 * _693;
-  int16_t _695 = _lgxy_stencil_2 >> _691;
-  int16_t _696 = _695 * _695;
-  int16_t _697 = _694 - _696;
-  int16_t _698 = _692 + _693;
-  int16_t _699 = _698 * _698;
-  int16_t _700 = (int16_t)(4);
-  int16_t _701 = _699 >> _700;
-  int16_t _702 = _697 - _701;
-  return _702;
+  int16_t _670 = (int16_t)(6);
+  int16_t _671 = _lgxx_stencil_2 >> _670;
+  int16_t _672 = _lgyy_stencil_2 >> _670;
+  int16_t _673 = _671 * _672;
+  int16_t _674 = _lgxy_stencil_2 >> _670;
+  int16_t _675 = _674 * _674;
+  int16_t _676 = _673 - _675;
+  int16_t _677 = _671 + _672;
+  int16_t _678 = _677 * _677;
+  int16_t _679 = (int16_t)(4);
+  int16_t _680 = _678 >> _679;
+  int16_t _681 = _676 - _680;
+  return _681;
 }
 
 //store is: cim.stencil((cim_s0_x_x*2), cim_s0_y) = ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)) - ((lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))) - ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))*((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)))/(int16)16))
@@ -327,19 +324,19 @@ hw_uint<16> hcompute_cim_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_
 
   int16_t _lgyy_stencil_3 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _732 = (int16_t)(6);
-  int16_t _733 = _lgxx_stencil_3 >> _732;
-  int16_t _734 = _lgyy_stencil_3 >> _732;
-  int16_t _735 = _733 * _734;
-  int16_t _736 = _lgxy_stencil_3 >> _732;
-  int16_t _737 = _736 * _736;
-  int16_t _738 = _735 - _737;
-  int16_t _739 = _733 + _734;
-  int16_t _740 = _739 * _739;
-  int16_t _741 = (int16_t)(4);
-  int16_t _742 = _740 >> _741;
-  int16_t _743 = _738 - _742;
-  return _743;
+  int16_t _711 = (int16_t)(6);
+  int16_t _712 = _lgxx_stencil_3 >> _711;
+  int16_t _713 = _lgyy_stencil_3 >> _711;
+  int16_t _714 = _712 * _713;
+  int16_t _715 = _lgxy_stencil_3 >> _711;
+  int16_t _716 = _715 * _715;
+  int16_t _717 = _714 - _716;
+  int16_t _718 = _712 + _713;
+  int16_t _719 = _718 * _718;
+  int16_t _720 = (int16_t)(4);
+  int16_t _721 = _719 >> _720;
+  int16_t _722 = _717 - _721;
+  return _722;
 }
 
 //store is: cim_output.stencil((cim_output_s0_x_x*2), cim_output_s0_y) = int16(select((((((((((cim.stencil(((cim_output_s0_x_x*2) + -1), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y)) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + -1), cim_output_s0_y) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + -1), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && ((int16)1 <= cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))), 255, 0))
@@ -354,27 +351,27 @@ hw_uint<16> hcompute_cim_output_stencil(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_8 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_9 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _772 = _cim_stencil_1 < _cim_stencil_2;
-  bool _773 = _cim_stencil_3 < _cim_stencil_2;
-  bool _774 = _772 && _773;
-  bool _775 = _cim_stencil_4 < _cim_stencil_2;
-  bool _776 = _774 && _775;
-  bool _777 = _cim_stencil_5 < _cim_stencil_2;
-  bool _778 = _776 && _777;
-  bool _779 = _cim_stencil_6 < _cim_stencil_2;
-  bool _780 = _778 && _779;
-  bool _781 = _cim_stencil_7 < _cim_stencil_2;
-  bool _782 = _780 && _781;
-  bool _783 = _cim_stencil_8 < _cim_stencil_2;
-  bool _784 = _782 && _783;
-  bool _785 = _cim_stencil_9 < _cim_stencil_2;
-  bool _786 = _784 && _785;
-  int16_t _787 = (int16_t)(1);
-  bool _788 = _787 <= _cim_stencil_2;
-  bool _789 = _786 && _788;
-  int32_t _790 = (int32_t)(_789 ? 255 : 0);
-  int16_t _791 = (int16_t)(_790);
-  return _791;
+  bool _751 = _cim_stencil_1 < _cim_stencil_2;
+  bool _752 = _cim_stencil_3 < _cim_stencil_2;
+  bool _753 = _751 && _752;
+  bool _754 = _cim_stencil_4 < _cim_stencil_2;
+  bool _755 = _753 && _754;
+  bool _756 = _cim_stencil_5 < _cim_stencil_2;
+  bool _757 = _755 && _756;
+  bool _758 = _cim_stencil_6 < _cim_stencil_2;
+  bool _759 = _757 && _758;
+  bool _760 = _cim_stencil_7 < _cim_stencil_2;
+  bool _761 = _759 && _760;
+  bool _762 = _cim_stencil_8 < _cim_stencil_2;
+  bool _763 = _761 && _762;
+  bool _764 = _cim_stencil_9 < _cim_stencil_2;
+  bool _765 = _763 && _764;
+  int16_t _766 = (int16_t)(1);
+  bool _767 = _766 <= _cim_stencil_2;
+  bool _768 = _765 && _767;
+  int32_t _769 = (int32_t)(_768 ? 255 : 0);
+  int16_t _770 = (int16_t)(_769);
+  return _770;
 }
 
 //store is: cim_output.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y)) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), cim_output_s0_y) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && ((int16)1 <= cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))), 255, 0))
@@ -389,27 +386,27 @@ hw_uint<16> hcompute_cim_output_stencil_1(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_17 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_18 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _846 = _cim_stencil_10 < _cim_stencil_11;
-  bool _847 = _cim_stencil_12 < _cim_stencil_11;
-  bool _848 = _846 && _847;
-  bool _849 = _cim_stencil_13 < _cim_stencil_11;
-  bool _850 = _848 && _849;
-  bool _851 = _cim_stencil_14 < _cim_stencil_11;
-  bool _852 = _850 && _851;
-  bool _853 = _cim_stencil_15 < _cim_stencil_11;
-  bool _854 = _852 && _853;
-  bool _855 = _cim_stencil_16 < _cim_stencil_11;
-  bool _856 = _854 && _855;
-  bool _857 = _cim_stencil_17 < _cim_stencil_11;
-  bool _858 = _856 && _857;
-  bool _859 = _cim_stencil_18 < _cim_stencil_11;
-  bool _860 = _858 && _859;
-  int16_t _861 = (int16_t)(1);
-  bool _862 = _861 <= _cim_stencil_11;
-  bool _863 = _860 && _862;
-  int32_t _864 = (int32_t)(_863 ? 255 : 0);
-  int16_t _865 = (int16_t)(_864);
-  return _865;
+  bool _825 = _cim_stencil_10 < _cim_stencil_11;
+  bool _826 = _cim_stencil_12 < _cim_stencil_11;
+  bool _827 = _825 && _826;
+  bool _828 = _cim_stencil_13 < _cim_stencil_11;
+  bool _829 = _827 && _828;
+  bool _830 = _cim_stencil_14 < _cim_stencil_11;
+  bool _831 = _829 && _830;
+  bool _832 = _cim_stencil_15 < _cim_stencil_11;
+  bool _833 = _831 && _832;
+  bool _834 = _cim_stencil_16 < _cim_stencil_11;
+  bool _835 = _833 && _834;
+  bool _836 = _cim_stencil_17 < _cim_stencil_11;
+  bool _837 = _835 && _836;
+  bool _838 = _cim_stencil_18 < _cim_stencil_11;
+  bool _839 = _837 && _838;
+  int16_t _840 = (int16_t)(1);
+  bool _841 = _840 <= _cim_stencil_11;
+  bool _842 = _839 && _841;
+  int32_t _843 = (int32_t)(_842 ? 255 : 0);
+  int16_t _844 = (int16_t)(_843);
+  return _844;
 }
 
 //store is: hw_output.stencil((hw_output_s0_x_xi_xi*2), hw_output_s0_y_yi) = cim_output.stencil((hw_output_s0_x_xi_xi*2), hw_output_s0_y_yi)


### PR DESCRIPTION
Fixes grad_x_unclamp being missing.
Properly unrolls all buffers (should run at 2 pixels/cycle)