### PR TITLE
Fixes to halide schedule variants: 3, 4, 6

### DIFF
--- a/app.cpp
+++ b/app.cpp
@@ -789,6 +789,8 @@ extract_div_free_linear_rational_approximation(isl_aff* aff_bound) {
 
 pair<isl_val*, isl_val*>
 extract_linear_rational_approximation(isl_aff* aff_bound) {
+  cout << "Extracting linear rational approximation: " << str(aff_bound) << endl;
+
   int in_dims = num_in_dims(aff_bound);
   int out_dims = num_out_dims(aff_bound);
   int div_dims = num_div_dims(aff_bound);

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16187,6 +16187,16 @@ schedule_info garnet_schedule_info(CodegenOptions& options, prog& prg) {
     }
   }
 
+  for (auto op : prg.all_ops()) {
+    if (op->func != "") {
+      if (options.rtl_options.use_pipelined_compute_units) {
+        sched.op_compute_unit_names[op->name] = op->func + "_pipelined";
+      } else {
+        sched.op_compute_unit_names[op->name] = op->func;
+      }
+    }
+  }
+
 #ifdef COREIR
   pipeline_compute_units(prg, sched);
 #endif

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16637,8 +16637,8 @@ vector<prog> harris_variants() {
   //test_programs.push_back(harris_sch2());
   
   // schedules take too long for 16 bit controllers
-  test_programs.push_back(harris_sch3_1pp9c());
-  test_programs.push_back(harris_sch4_1pp3c());
+  //test_programs.push_back(harris_sch3_1pp9c());
+  //test_programs.push_back(harris_sch4_1pp3c());
 
   // Works
   test_programs.push_back(harris_sch5_1ppc());

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16158,22 +16158,22 @@ schedule_info garnet_schedule_info(CodegenOptions& options, prog& prg) {
     // Extremely hacky rom latency introduction
     if (op->func == "hcompute_curved_stencil") {
       sched.compute_unit_latencies[op->func] = 1;
-      sched.op_compute_unit_latencies[op->name] = 1;
+      //sched.op_compute_unit_latencies[op->name] = 1;
     } else if (op->func == "hcompute_curved_stencil_1") {
       sched.compute_unit_latencies[op->func] = 1;
-      sched.op_compute_unit_latencies[op->name] = 1;
+      //sched.op_compute_unit_latencies[op->name] = 1;
     } else if (op->func == "hcompute_curved_stencil_2") {
       sched.compute_unit_latencies[op->func] = 1;
-      sched.op_compute_unit_latencies[op->name] = 1;
+      //sched.op_compute_unit_latencies[op->name] = 1;
     } else if (prg.name == "rom" && op->func == "hcompute_hw_output_stencil") {
       //assert(false);
       sched.compute_unit_latencies[op->func] = 1;
-      sched.op_compute_unit_latencies[op->name] = 1;
+      //sched.op_compute_unit_latencies[op->name] = 1;
     } else if (op->func != "") {
       sched.compute_unit_latencies[op->func] = 0;
-      sched.op_compute_unit_latencies[op->name] = 0;
+      //sched.op_compute_unit_latencies[op->name] = 0;
     } else {
-      sched.op_compute_unit_latencies[op->name] = 0;
+      //sched.op_compute_unit_latencies[op->name] = 0;
     }
 
     for (auto b : op->buffers_referenced()) {

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16364,6 +16364,7 @@ void compile_for_FPGA_BRAM_mem(prog& prg) {
 
 void compile_for_garnet_platonic_mem(prog& prg) {
   auto options = garnet_codegen_options(prg);
+  //options.rtl_options.use_pipelined_compute_units = true;
   schedule_info sched = garnet_schedule_info(options, prg);
   compile_cycle_accurate_hw(options, sched, prg);
 }

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16187,7 +16187,9 @@ schedule_info garnet_schedule_info(CodegenOptions& options, prog& prg) {
     }
   }
 
+#ifdef COREIR
   pipeline_compute_units(prg, sched);
+#endif
   return sched;
 }
 

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -15197,7 +15197,7 @@ void rate_matched_schedule(schedule_info& sched, op* root, prog& prg, const int 
   vector<op*> l2_loops = ops_at_level(2, prg);
   level_iis[2] = -1;
   cout << "l2 loops..." << endl;
-  int pos = 0;
+  //int pos = 0;
   int max_tc = 0;
   int l2_latency = 0;
   for (auto l : l2_loops) {
@@ -15206,21 +15206,33 @@ void rate_matched_schedule(schedule_info& sched, op* root, prog& prg, const int 
     cout << tab(2) << "total latency    : " << sched.total_latency(l) << endl;
     cout << tab(2) << "iteration latency: " << sched.instance_latency(l) << endl;
     level_iis[2] = max(sched.instance_latency(l), level_iis[2]);
-    loop_delays[l->name] = 10*pos;
+    loop_delays[l->name] = 0;
     cout << tab(2) << "iter start delay : " << loop_delays[l->name] << endl;
     max_tc = max(l->trip_count(), max_tc);
-    pos++;
+    //pos++;
   }
 
   for (auto l : l2_loops) {
     sched.loop_iis[l->name] = level_iis[2];
+    sched.op_offset_within_parent[l] = 0;
   }
 
   cout << "L2 II = " << level_iis[2] << endl;
   cout << "L2 TC = " << max_tc << endl;
 
+  int outer_ii = max_tc*level_iis[2];
+  cout << "Outer II = " << outer_ii << endl;
 
-  //vector<op*> l1_loops = ops_at_level(1, prg);
+
+  vector<op*> l1_loops = ops_at_level(1, prg);
+  int pos = 0;
+  for (auto l : l1_loops) {
+    sched.loop_iis[l->name] = outer_ii;
+    sched.op_offset_within_parent[l] = pos*outer_ii;
+    pos += 10;
+  }
+  sched.loop_iis["root"] = sched.instance_latency(prg.find_loop("root"));
+
   //cout << "l1 loops..." << endl;
   //int pos = 0;
   //for (auto l : l1_loops) {
@@ -15232,75 +15244,75 @@ void rate_matched_schedule(schedule_info& sched, op* root, prog& prg, const int 
     //cout << tab(2) << "iter start delay : " << loop_delays[l->name] << endl;
     //pos++;
   //}
-  assert(false);
+  //assert(false);
 
-  cout << "Computing rate matched schedule at level " << dims << endl;
-  auto levels = get_variable_levels(prg);
-  vector<op*> body_ops;
-  int body_latency = 0;
-  int inner_ii = 1;
-  for (auto l : levels) {
-    cout << endl;
-    if (l.second == dims) {
-      for (auto c : prg.find_loop(l.first)->children) {
-        body_ops.push_back(c);
-      }
-
-      cout << endl;
-      prg.find_loop(l.first)->pretty_print();
-      cout << endl;
-      auto consumed = read_at(l.first, prg);
-      if (consumed != nullptr) {
-        cout << "Consumed: " << str(consumed) << endl;
-      }
-    }
-  }
-
-  assert(false);
-  //for (auto b : body_ops) {
-    //sequential_schedule(sched, b, prg);
-    //sched.op_offset_within_parent[b] = body_latency;
-    //body_latency += sched.total_latency(b);
-    //inner_ii = max(inner_ii, sched.total_latency(b));
-  //}
-  //inner_ii = 12;
-  //cout << "Body latency = " << body_latency << endl;
-  //cout << "Inner II     = " << inner_ii << endl;
+  //cout << "Computing rate matched schedule at level " << dims << endl;
+  //auto levels = get_variable_levels(prg);
+  //vector<op*> body_ops;
+  //int body_latency = 0;
+  //int inner_ii = 1;
   //for (auto l : levels) {
-    //if (l.second <= dims) {
-      //if (l.second == dims) {
-        //sched.loop_iis[l.first] = inner_ii;
-        //sched.op_offset_within_parent[prg.find_loop(l.first)] = 0;
-        //sched.instance_latencies[prg.find_loop(l.first)] = 1;
-      //} else if (l.second == 1) {
-        //auto lp = prg.find_loop(l.first);
+    //cout << endl;
+    //if (l.second == dims) {
+      //for (auto c : prg.find_loop(l.first)->children) {
+        //body_ops.push_back(c);
+      //}
 
-        //assert(elem(lp, prg.root->children));
-
-        //int pos;
-        //for (pos = 0; pos < prg.root->children.size(); pos++) {
-          //if (prg.root->children[pos] == lp) {
-            //break;
-          //}
-        //}
-
-        //sched.loop_iis[l.first] = inner_ii*60;
-        //sched.op_offset_within_parent[prg.find_loop(l.first)] = inner_ii*60*pos;
-        //sched.instance_latencies[prg.find_loop(l.first)] = 1;
-      //} else {
-        //cout << l.second << endl;
-        //assert(l.second == 0);
-        //sched.loop_iis[l.first] = 65000;
-        //sched.instance_latencies[prg.find_loop(l.first)] = 1;
+      //cout << endl;
+      //prg.find_loop(l.first)->pretty_print();
+      //cout << endl;
+      //auto consumed = read_at(l.first, prg);
+      //if (consumed != nullptr) {
+        //cout << "Consumed: " << str(consumed) << endl;
       //}
     //}
   //}
 
-  //cout << "Not scheduled..." << endl;
-  //for (auto op : unscheduled_nodes(sched, prg)) {
-    //op->pretty_print();
-    //cout << endl;
-  //}
+  //assert(false);
+  ////for (auto b : body_ops) {
+    ////sequential_schedule(sched, b, prg);
+    ////sched.op_offset_within_parent[b] = body_latency;
+    ////body_latency += sched.total_latency(b);
+    ////inner_ii = max(inner_ii, sched.total_latency(b));
+  ////}
+  ////inner_ii = 12;
+  ////cout << "Body latency = " << body_latency << endl;
+  ////cout << "Inner II     = " << inner_ii << endl;
+  ////for (auto l : levels) {
+    ////if (l.second <= dims) {
+      ////if (l.second == dims) {
+        ////sched.loop_iis[l.first] = inner_ii;
+        ////sched.op_offset_within_parent[prg.find_loop(l.first)] = 0;
+        ////sched.instance_latencies[prg.find_loop(l.first)] = 1;
+      ////} else if (l.second == 1) {
+        ////auto lp = prg.find_loop(l.first);
+
+        ////assert(elem(lp, prg.root->children));
+
+        ////int pos;
+        ////for (pos = 0; pos < prg.root->children.size(); pos++) {
+          ////if (prg.root->children[pos] == lp) {
+            ////break;
+          ////}
+        ////}
+
+        ////sched.loop_iis[l.first] = inner_ii*60;
+        ////sched.op_offset_within_parent[prg.find_loop(l.first)] = inner_ii*60*pos;
+        ////sched.instance_latencies[prg.find_loop(l.first)] = 1;
+      ////} else {
+        ////cout << l.second << endl;
+        ////assert(l.second == 0);
+        ////sched.loop_iis[l.first] = 65000;
+        ////sched.instance_latencies[prg.find_loop(l.first)] = 1;
+      ////}
+    ////}
+  ////}
+
+  ////cout << "Not scheduled..." << endl;
+  ////for (auto op : unscheduled_nodes(sched, prg)) {
+    ////op->pretty_print();
+    ////cout << endl;
+  ////}
 
 }
 
@@ -16637,8 +16649,8 @@ vector<prog> harris_variants() {
   //test_programs.push_back(harris_sch2());
   
   // schedules take too long for 16 bit controllers
-  //test_programs.push_back(harris_sch3_1pp9c());
-  //test_programs.push_back(harris_sch4_1pp3c());
+  test_programs.push_back(harris_sch3_1pp9c());
+  test_programs.push_back(harris_sch4_1pp3c());
 
   // Works
   test_programs.push_back(harris_sch5_1ppc());

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16587,11 +16587,11 @@ vector<prog> stencil_programs() {
   //test_programs.push_back(rom());
 
 
+  test_programs.push_back(pointwise());
   test_programs.push_back(camera_pipeline());
   test_programs.push_back(up_sample());
   test_programs.push_back(harris());
   test_programs.push_back(gaussian());
-  test_programs.push_back(pointwise());
 
   // Fails with dual port tile?
   test_programs.push_back(strided_conv());
@@ -16639,6 +16639,7 @@ vector<prog> harris_variants() {
 vector<prog> all_cgra_programs() {
 
   vector<prog> test_programs;
+  concat(test_programs, stencil_programs());
   concat(test_programs, harris_variants());
 
   // Too large to fit in 16 bit controller,
@@ -16657,7 +16658,6 @@ vector<prog> all_cgra_programs() {
   test_programs.push_back(mobilenet_small());
 
 
-  concat(test_programs, stencil_programs());
 
   return test_programs;
 }

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16187,6 +16187,7 @@ schedule_info garnet_schedule_info(CodegenOptions& options, prog& prg) {
     }
   }
 
+  pipeline_compute_units(prg, sched);
   return sched;
 }
 

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -18791,6 +18791,11 @@ void test_if_construction() {
 
 void dhuff_playground() {
   {
+    prog prg = resnet_full_layer();
+    prg.pretty_print();
+    assert(false);
+  }
+  {
     prog prg = resnet();
 #ifdef COREIR
     pipeline_compute_units(prg);

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -18798,7 +18798,7 @@ void dhuff_playground() {
   {
     prog prg = resnet();
 #ifdef COREIR
-    pipeline_compute_units(prg);
+    //pipeline_compute_units(prg);
 #endif
     assert(false);
   }

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16364,7 +16364,7 @@ void compile_for_FPGA_BRAM_mem(prog& prg) {
 
 void compile_for_garnet_platonic_mem(prog& prg) {
   auto options = garnet_codegen_options(prg);
-  //options.rtl_options.use_pipelined_compute_units = true;
+  options.rtl_options.use_pipelined_compute_units = true;
   schedule_info sched = garnet_schedule_info(options, prg);
   compile_cycle_accurate_hw(options, sched, prg);
 }

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -15094,7 +15094,7 @@ void infer_bounds_unrolled_test() {
 
 }
 
-int op_latency(op* op, const schedule_info& hwinfo) {
+int op_latency(op* op, schedule_info& hwinfo) {
   assert(!op->is_loop());
 
   int total_latency = 0;
@@ -15111,7 +15111,10 @@ int op_latency(op* op, const schedule_info& hwinfo) {
 
   // Then we need to wait for the compute unit to finish
   if (op->func != "") {
-    int latency = map_find(op->func, hwinfo.compute_unit_latencies);
+    //int latency = map_find(op->func, hwinfo.compute_unit_latencies);
+    int latency =
+      hwinfo.compute_latency(op);
+      //map_find(op->func, hwinfo.compute_unit_latencies);
     //assert(latency == 0);
     total_latency += latency;
   }

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -18790,6 +18790,13 @@ void test_if_construction() {
 }
 
 void dhuff_playground() {
+  {
+    prog prg = resnet();
+#ifdef COREIR
+    pipeline_compute_units(prg);
+#endif
+    assert(false);
+  }
   //{
     //vector<prog> prgs = all_cgra_programs();
     //vector<prog> not_coarse;

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16361,13 +16361,14 @@ void compile_for_generic_SRAM_mem(prog& prg) {
 
 void compile_for_FPGA_BRAM_mem(prog& prg) {
   auto options = FPGA_BRAM_codegen_options(prg);
+  options.rtl_options.use_pipelined_compute_units = true;
   schedule_info sched = garnet_schedule_info(options, prg);
   compile_cycle_accurate_hw(options, sched, prg);
 }
 
 void compile_for_garnet_platonic_mem(prog& prg) {
   auto options = garnet_codegen_options(prg);
-  options.rtl_options.use_pipelined_compute_units = true;
+  //options.rtl_options.use_pipelined_compute_units = true;
   schedule_info sched = garnet_schedule_info(options, prg);
   compile_cycle_accurate_hw(options, sched, prg);
 }
@@ -17005,16 +17006,15 @@ void fpga_asplos_tests() {
 }
 
 void cgra_flow_tests() {
+  vector<prog> bram_test_programs{resnet()};
+  test_codegen(bram_test_programs, compile_for_FPGA_BRAM_mem);
+
   auto test_programs =
     all_cgra_programs();
   test_platonic_codegen(test_programs);
 
-  vector<prog> bram_test_programs{resnet()};
-  test_codegen(bram_test_programs, compile_for_FPGA_BRAM_mem);
-
   vector<prog> sram_test_programs{pointwise(), camera_pipeline(), resnet()};
   test_codegen(sram_test_programs, compile_for_generic_SRAM_mem);
-  
 }
 
 void dse_flow_tests() {

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -15229,7 +15229,7 @@ void rate_matched_schedule(schedule_info& sched, op* root, prog& prg, const int 
     pos += 3;
   }
   sched.loop_iis["root"] = sched.instance_latency(prg.find_loop("root"));
-  //adjust_outer_delays(sched, prg);
+  adjust_outer_delays(sched, prg);
 
   //cout << "l1 loops..." << endl;
   //int pos = 0;
@@ -16570,14 +16570,16 @@ vector<prog> harris_variants() {
   //test_programs.push_back(harris_sch1());
   //
   // 1. Extract_linear_rational_approximation fails?
-  //test_programs.push_back(harris_sch6());
+  test_programs.push_back(harris_sch6_2ppc());
 
   // 2. Final output is wrong
   //test_programs.push_back(harris_sch2());
   
   // schedules take too long for 16 bit controllers
-  //test_programs.push_back(harris_sch3_1pp9c());
-  test_programs.push_back(harris_sch4_1pp3c());
+  // - Fixable though,
+  // Now: They also have an error in the ROMs
+  // test_programs.push_back(harris_sch3_1pp9c());
+  // test_programs.push_back(harris_sch4_1pp3c());
 
   // Works
   test_programs.push_back(harris_sch5_1ppc());

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16570,7 +16570,10 @@ vector<prog> harris_variants() {
   //test_programs.push_back(harris_sch1());
   //
   // 1. Extract_linear_rational_approximation fails?
-  test_programs.push_back(harris_sch6_2ppc());
+  //    - Update: The failure is due to running
+  //      clockwork on input loops with different
+  //      amounts of unrolling in different loops
+  //test_programs.push_back(harris_sch6_2ppc());
 
   // 2. Final output is wrong
   //test_programs.push_back(harris_sch2());
@@ -18746,7 +18749,9 @@ void test_if_construction() {
 
 void dhuff_playground() {
   {
-    prog prg = resnet_full_layer();
+    //prog prg = resnet_full_layer();
+    //prg.pretty_print();
+    prog prg = harris_sch6_2ppc();
     prg.pretty_print();
     assert(false);
   }

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -16626,9 +16626,9 @@ vector<prog> harris_variants() {
   //test_programs.push_back(harris_sch4());
 
   // Works
-  test_programs.push_back(harris_sch5());
-  test_programs.push_back(harris_sch7());
-  test_programs.push_back(harris_sch8());
+  test_programs.push_back(harris_sch5_1ppc());
+  test_programs.push_back(harris_sch7_bigtile());
+  test_programs.push_back(harris_sch8_endcim());
 
   return test_programs;
 }

--- a/build_set_test.cpp
+++ b/build_set_test.cpp
@@ -17006,15 +17006,15 @@ void fpga_asplos_tests() {
 }
 
 void cgra_flow_tests() {
-  vector<prog> bram_test_programs{resnet()};
-  test_codegen(bram_test_programs, compile_for_FPGA_BRAM_mem);
-
   auto test_programs =
     all_cgra_programs();
   test_platonic_codegen(test_programs);
 
   vector<prog> sram_test_programs{pointwise(), camera_pipeline(), resnet()};
   test_codegen(sram_test_programs, compile_for_generic_SRAM_mem);
+
+  vector<prog> bram_test_programs{resnet()};
+  test_codegen(bram_test_programs, compile_for_FPGA_BRAM_mem);
 }
 
 void dse_flow_tests() {

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1048,7 +1048,7 @@ Instance* generate_coreir_op_controller_verilog(CodegenOptions& options, ModuleD
   }
 
   assert(verilog_collateral_file != nullptr);
-  generate_fsm(*verilog_collateral_file, options, "my_test_ctrl", "d", "wen", aff, dom);
+  generate_fsm(*verilog_collateral_file, options, controller->getInstname() + c->getUnique(), "d", "valid", aff, dom);
 
   connect_op_control_wires(options, def, op, hwinfo, controller);
   return controller;

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2973,6 +2973,7 @@ Wireable* base(Wireable* w) {
   }
   return w;
 }
+
 void pipeline_compute_units(prog& prg) {
   CoreIR::Context* context = CoreIR::newContext();
   auto c = context;
@@ -3076,6 +3077,30 @@ void pipeline_compute_units(prog& prg) {
       map<Instance*, Instance*> instance_map;
       for (auto inst : instances) {
         instance_map[inst] = copy_def->addInstance(inst, inst->getInstname());
+      }
+
+      for (auto c : mod->getDef()->getConnections()) {
+        Wireable* base0 = base(c.first);
+        Wireable* base1 = base(c.second);
+        //if (isa<Instance>(base0) && isa<Instance>(base1)) {
+          //Instance* src = nullptr;
+          //Instance* dst = nullptr;
+          //cout << tab(1) << "Instance connection between " << base0->toString() << " and " << base1->toString() << endl;
+          //cout << tab(2) << c.first->getType()->isInput() << endl;
+
+          //if (c.first->getType()->isInput()) {
+            //dst = static_cast<Instance*>(base0);
+            //src = static_cast<Instance*>(base1);
+          //} else {
+            //dst = static_cast<Instance*>(base1);
+            //src = static_cast<Instance*>(base0);
+          //}
+
+          //assert(src != nullptr);
+          //assert(dst != nullptr);
+
+          //instance_connections_dst_to_src[dst].insert(src);
+          //}
       }
       copy->setDef(copy_def);
     }

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -3194,8 +3194,8 @@ void pipeline_compute_units(prog& prg, schedule_info& hwinfo) {
       }
       copy->setDef(copy_def);
 
-      hwinfo.op_compute_unit_latencies[op->func + "_pipelined"] =
-        std::max(0, ((int)schedule.size()) - 1);
+      //hwinfo.op_compute_unit_latencies[op->func + "_pipelined"] =
+        //std::max(0, ((int)schedule.size()) - 1);
       hwinfo.compute_unit_latencies[op->func + "_pipelined"] =
         std::max(0, ((int)schedule.size()) - 1);
     }

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -749,8 +749,8 @@ void generate_coreir_compute_unit(CodegenOptions& options, bool found_compute,
       if (hwinfo.use_dse_compute) {
         halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_mapped"));
       } else {
-        //halide_cu = def->addInstance("inner_compute", ns->getModule(op->func));
-        halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_pipelined"));
+        halide_cu = def->addInstance("inner_compute", ns->getModule(op->func));
+        //halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_pipelined"));
       }
       assert(halide_cu != nullptr);
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1864,7 +1864,7 @@ void generate_coreir(CodegenOptions& options,
     prog& prg,
     umap* schedmap,
     schedule_info& hwinfo) {
-  pipeline_compute_units(prg);
+  //pipeline_compute_units(prg);
 
   CoreIR::Context* context = CoreIR::newContext();
   CoreIRLoadLibrary_commonlib(context);
@@ -3069,7 +3069,7 @@ void copy_and_pipeline_connection(vector<std::set<Instance*> >& stages, map<Inst
   copy_def->connect(wc0, wc1);
 }
 
-void pipeline_compute_units(prog& prg) {
+void pipeline_compute_units(prog& prg, schedule_info& hwinfo) {
   CoreIR::Context* context = CoreIR::newContext();
   CoreIRLoadLibrary_commonlib(context);
   CoreIRLoadLibrary_cgralib(context);
@@ -3188,6 +3188,9 @@ void pipeline_compute_units(prog& prg) {
         copy_and_pipeline_connection(schedule, instance_map, c.first, c.second, copy_def);
       }
       copy->setDef(copy_def);
+
+      hwinfo.op_compute_unit_latencies[op->func] =
+        std::max(0, ((int)schedule.size()) - 1);
     }
   }
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -3029,6 +3029,43 @@ void pipeline_compute_units(prog& prg) {
       for (auto i : instance_connections_dst_to_src) {
         cout << tab(1) << i.first->toString() << endl;
       }
+
+      vector<std::set<Instance*> > schedule;
+      int num_scheduled = 0;
+      std::set<Instance*> unscheduled;
+      for (auto i : instances) {
+        unscheduled.insert(i);
+      }
+      while (unscheduled.size() > 0) {
+        Instance* next_sched = nullptr;
+        for (Instance* i : unscheduled) {
+          bool all_deps_scheduled = true;
+          for (auto d : instance_connections_dst_to_src[i]) {
+            if (dbhc::elem(d, unscheduled)) {
+              all_deps_scheduled = false;
+              break;
+            }
+          }
+
+          if (all_deps_scheduled) {
+            next_sched = i;
+            break;
+          }
+        }
+        assert(next_sched != nullptr);
+        unscheduled.erase(next_sched);
+        schedule.push_back({next_sched});
+        num_scheduled++;
+      }
+      assert(num_scheduled == instances.size());
+
+      cout << "Final schedule size: " << schedule.size() << endl;
+      for (auto f : schedule) {
+        cout << "Level..." << endl;
+        for (auto l : f) {
+          cout << tab(1) << l->toString() << endl;
+        }
+      }
     }
   }
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1430,7 +1430,8 @@ CoreIR::Module* generate_coreir(CodegenOptions& options,
   Module* ub = coreir_moduledef(options, buffers, prg, schedmap, context, hwinfo);
 
   bool found_compute = true;
-  string compute_file = "./coreir_compute/" + prg.name + "_compute.json";
+  //string compute_file = "./coreir_compute/" + prg.name + "_compute.json";
+  string compute_file = "./coreir_compute/" + prg.name + "_compute_pipelined.json";
   if (hwinfo.use_dse_compute) {
     compute_file = "./dse_compute/" + prg.name + "_mapped.json";
   }
@@ -1862,6 +1863,8 @@ void generate_coreir(CodegenOptions& options,
     prog& prg,
     umap* schedmap,
     schedule_info& hwinfo) {
+  pipeline_compute_units(prg);
+
   CoreIR::Context* context = CoreIR::newContext();
   CoreIRLoadLibrary_commonlib(context);
   CoreIRLoadLibrary_cgralib(context);
@@ -3112,11 +3115,12 @@ void pipeline_compute_units(prog& prg) {
     }
   }
 
-  if(!saveToFile(ns, prg.name + "_compute_pipelined.json")) {
+  if(!saveToFile(ns, "./coreir_compute/" + prg.name + "_compute_pipelined.json")) {
     cout << "Could not save ubuffer coreir" << endl;
     context->die();
   }
   deleteContext(context);
+  assert(false);
 }
 
 #endif

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1863,7 +1863,7 @@ void generate_coreir(CodegenOptions& options,
     prog& prg,
     umap* schedmap,
     schedule_info& hwinfo) {
-  //pipeline_compute_units(prg);
+  pipeline_compute_units(prg);
 
   CoreIR::Context* context = CoreIR::newContext();
   CoreIRLoadLibrary_commonlib(context);
@@ -3003,6 +3003,12 @@ void copy_and_pipeline_connection(vector<std::set<Instance*> >& stages, map<Inst
 
 void pipeline_compute_units(prog& prg) {
   CoreIR::Context* context = CoreIR::newContext();
+  CoreIRLoadLibrary_commonlib(context);
+  CoreIRLoadLibrary_cgralib(context);
+  CoreIRLoadLibrary_cwlib(context);
+  add_delay_tile_generator(context);
+  add_raw_quad_port_memtile_generator(context);
+  add_tahoe_memory_generator(context);
   auto c = context;
 
 
@@ -3011,12 +3017,14 @@ void pipeline_compute_units(prog& prg) {
   ifstream cfile(compute_file);
   if (!cfile.good()) {
     cout << "No compute unit file: " << compute_file << endl;
-    assert(false);
+    return;
+    //assert(false);
   }
   if (!loadFromFile(context, compute_file)) {
     found_compute = false;
     cout << "Could not load compute file for: " << prg.name << ", file name = " << compute_file << endl;
-    assert(false);
+    return;
+    //assert(false);
   }
 
   auto ns = c->getNamespace("global");
@@ -3120,7 +3128,7 @@ void pipeline_compute_units(prog& prg) {
     context->die();
   }
   deleteContext(context);
-  assert(false);
+  //assert(false);
 }
 
 #endif

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -749,8 +749,8 @@ void generate_coreir_compute_unit(CodegenOptions& options, bool found_compute,
       if (hwinfo.use_dse_compute) {
         halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_mapped"));
       } else {
-        halide_cu = def->addInstance("inner_compute", ns->getModule(op->func));
-        //halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_pipelined"));
+        //halide_cu = def->addInstance("inner_compute", ns->getModule(op->func));
+        halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_pipelined"));
       }
       assert(halide_cu != nullptr);
 
@@ -875,7 +875,9 @@ Wireable* write_start_wire(ModuleDef* def, const std::string& opname) {
 
 void connect_op_control_wires(CodegenOptions& options, ModuleDef* def, op* op, schedule_info& hwinfo, Instance* controller) {
   cout << "Find compute" << endl;
-  int op_latency = map_find(op->name, hwinfo.op_compute_unit_latencies);
+  //int op_latency = map_find(op->name, hwinfo.op_compute_unit_latencies);
+  int op_latency = hwinfo.compute_latency(op);
+  //map_find(op->name, hwinfo.op_compute_unit_latencies);
   int read_latency =
     op->buffers_read().size() == 0 ? 0 :
     hwinfo.load_latency(pick(op->buffers_read()));
@@ -3189,7 +3191,9 @@ void pipeline_compute_units(prog& prg, schedule_info& hwinfo) {
       }
       copy->setDef(copy_def);
 
-      hwinfo.op_compute_unit_latencies[op->func] =
+      hwinfo.op_compute_unit_latencies[op->func + "_pipelined"] =
+        std::max(0, ((int)schedule.size()) - 1);
+      hwinfo.compute_unit_latencies[op->func + "_pipelined"] =
         std::max(0, ((int)schedule.size()) - 1);
     }
   }

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2998,6 +2998,14 @@ void copy_and_pipeline_connection(vector<std::set<Instance*> >& stages, map<Inst
   Wireable* wc0 = copy_wireable(instance_map, w0, copy_def);
   Wireable* wc1 = copy_wireable(instance_map, w1, copy_def);
 
+  auto context = wc0->getContext();
+
+  if (wc0->getType()->isOutput()) {
+    wc0 = delay_by(copy_def, context->getUnique(), wc0, 0);
+  }
+  if (wc1->getType()->isOutput()) {
+    wc1 = delay_by(copy_def, context->getUnique(), wc1, 0);
+  }
   copy_def->connect(wc0, wc1);
 }
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1048,7 +1048,8 @@ Instance* generate_coreir_op_controller_verilog(CodegenOptions& options, ModuleD
   }
 
   assert(verilog_collateral_file != nullptr);
-  generate_fsm(*verilog_collateral_file, options, controller->getInstname() + c->getUnique(), "d", "valid", aff, dom);
+  //generate_fsm(*verilog_collateral_file, options, controller->getInstname() + c->getUnique(), "d", "valid", aff, dom);
+  generate_fsm(*verilog_collateral_file, options, controller->getInstname(), "d", "valid", aff, dom);
 
   connect_op_control_wires(options, def, op, hwinfo, controller);
   return controller;

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2965,6 +2965,36 @@ CoreIR::Instance* cmux(CoreIR::ModuleDef* def,
   return next_val;
 }
 
+void pipeline_compute_units(prog& prg) {
+  CoreIR::Context* context = CoreIR::newContext();
+  auto c = context;
+
+
+  bool found_compute = true;
+  string compute_file = "./coreir_compute/" + prg.name + "_compute.json";
+  ifstream cfile(compute_file);
+  if (!cfile.good()) {
+    cout << "No compute unit file: " << compute_file << endl;
+    assert(false);
+  }
+  if (!loadFromFile(context, compute_file)) {
+    found_compute = false;
+    cout << "Could not load compute file for: " << prg.name << ", file name = " << compute_file << endl;
+    assert(false);
+  }
+
+  auto ns = c->getNamespace("global");
+  for (auto op : prg.all_ops()) {
+    if (op->func != "") {
+      string compute_name = op->func;
+      auto mod = ns->getModule(compute_name);
+      mod->print();
+    }
+  }
+
+  deleteContext(context);
+}
+
 #endif
 
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2974,6 +2974,17 @@ Wireable* base(Wireable* w) {
   return w;
 }
 
+Wireable* copy_wireable(map<Instance*, Instance*>& instance_map, Wireable* w0, ModuleDef* copy_def) {
+  assert(false);
+}
+
+void copy_and_pipeline_connection(vector<std::set<Instance*> >& stages, map<Instance*, Instance*>& instance_map, Wireable* w0, Wireable* w1, ModuleDef* copy_def) {
+  Wireable* wc0 = copy_wireable(instance_map, w0, copy_def);
+  Wireable* wc1 = copy_wireable(instance_map, w1, copy_def);
+
+  copy_def->connect(wc0, wc1);
+}
+
 void pipeline_compute_units(prog& prg) {
   CoreIR::Context* context = CoreIR::newContext();
   auto c = context;
@@ -3082,25 +3093,7 @@ void pipeline_compute_units(prog& prg) {
       for (auto c : mod->getDef()->getConnections()) {
         Wireable* base0 = base(c.first);
         Wireable* base1 = base(c.second);
-        //if (isa<Instance>(base0) && isa<Instance>(base1)) {
-          //Instance* src = nullptr;
-          //Instance* dst = nullptr;
-          //cout << tab(1) << "Instance connection between " << base0->toString() << " and " << base1->toString() << endl;
-          //cout << tab(2) << c.first->getType()->isInput() << endl;
-
-          //if (c.first->getType()->isInput()) {
-            //dst = static_cast<Instance*>(base0);
-            //src = static_cast<Instance*>(base1);
-          //} else {
-            //dst = static_cast<Instance*>(base1);
-            //src = static_cast<Instance*>(base0);
-          //}
-
-          //assert(src != nullptr);
-          //assert(dst != nullptr);
-
-          //instance_connections_dst_to_src[dst].insert(src);
-          //}
+        copy_and_pipeline_connection(schedule, instance_map, c.first, c.second, copy_def);
       }
       copy->setDef(copy_def);
     }

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1430,8 +1430,8 @@ CoreIR::Module* generate_coreir(CodegenOptions& options,
   Module* ub = coreir_moduledef(options, buffers, prg, schedmap, context, hwinfo);
 
   bool found_compute = true;
-  //string compute_file = "./coreir_compute/" + prg.name + "_compute.json";
-  string compute_file = "./coreir_compute/" + prg.name + "_compute_pipelined.json";
+  string compute_file = "./coreir_compute/" + prg.name + "_compute.json";
+  //string compute_file = "./coreir_compute/" + prg.name + "_compute_pipelined.json";
   if (hwinfo.use_dse_compute) {
     compute_file = "./dse_compute/" + prg.name + "_mapped.json";
   }
@@ -1863,7 +1863,7 @@ void generate_coreir(CodegenOptions& options,
     prog& prg,
     umap* schedmap,
     schedule_info& hwinfo) {
-  pipeline_compute_units(prg);
+  //pipeline_compute_units(prg);
 
   CoreIR::Context* context = CoreIR::newContext();
   CoreIRLoadLibrary_commonlib(context);

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1031,6 +1031,7 @@ Instance* generate_coreir_op_controller_verilog(CodegenOptions& options, ModuleD
   cout << "sched = " << str(saff) << endl;
   cout << tab(1) << "dom = " << str(dom) << endl;
 
+
   // TODO: Assert multi size == 1
   auto aff = isl_multi_aff_get_aff(saff, 0);
   Instance* controller;
@@ -1045,6 +1046,9 @@ Instance* generate_coreir_op_controller_verilog(CodegenOptions& options, ModuleD
     //generate verilog collateral
     generate_lake_tile_verilog(options, controller);
   }
+
+  assert(verilog_collateral_file != nullptr);
+  generate_fsm(*verilog_collateral_file, options, "my_test_ctrl", "d", "wen", aff, dom);
 
   connect_op_control_wires(options, def, op, hwinfo, controller);
   return controller;

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2988,7 +2988,11 @@ void pipeline_compute_units(prog& prg) {
     if (op->func != "") {
       string compute_name = op->func;
       auto mod = ns->getModule(compute_name);
-      mod->print();
+      vector<Instance*> instances;
+      for (auto inst : mod->getDef()->getInstances()) {
+        instances.push_back(inst.second);
+      }
+      cout << "# of instances: " << instances.size() << endl;
     }
   }
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -3003,7 +3003,6 @@ void pipeline_compute_units(prog& prg) {
       }
       cout << "# of instances: " << instances.size() << endl;
       for (auto c : mod->getDef()->getConnections()) {
-        //cout << tab(1) << c.first->toString() << " <-> " << c.second->toString() << endl;
         Wireable* base0 = base(c.first);
         Wireable* base1 = base(c.second);
         if (isa<Instance>(base0) && isa<Instance>(base1)) {
@@ -3070,9 +3069,22 @@ void pipeline_compute_units(prog& prg) {
           cout << tab(1) << l->toString() << endl;
         }
       }
+
+      auto mod_tp = mod->getType();
+      auto copy = ns->newModuleDecl(mod->getName() + "_pipelined", mod_tp);
+      auto copy_def = copy->newModuleDef();
+      map<Instance*, Instance*> instance_map;
+      for (auto inst : instances) {
+        instance_map[inst] = copy_def->addInstance(inst, inst->getInstname());
+      }
+      copy->setDef(copy_def);
     }
   }
 
+  if(!saveToFile(ns, prg.name + "_compute_pipelined.json")) {
+    cout << "Could not save ubuffer coreir" << endl;
+    context->die();
+  }
   deleteContext(context);
 }
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2993,6 +2993,9 @@ void pipeline_compute_units(prog& prg) {
         instances.push_back(inst.second);
       }
       cout << "# of instances: " << instances.size() << endl;
+      for (auto c : mod->getDef()->getConnections()) {
+        cout << tab(1) << c.first->toString() << " <-> " << c.second->toString() << endl;
+      }
     }
   }
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -2968,7 +2968,8 @@ CoreIR::Instance* cmux(CoreIR::ModuleDef* def,
 
 Wireable* base(Wireable* w) {
   if (isa<Select>(w)) {
-    return static_cast<Select*>(w)->getParent();
+    //return static_cast<Select*>(w)->getParent();
+    return static_cast<Select*>(w)->getTopParent();
   }
   return w;
 }
@@ -3012,11 +3013,11 @@ void pipeline_compute_units(prog& prg) {
           cout << tab(2) << c.first->getType()->isInput() << endl;
 
           if (c.first->getType()->isInput()) {
-            dst = static_cast<Instance*>(c.first);
-            src = static_cast<Instance*>(c.second);
+            dst = static_cast<Instance*>(base0);
+            src = static_cast<Instance*>(base1);
           } else {
-            dst = static_cast<Instance*>(c.second);
-            src = static_cast<Instance*>(c.first);
+            dst = static_cast<Instance*>(base1);
+            src = static_cast<Instance*>(base0);
           }
 
           assert(src != nullptr);
@@ -3028,6 +3029,9 @@ void pipeline_compute_units(prog& prg) {
       cout << "Instance connections..." << endl;
       for (auto i : instance_connections_dst_to_src) {
         cout << tab(1) << i.first->toString() << endl;
+        for (auto c : i.second) {
+          cout << tab(2) << c->toString() << endl;
+        }
       }
 
       vector<std::set<Instance*> > schedule;

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -21,6 +21,7 @@ using CoreIR::TypeGen;
 using CoreIR::Type;
 using CoreIR::Values;
 
+using CoreIR::Interface;
 using CoreIR::Select;
 using CoreIR::SelectPath;
 using CoreIR::join;
@@ -2975,6 +2976,18 @@ Wireable* base(Wireable* w) {
 }
 
 Wireable* copy_wireable(map<Instance*, Instance*>& instance_map, Wireable* w0, ModuleDef* copy_def) {
+  if (isa<Interface>(w0)) {
+    return copy_def->sel("self");
+  }
+
+  if (isa<Instance>(w0)) {
+    return instance_map[static_cast<Instance*>(w0)];
+  }
+  if (isa<Select>(w0)) {
+    auto wc = static_cast<Select*>(w0);
+    return copy_wireable(instance_map, wc->getParent(), copy_def)->sel(wc->getSelStr());
+  }
+  cout << "Error: Cannot copy: " << w0->toString() << endl;
   assert(false);
 }
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -749,8 +749,11 @@ void generate_coreir_compute_unit(CodegenOptions& options, bool found_compute,
       if (hwinfo.use_dse_compute) {
         halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_mapped"));
       } else {
-        halide_cu = def->addInstance("inner_compute", ns->getModule(op->func));
-        //halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_pipelined"));
+        if (options.rtl_options.use_pipelined_compute_units) {
+          halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_pipelined"));
+        } else {
+          halide_cu = def->addInstance("inner_compute", ns->getModule(op->func));
+        }
       }
       assert(halide_cu != nullptr);
 

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -1049,7 +1049,8 @@ Instance* generate_coreir_op_controller_verilog(CodegenOptions& options, ModuleD
 
   assert(verilog_collateral_file != nullptr);
   //generate_fsm(*verilog_collateral_file, options, controller->getInstname() + c->getUnique(), "d", "valid", aff, dom);
-  generate_fsm(*verilog_collateral_file, options, controller->getInstname(), "d", "valid", aff, dom);
+  //generate_fsm(*verilog_collateral_file, options, controller->getInstname(), "d", "valid", aff, dom);
+  generate_fsm(*verilog_collateral_file, options, controller->getModuleRef()->getName(), "d", "valid", aff, dom);
 
   connect_op_control_wires(options, def, op, hwinfo, controller);
   return controller;

--- a/coreir_backend.cpp
+++ b/coreir_backend.cpp
@@ -750,6 +750,7 @@ void generate_coreir_compute_unit(CodegenOptions& options, bool found_compute,
         halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_mapped"));
       } else {
         halide_cu = def->addInstance("inner_compute", ns->getModule(op->func));
+        //halide_cu = def->addInstance("inner_compute", ns->getModule(op->func + "_pipelined"));
       }
       assert(halide_cu != nullptr);
 
@@ -1430,8 +1431,8 @@ CoreIR::Module* generate_coreir(CodegenOptions& options,
   Module* ub = coreir_moduledef(options, buffers, prg, schedmap, context, hwinfo);
 
   bool found_compute = true;
-  string compute_file = "./coreir_compute/" + prg.name + "_compute.json";
-  //string compute_file = "./coreir_compute/" + prg.name + "_compute_pipelined.json";
+  //string compute_file = "./coreir_compute/" + prg.name + "_compute.json";
+  string compute_file = "./coreir_compute/" + prg.name + "_compute_pipelined.json";
   if (hwinfo.use_dse_compute) {
     compute_file = "./dse_compute/" + prg.name + "_mapped.json";
   }

--- a/coreir_backend.h
+++ b/coreir_backend.h
@@ -143,5 +143,7 @@ void generate_platonic_ubuffer(
     UBuffer& buf,
     schedule_info& hwinfo);
 
+void pipeline_compute_units(prog& prg);
+
 #endif
 

--- a/coreir_backend.h
+++ b/coreir_backend.h
@@ -143,7 +143,7 @@ void generate_platonic_ubuffer(
     UBuffer& buf,
     schedule_info& hwinfo);
 
-void pipeline_compute_units(prog& prg);
+void pipeline_compute_units(prog& prg, schedule_info& hwinfo);
 
 #endif
 

--- a/coreir_compute/harris_sch3_1pp9c_compute.json
+++ b/coreir_compute/harris_sch3_1pp9c_compute.json
@@ -8,28 +8,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_475_476_477":{
+          "bitand_625_626_627":{
             "modref":"corebit.and"
           },
-          "bitand_477_478_479":{
+          "bitand_627_628_629":{
             "modref":"corebit.and"
           },
-          "bitand_479_480_481":{
+          "bitand_629_630_631":{
             "modref":"corebit.and"
           },
-          "bitand_481_482_483":{
+          "bitand_631_632_633":{
             "modref":"corebit.and"
           },
-          "bitand_483_484_485":{
+          "bitand_633_634_635":{
             "modref":"corebit.and"
           },
-          "bitand_485_486_487":{
+          "bitand_635_636_637":{
             "modref":"corebit.and"
           },
-          "bitand_487_488_489":{
+          "bitand_637_638_639":{
             "modref":"corebit.and"
           },
-          "bitand_489_491_492":{
+          "bitand_639_641_642":{
             "modref":"corebit.and"
           },
           "const_p0_0":{
@@ -37,7 +37,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__490":{
+          "const_p1__640":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -47,86 +47,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_4922550":{
+          "mux_6422550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_490_cim_stencil_2_491":{
+          "sle_640_cim_stencil_2_641":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_1_cim_stencil_2_475":{
+          "slt_cim_stencil_1_cim_stencil_2_625":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_3_cim_stencil_2_476":{
+          "slt_cim_stencil_3_cim_stencil_2_626":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_4_cim_stencil_2_478":{
+          "slt_cim_stencil_4_cim_stencil_2_628":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_5_cim_stencil_2_480":{
+          "slt_cim_stencil_5_cim_stencil_2_630":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_6_cim_stencil_2_482":{
+          "slt_cim_stencil_6_cim_stencil_2_632":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_7_cim_stencil_2_484":{
+          "slt_cim_stencil_7_cim_stencil_2_634":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_8_cim_stencil_2_486":{
+          "slt_cim_stencil_8_cim_stencil_2_636":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_9_cim_stencil_2_488":{
+          "slt_cim_stencil_9_cim_stencil_2_638":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_1_cim_stencil_2_475.out","bitand_475_476_477.in0"],
-          ["slt_cim_stencil_3_cim_stencil_2_476.out","bitand_475_476_477.in1"],
-          ["bitand_477_478_479.in0","bitand_475_476_477.out"],
-          ["slt_cim_stencil_4_cim_stencil_2_478.out","bitand_477_478_479.in1"],
-          ["bitand_479_480_481.in0","bitand_477_478_479.out"],
-          ["slt_cim_stencil_5_cim_stencil_2_480.out","bitand_479_480_481.in1"],
-          ["bitand_481_482_483.in0","bitand_479_480_481.out"],
-          ["slt_cim_stencil_6_cim_stencil_2_482.out","bitand_481_482_483.in1"],
-          ["bitand_483_484_485.in0","bitand_481_482_483.out"],
-          ["slt_cim_stencil_7_cim_stencil_2_484.out","bitand_483_484_485.in1"],
-          ["bitand_485_486_487.in0","bitand_483_484_485.out"],
-          ["slt_cim_stencil_8_cim_stencil_2_486.out","bitand_485_486_487.in1"],
-          ["bitand_487_488_489.in0","bitand_485_486_487.out"],
-          ["slt_cim_stencil_9_cim_stencil_2_488.out","bitand_487_488_489.in1"],
-          ["bitand_489_491_492.in0","bitand_487_488_489.out"],
-          ["sle_490_cim_stencil_2_491.out","bitand_489_491_492.in1"],
-          ["mux_4922550.sel","bitand_489_491_492.out"],
-          ["mux_4922550.in0","const_p0_0.out"],
-          ["sle_490_cim_stencil_2_491.in0","const_p1__490.out"],
-          ["mux_4922550.in1","const_p255_255.out"],
-          ["self.out_cim_output_stencil","mux_4922550.out"],
-          ["slt_cim_stencil_1_cim_stencil_2_475.in0","self.in0_cim_stencil.0"],
-          ["sle_490_cim_stencil_2_491.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_1_cim_stencil_2_475.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_476.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_4_cim_stencil_2_478.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_5_cim_stencil_2_480.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_6_cim_stencil_2_482.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_7_cim_stencil_2_484.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_8_cim_stencil_2_486.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_9_cim_stencil_2_488.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_476.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_4_cim_stencil_2_478.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_5_cim_stencil_2_480.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_6_cim_stencil_2_482.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_7_cim_stencil_2_484.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_8_cim_stencil_2_486.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_9_cim_stencil_2_488.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_1_cim_stencil_2_625.out","bitand_625_626_627.in0"],
+          ["slt_cim_stencil_3_cim_stencil_2_626.out","bitand_625_626_627.in1"],
+          ["bitand_627_628_629.in0","bitand_625_626_627.out"],
+          ["slt_cim_stencil_4_cim_stencil_2_628.out","bitand_627_628_629.in1"],
+          ["bitand_629_630_631.in0","bitand_627_628_629.out"],
+          ["slt_cim_stencil_5_cim_stencil_2_630.out","bitand_629_630_631.in1"],
+          ["bitand_631_632_633.in0","bitand_629_630_631.out"],
+          ["slt_cim_stencil_6_cim_stencil_2_632.out","bitand_631_632_633.in1"],
+          ["bitand_633_634_635.in0","bitand_631_632_633.out"],
+          ["slt_cim_stencil_7_cim_stencil_2_634.out","bitand_633_634_635.in1"],
+          ["bitand_635_636_637.in0","bitand_633_634_635.out"],
+          ["slt_cim_stencil_8_cim_stencil_2_636.out","bitand_635_636_637.in1"],
+          ["bitand_637_638_639.in0","bitand_635_636_637.out"],
+          ["slt_cim_stencil_9_cim_stencil_2_638.out","bitand_637_638_639.in1"],
+          ["bitand_639_641_642.in0","bitand_637_638_639.out"],
+          ["sle_640_cim_stencil_2_641.out","bitand_639_641_642.in1"],
+          ["mux_6422550.sel","bitand_639_641_642.out"],
+          ["mux_6422550.in0","const_p0_0.out"],
+          ["sle_640_cim_stencil_2_641.in0","const_p1__640.out"],
+          ["mux_6422550.in1","const_p255_255.out"],
+          ["self.out_cim_output_stencil","mux_6422550.out"],
+          ["slt_cim_stencil_1_cim_stencil_2_625.in0","self.in0_cim_stencil.0"],
+          ["sle_640_cim_stencil_2_641.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_1_cim_stencil_2_625.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_626.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_4_cim_stencil_2_628.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_5_cim_stencil_2_630.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_6_cim_stencil_2_632.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_7_cim_stencil_2_634.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_8_cim_stencil_2_636.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_9_cim_stencil_2_638.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_626.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_4_cim_stencil_2_628.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_5_cim_stencil_2_630.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_6_cim_stencil_2_632.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_7_cim_stencil_2_634.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_8_cim_stencil_2_636.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_9_cim_stencil_2_638.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_stencil":{
@@ -137,89 +137,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_429_430_435":{
+          "add_579_580_585":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_436_437_438":{
+          "ashr_586_587_588":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_2_428_429":{
+          "ashr_lgxx_stencil_2_578_579":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_2_428_432":{
+          "ashr_lgxy_stencil_2_578_582":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_2_428_430":{
+          "ashr_lgyy_stencil_2_578_580":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__437":{
+          "const_p4__587":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__428":{
+          "const_p6__578":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__428$1":{
+          "const_p6__578$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__428$2":{
+          "const_p6__578$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_429_430_431":{
+          "mul_579_580_581":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_432_432_433":{
+          "mul_582_582_583":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_435_435_436":{
+          "mul_585_585_586":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_431_433_434":{
+          "sub_581_583_584":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_434_438_439":{
+          "sub_584_588_589":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_2_428_429.out","add_429_430_435.in0"],
-          ["ashr_lgyy_stencil_2_428_430.out","add_429_430_435.in1"],
-          ["mul_435_435_436.in0","add_429_430_435.out"],
-          ["mul_435_435_436.in1","add_429_430_435.out"],
-          ["mul_435_435_436.out","ashr_436_437_438.in0"],
-          ["const_p4__437.out","ashr_436_437_438.in1"],
-          ["sub_434_438_439.in1","ashr_436_437_438.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_428_429.in0"],
-          ["const_p6__428.out","ashr_lgxx_stencil_2_428_429.in1"],
-          ["mul_429_430_431.in0","ashr_lgxx_stencil_2_428_429.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_428_432.in0"],
-          ["const_p6__428$2.out","ashr_lgxy_stencil_2_428_432.in1"],
-          ["mul_432_432_433.in0","ashr_lgxy_stencil_2_428_432.out"],
-          ["mul_432_432_433.in1","ashr_lgxy_stencil_2_428_432.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_428_430.in0"],
-          ["const_p6__428$1.out","ashr_lgyy_stencil_2_428_430.in1"],
-          ["mul_429_430_431.in1","ashr_lgyy_stencil_2_428_430.out"],
-          ["sub_431_433_434.in0","mul_429_430_431.out"],
-          ["sub_431_433_434.in1","mul_432_432_433.out"],
-          ["sub_434_438_439.out","self.out_cim_stencil"],
-          ["sub_434_438_439.in0","sub_431_433_434.out"]
+          ["ashr_lgxx_stencil_2_578_579.out","add_579_580_585.in0"],
+          ["ashr_lgyy_stencil_2_578_580.out","add_579_580_585.in1"],
+          ["mul_585_585_586.in0","add_579_580_585.out"],
+          ["mul_585_585_586.in1","add_579_580_585.out"],
+          ["mul_585_585_586.out","ashr_586_587_588.in0"],
+          ["const_p4__587.out","ashr_586_587_588.in1"],
+          ["sub_584_588_589.in1","ashr_586_587_588.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_578_579.in0"],
+          ["const_p6__578.out","ashr_lgxx_stencil_2_578_579.in1"],
+          ["mul_579_580_581.in0","ashr_lgxx_stencil_2_578_579.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_578_582.in0"],
+          ["const_p6__578$2.out","ashr_lgxy_stencil_2_578_582.in1"],
+          ["mul_582_582_583.in0","ashr_lgxy_stencil_2_578_582.out"],
+          ["mul_582_582_583.in1","ashr_lgxy_stencil_2_578_582.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_578_580.in0"],
+          ["const_p6__578$1.out","ashr_lgyy_stencil_2_578_580.in1"],
+          ["mul_579_580_581.in1","ashr_lgyy_stencil_2_578_580.out"],
+          ["sub_581_583_584.in0","mul_579_580_581.out"],
+          ["sub_581_583_584.in1","mul_582_582_583.out"],
+          ["sub_584_588_589.out","self.out_cim_stencil"],
+          ["sub_584_588_589.in0","sub_581_583_584.out"]
         ]
       },
       "hcompute_grad_x_stencil":{
@@ -228,31 +228,31 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n255__301":{
+          "const_n255__295":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__299":{
+          "const_p255__293":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "smax_300_301_302":{
+          "smax_294_295_296":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_2_299_300":{
+          "smin_grad_x_unclamp_stencil_2_293_294":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_300_301_302.in1","const_n255__301.out"],
-          ["smin_grad_x_unclamp_stencil_2_299_300.in1","const_p255__299.out"],
-          ["smin_grad_x_unclamp_stencil_2_299_300.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smax_300_301_302.out","self.out_grad_x_stencil"],
-          ["smin_grad_x_unclamp_stencil_2_299_300.out","smax_300_301_302.in0"]
+          ["smax_294_295_296.in1","const_n255__295.out"],
+          ["smin_grad_x_unclamp_stencil_2_293_294.in1","const_p255__293.out"],
+          ["smin_grad_x_unclamp_stencil_2_293_294.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smax_294_295_296.out","self.out_grad_x_stencil"],
+          ["smin_grad_x_unclamp_stencil_2_293_294.out","smax_294_295_296.in0"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil":{
@@ -279,15 +279,15 @@
           ["grad_x_unclamp_s1_r_y",["Array",16,"BitIn"]]
         ]],
         "instances":{
-          "add_2774_278":{
+          "add_2714_272":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_grad_x_unclamp_s1_r_x_278_279":{
+          "add_grad_x_unclamp_s1_r_x_272_273":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_grad_x_unclamp_stencil_1_282_283":{
+          "add_grad_x_unclamp_stencil_1_276_277":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
@@ -301,18 +301,18 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "mul_grad_x_unclamp_s1_r_y3_277":{
+          "mul_grad_x_unclamp_s1_r_y3_271":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_1_281_282":{
+          "mul_padded16_global_wrapper_stencil_1_275_276":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
           "rom_kernel_xa0":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[-1,null,1,-2,null,2,-1,null,1]]}
+            "modargs":{"init":["Json",[-1,0,1,-2,0,2,-1,0,1]]}
           },
           "rom_kernel_xa0_ren":{
             "modref":"corebit.const",
@@ -320,18 +320,18 @@
           }
         },
         "connections":[
-          ["mul_grad_x_unclamp_s1_r_y3_277.out","add_2774_278.in0"],
-          ["const_p4_4.out","add_2774_278.in1"],
-          ["add_grad_x_unclamp_s1_r_x_278_279.in1","add_2774_278.out"],
-          ["self.grad_x_unclamp_s1_r_x","add_grad_x_unclamp_s1_r_x_278_279.in0"],
-          ["rom_kernel_xa0.raddr","add_grad_x_unclamp_s1_r_x_278_279.out"],
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_282_283.in0"],
-          ["mul_padded16_global_wrapper_stencil_1_281_282.out","add_grad_x_unclamp_stencil_1_282_283.in1"],
-          ["self.out_grad_x_unclamp_stencil","add_grad_x_unclamp_stencil_1_282_283.out"],
-          ["mul_grad_x_unclamp_s1_r_y3_277.in1","const_p3_3.out"],
-          ["self.grad_x_unclamp_s1_r_y","mul_grad_x_unclamp_s1_r_y3_277.in0"],
-          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_281_282.in0"],
-          ["rom_kernel_xa0.rdata","mul_padded16_global_wrapper_stencil_1_281_282.in1"],
+          ["mul_grad_x_unclamp_s1_r_y3_271.out","add_2714_272.in0"],
+          ["const_p4_4.out","add_2714_272.in1"],
+          ["add_grad_x_unclamp_s1_r_x_272_273.in1","add_2714_272.out"],
+          ["self.grad_x_unclamp_s1_r_x","add_grad_x_unclamp_s1_r_x_272_273.in0"],
+          ["rom_kernel_xa0.raddr","add_grad_x_unclamp_s1_r_x_272_273.out"],
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_276_277.in0"],
+          ["mul_padded16_global_wrapper_stencil_1_275_276.out","add_grad_x_unclamp_stencil_1_276_277.in1"],
+          ["self.out_grad_x_unclamp_stencil","add_grad_x_unclamp_stencil_1_276_277.out"],
+          ["mul_grad_x_unclamp_s1_r_y3_271.in1","const_p3_3.out"],
+          ["self.grad_x_unclamp_s1_r_y","mul_grad_x_unclamp_s1_r_y3_271.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_275_276.in0"],
+          ["rom_kernel_xa0.rdata","mul_padded16_global_wrapper_stencil_1_275_276.in1"],
           ["rom_kernel_xa0_ren.out","rom_kernel_xa0.ren"]
         ]
       },
@@ -341,31 +341,31 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n255__368":{
+          "const_n255__410":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__366":{
+          "const_p255__408":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "smax_367_368_369":{
+          "smax_409_410_411":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_2_366_367":{
+          "smin_grad_y_unclamp_stencil_2_408_409":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_367_368_369.in1","const_n255__368.out"],
-          ["smin_grad_y_unclamp_stencil_2_366_367.in1","const_p255__366.out"],
-          ["smin_grad_y_unclamp_stencil_2_366_367.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smax_367_368_369.out","self.out_grad_y_stencil"],
-          ["smin_grad_y_unclamp_stencil_2_366_367.out","smax_367_368_369.in0"]
+          ["smax_409_410_411.in1","const_n255__410.out"],
+          ["smin_grad_y_unclamp_stencil_2_408_409.in1","const_p255__408.out"],
+          ["smin_grad_y_unclamp_stencil_2_408_409.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smax_409_410_411.out","self.out_grad_y_stencil"],
+          ["smin_grad_y_unclamp_stencil_2_408_409.out","smax_409_410_411.in0"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil":{
@@ -373,14 +373,14 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__329":{
+          "const_p0__377":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__329.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__377.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_1":{
@@ -392,15 +392,15 @@
           ["grad_y_unclamp_s1_r_y",["Array",16,"BitIn"]]
         ]],
         "instances":{
-          "add_3444_345":{
+          "add_3864_387":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_grad_y_unclamp_s1_r_x_345_346":{
+          "add_grad_y_unclamp_s1_r_x_387_388":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_grad_y_unclamp_stencil_1_349_350":{
+          "add_grad_y_unclamp_stencil_1_391_392":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
@@ -414,18 +414,18 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "mul_grad_y_unclamp_s1_r_y3_344":{
+          "mul_grad_y_unclamp_s1_r_y3_386":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_2_348_349":{
+          "mul_padded16_global_wrapper_stencil_2_390_391":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
           "rom_kernel_ya1":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[1,2,1,null,null,null,-1,-2,-1]]}
+            "modargs":{"init":["Json",[-1,-2,-1,0,0,0,1,2,1]]}
           },
           "rom_kernel_ya1_ren":{
             "modref":"corebit.const",
@@ -433,18 +433,18 @@
           }
         },
         "connections":[
-          ["mul_grad_y_unclamp_s1_r_y3_344.out","add_3444_345.in0"],
-          ["const_p4_4$1.out","add_3444_345.in1"],
-          ["add_grad_y_unclamp_s1_r_x_345_346.in1","add_3444_345.out"],
-          ["self.grad_y_unclamp_s1_r_x","add_grad_y_unclamp_s1_r_x_345_346.in0"],
-          ["rom_kernel_ya1.raddr","add_grad_y_unclamp_s1_r_x_345_346.out"],
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_349_350.in0"],
-          ["mul_padded16_global_wrapper_stencil_2_348_349.out","add_grad_y_unclamp_stencil_1_349_350.in1"],
-          ["self.out_grad_y_unclamp_stencil","add_grad_y_unclamp_stencil_1_349_350.out"],
-          ["mul_grad_y_unclamp_s1_r_y3_344.in1","const_p3_3$1.out"],
-          ["self.grad_y_unclamp_s1_r_y","mul_grad_y_unclamp_s1_r_y3_344.in0"],
-          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_2_348_349.in0"],
-          ["rom_kernel_ya1.rdata","mul_padded16_global_wrapper_stencil_2_348_349.in1"],
+          ["mul_grad_y_unclamp_s1_r_y3_386.out","add_3864_387.in0"],
+          ["const_p4_4$1.out","add_3864_387.in1"],
+          ["add_grad_y_unclamp_s1_r_x_387_388.in1","add_3864_387.out"],
+          ["self.grad_y_unclamp_s1_r_x","add_grad_y_unclamp_s1_r_x_387_388.in0"],
+          ["rom_kernel_ya1.raddr","add_grad_y_unclamp_s1_r_x_387_388.out"],
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_391_392.in0"],
+          ["mul_padded16_global_wrapper_stencil_2_390_391.out","add_grad_y_unclamp_stencil_1_391_392.in1"],
+          ["self.out_grad_y_unclamp_stencil","add_grad_y_unclamp_stencil_1_391_392.out"],
+          ["mul_grad_y_unclamp_s1_r_y3_386.in1","const_p3_3$1.out"],
+          ["self.grad_y_unclamp_s1_r_y","mul_grad_y_unclamp_s1_r_y3_386.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_2_390_391.in0"],
+          ["rom_kernel_ya1.rdata","mul_padded16_global_wrapper_stencil_2_390_391.in1"],
           ["rom_kernel_ya1_ren.out","rom_kernel_ya1.ren"]
         ]
       },
@@ -462,32 +462,152 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__319":{
+          "const_p0__313":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__319.out"]
+          ["self.out_lgxx_stencil","const_p0__313.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__320":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__320.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_2":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__326":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__326.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_3":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__333":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__333.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_4":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__339":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__339.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_5":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__344":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__344.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_6":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__350":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__350.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_7":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__357":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__357.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_8":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__363":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__363.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_9":{
         "type":["Record",[
           ["out_lgxx_stencil",["Array",16,"Bit"]],
           ["in0_lgxx_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_lxx_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_lxx_stencil_1_322":{
+          "add_lgxx_stencil_1_lxx_stencil_1_370":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_lxx_stencil_1_322.in0"],
-          ["self.in1_lxx_stencil.0","add_lgxx_stencil_1_lxx_stencil_1_322.in1"],
-          ["self.out_lgxx_stencil","add_lgxx_stencil_1_lxx_stencil_1_322.out"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_lxx_stencil_1_370.in0"],
+          ["self.in1_lxx_stencil.0","add_lgxx_stencil_1_lxx_stencil_1_370.in1"],
+          ["self.out_lgxx_stencil","add_lgxx_stencil_1_lxx_stencil_1_370.out"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -495,32 +615,152 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__387":{
+          "const_p0__429":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__387.out"]
+          ["self.out_lgxy_stencil","const_p0__429.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__436":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__436.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_2":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__442":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__442.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_3":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__449":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__449.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_4":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__455":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__455.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_5":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__460":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__460.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_6":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__466":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__466.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_7":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__473":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__473.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_8":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__479":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__479.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_9":{
         "type":["Record",[
           ["out_lgxy_stencil",["Array",16,"Bit"]],
           ["in0_lgxy_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_lxy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_lxy_stencil_1_390":{
+          "add_lgxy_stencil_1_lxy_stencil_1_486":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_lxy_stencil_1_390.in0"],
-          ["self.in1_lxy_stencil.0","add_lgxy_stencil_1_lxy_stencil_1_390.in1"],
-          ["self.out_lgxy_stencil","add_lgxy_stencil_1_lxy_stencil_1_390.out"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_lxy_stencil_1_486.in0"],
+          ["self.in1_lxy_stencil.0","add_lgxy_stencil_1_lxy_stencil_1_486.in1"],
+          ["self.out_lgxy_stencil","add_lgxy_stencil_1_lxy_stencil_1_486.out"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -528,32 +768,152 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__407":{
+          "const_p0__503":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__407.out"]
+          ["self.out_lgyy_stencil","const_p0__503.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__510":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__510.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_2":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__516":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__516.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_3":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__523":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__523.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_4":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__529":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__529.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_5":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__534":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__534.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_6":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__540":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__540.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_7":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__547":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__547.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_8":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__553":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__553.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_9":{
         "type":["Record",[
           ["out_lgyy_stencil",["Array",16,"Bit"]],
           ["in0_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_lyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_lyy_stencil_1_410":{
+          "add_lgyy_stencil_1_lyy_stencil_1_560":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_lyy_stencil_1_410.in0"],
-          ["self.in1_lyy_stencil.0","add_lgyy_stencil_1_lyy_stencil_1_410.in1"],
-          ["self.out_lgyy_stencil","add_lgyy_stencil_1_lyy_stencil_1_410.out"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_lyy_stencil_1_560.in0"],
+          ["self.in1_lyy_stencil.0","add_lgyy_stencil_1_lyy_stencil_1_560.in1"],
+          ["self.out_lgyy_stencil","add_lgyy_stencil_1_lyy_stencil_1_560.out"]
         ]
       },
       "hcompute_lxx_stencil":{
@@ -562,26 +922,26 @@
           ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_311_312_313":{
+          "ashr_305_306_307":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__312":{
+          "const_p7__306":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_x_stencil_1_grad_x_stencil_1_311":{
+          "mul_grad_x_stencil_1_grad_x_stencil_1_305":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_1_grad_x_stencil_1_311.out","ashr_311_312_313.in0"],
-          ["const_p7__312.out","ashr_311_312_313.in1"],
-          ["self.out_lxx_stencil","ashr_311_312_313.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_311.in0"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_311.in1"]
+          ["mul_grad_x_stencil_1_grad_x_stencil_1_305.out","ashr_305_306_307.in0"],
+          ["const_p7__306.out","ashr_305_306_307.in1"],
+          ["self.out_lxx_stencil","ashr_305_306_307.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_305.in0"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_305.in1"]
         ]
       },
       "hcompute_lxy_stencil":{
@@ -591,26 +951,26 @@
           ["in1_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_378_379_380":{
+          "ashr_420_421_422":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__379":{
+          "const_p7__421":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_x_stencil_2_grad_y_stencil_1_378":{
+          "mul_grad_x_stencil_2_grad_y_stencil_1_420":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_2_grad_y_stencil_1_378.out","ashr_378_379_380.in0"],
-          ["const_p7__379.out","ashr_378_379_380.in1"],
-          ["self.out_lxy_stencil","ashr_378_379_380.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_378.in0"],
-          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_378.in1"]
+          ["mul_grad_x_stencil_2_grad_y_stencil_1_420.out","ashr_420_421_422.in0"],
+          ["const_p7__421.out","ashr_420_421_422.in1"],
+          ["self.out_lxy_stencil","ashr_420_421_422.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_420.in0"],
+          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_420.in1"]
         ]
       },
       "hcompute_lyy_stencil":{
@@ -619,26 +979,26 @@
           ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_399_400_401":{
+          "ashr_495_496_497":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__400":{
+          "const_p7__496":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_y_stencil_2_grad_y_stencil_2_399":{
+          "mul_grad_y_stencil_2_grad_y_stencil_2_495":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_y_stencil_2_grad_y_stencil_2_399.out","ashr_399_400_401.in0"],
-          ["const_p7__400.out","ashr_399_400_401.in1"],
-          ["self.out_lyy_stencil","ashr_399_400_401.out"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_399.in0"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_399.in1"]
+          ["mul_grad_y_stencil_2_grad_y_stencil_2_495.out","ashr_495_496_497.in0"],
+          ["const_p7__496.out","ashr_495_496_497.in1"],
+          ["self.out_lyy_stencil","ashr_495_496_497.out"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_495.in0"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_495.in1"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{

--- a/coreir_compute/harris_sch4_1pp3c_compute.json
+++ b/coreir_compute/harris_sch4_1pp3c_compute.json
@@ -8,28 +8,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_574_575_576":{
+          "bitand_712_713_714":{
             "modref":"corebit.and"
           },
-          "bitand_576_577_578":{
+          "bitand_714_715_716":{
             "modref":"corebit.and"
           },
-          "bitand_578_579_580":{
+          "bitand_716_717_718":{
             "modref":"corebit.and"
           },
-          "bitand_580_581_582":{
+          "bitand_718_719_720":{
             "modref":"corebit.and"
           },
-          "bitand_582_583_584":{
+          "bitand_720_721_722":{
             "modref":"corebit.and"
           },
-          "bitand_584_585_586":{
+          "bitand_722_723_724":{
             "modref":"corebit.and"
           },
-          "bitand_586_587_588":{
+          "bitand_724_725_726":{
             "modref":"corebit.and"
           },
-          "bitand_588_590_591":{
+          "bitand_726_728_729":{
             "modref":"corebit.and"
           },
           "const_p0_0":{
@@ -37,7 +37,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__589":{
+          "const_p1__727":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -47,86 +47,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_5912550":{
+          "mux_7292550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_589_cim_stencil_2_590":{
+          "sle_727_cim_stencil_2_728":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_1_cim_stencil_2_574":{
+          "slt_cim_stencil_1_cim_stencil_2_712":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_3_cim_stencil_2_575":{
+          "slt_cim_stencil_3_cim_stencil_2_713":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_4_cim_stencil_2_577":{
+          "slt_cim_stencil_4_cim_stencil_2_715":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_5_cim_stencil_2_579":{
+          "slt_cim_stencil_5_cim_stencil_2_717":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_6_cim_stencil_2_581":{
+          "slt_cim_stencil_6_cim_stencil_2_719":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_7_cim_stencil_2_583":{
+          "slt_cim_stencil_7_cim_stencil_2_721":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_8_cim_stencil_2_585":{
+          "slt_cim_stencil_8_cim_stencil_2_723":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_9_cim_stencil_2_587":{
+          "slt_cim_stencil_9_cim_stencil_2_725":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_1_cim_stencil_2_574.out","bitand_574_575_576.in0"],
-          ["slt_cim_stencil_3_cim_stencil_2_575.out","bitand_574_575_576.in1"],
-          ["bitand_576_577_578.in0","bitand_574_575_576.out"],
-          ["slt_cim_stencil_4_cim_stencil_2_577.out","bitand_576_577_578.in1"],
-          ["bitand_578_579_580.in0","bitand_576_577_578.out"],
-          ["slt_cim_stencil_5_cim_stencil_2_579.out","bitand_578_579_580.in1"],
-          ["bitand_580_581_582.in0","bitand_578_579_580.out"],
-          ["slt_cim_stencil_6_cim_stencil_2_581.out","bitand_580_581_582.in1"],
-          ["bitand_582_583_584.in0","bitand_580_581_582.out"],
-          ["slt_cim_stencil_7_cim_stencil_2_583.out","bitand_582_583_584.in1"],
-          ["bitand_584_585_586.in0","bitand_582_583_584.out"],
-          ["slt_cim_stencil_8_cim_stencil_2_585.out","bitand_584_585_586.in1"],
-          ["bitand_586_587_588.in0","bitand_584_585_586.out"],
-          ["slt_cim_stencil_9_cim_stencil_2_587.out","bitand_586_587_588.in1"],
-          ["bitand_588_590_591.in0","bitand_586_587_588.out"],
-          ["sle_589_cim_stencil_2_590.out","bitand_588_590_591.in1"],
-          ["mux_5912550.sel","bitand_588_590_591.out"],
-          ["mux_5912550.in0","const_p0_0.out"],
-          ["sle_589_cim_stencil_2_590.in0","const_p1__589.out"],
-          ["mux_5912550.in1","const_p255_255.out"],
-          ["self.out_cim_output_stencil","mux_5912550.out"],
-          ["slt_cim_stencil_1_cim_stencil_2_574.in0","self.in0_cim_stencil.0"],
-          ["sle_589_cim_stencil_2_590.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_1_cim_stencil_2_574.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_575.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_4_cim_stencil_2_577.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_5_cim_stencil_2_579.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_6_cim_stencil_2_581.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_7_cim_stencil_2_583.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_8_cim_stencil_2_585.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_9_cim_stencil_2_587.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_575.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_4_cim_stencil_2_577.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_5_cim_stencil_2_579.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_6_cim_stencil_2_581.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_7_cim_stencil_2_583.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_8_cim_stencil_2_585.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_9_cim_stencil_2_587.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_1_cim_stencil_2_712.out","bitand_712_713_714.in0"],
+          ["slt_cim_stencil_3_cim_stencil_2_713.out","bitand_712_713_714.in1"],
+          ["bitand_714_715_716.in0","bitand_712_713_714.out"],
+          ["slt_cim_stencil_4_cim_stencil_2_715.out","bitand_714_715_716.in1"],
+          ["bitand_716_717_718.in0","bitand_714_715_716.out"],
+          ["slt_cim_stencil_5_cim_stencil_2_717.out","bitand_716_717_718.in1"],
+          ["bitand_718_719_720.in0","bitand_716_717_718.out"],
+          ["slt_cim_stencil_6_cim_stencil_2_719.out","bitand_718_719_720.in1"],
+          ["bitand_720_721_722.in0","bitand_718_719_720.out"],
+          ["slt_cim_stencil_7_cim_stencil_2_721.out","bitand_720_721_722.in1"],
+          ["bitand_722_723_724.in0","bitand_720_721_722.out"],
+          ["slt_cim_stencil_8_cim_stencil_2_723.out","bitand_722_723_724.in1"],
+          ["bitand_724_725_726.in0","bitand_722_723_724.out"],
+          ["slt_cim_stencil_9_cim_stencil_2_725.out","bitand_724_725_726.in1"],
+          ["bitand_726_728_729.in0","bitand_724_725_726.out"],
+          ["sle_727_cim_stencil_2_728.out","bitand_726_728_729.in1"],
+          ["mux_7292550.sel","bitand_726_728_729.out"],
+          ["mux_7292550.in0","const_p0_0.out"],
+          ["sle_727_cim_stencil_2_728.in0","const_p1__727.out"],
+          ["mux_7292550.in1","const_p255_255.out"],
+          ["self.out_cim_output_stencil","mux_7292550.out"],
+          ["slt_cim_stencil_1_cim_stencil_2_712.in0","self.in0_cim_stencil.0"],
+          ["sle_727_cim_stencil_2_728.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_1_cim_stencil_2_712.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_713.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_4_cim_stencil_2_715.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_5_cim_stencil_2_717.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_6_cim_stencil_2_719.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_7_cim_stencil_2_721.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_8_cim_stencil_2_723.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_9_cim_stencil_2_725.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_713.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_4_cim_stencil_2_715.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_5_cim_stencil_2_717.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_6_cim_stencil_2_719.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_7_cim_stencil_2_721.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_8_cim_stencil_2_723.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_9_cim_stencil_2_725.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_stencil":{
@@ -137,89 +137,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_528_529_534":{
+          "add_666_667_672":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_535_536_537":{
+          "ashr_673_674_675":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_2_527_528":{
+          "ashr_lgxx_stencil_2_665_666":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_2_527_531":{
+          "ashr_lgxy_stencil_2_665_669":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_2_527_529":{
+          "ashr_lgyy_stencil_2_665_667":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__536":{
+          "const_p4__674":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__527":{
+          "const_p6__665":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__527$1":{
+          "const_p6__665$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__527$2":{
+          "const_p6__665$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_528_529_530":{
+          "mul_666_667_668":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_531_531_532":{
+          "mul_669_669_670":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_534_534_535":{
+          "mul_672_672_673":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_530_532_533":{
+          "sub_668_670_671":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_533_537_538":{
+          "sub_671_675_676":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_2_527_528.out","add_528_529_534.in0"],
-          ["ashr_lgyy_stencil_2_527_529.out","add_528_529_534.in1"],
-          ["mul_534_534_535.in0","add_528_529_534.out"],
-          ["mul_534_534_535.in1","add_528_529_534.out"],
-          ["mul_534_534_535.out","ashr_535_536_537.in0"],
-          ["const_p4__536.out","ashr_535_536_537.in1"],
-          ["sub_533_537_538.in1","ashr_535_536_537.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_527_528.in0"],
-          ["const_p6__527.out","ashr_lgxx_stencil_2_527_528.in1"],
-          ["mul_528_529_530.in0","ashr_lgxx_stencil_2_527_528.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_527_531.in0"],
-          ["const_p6__527$2.out","ashr_lgxy_stencil_2_527_531.in1"],
-          ["mul_531_531_532.in0","ashr_lgxy_stencil_2_527_531.out"],
-          ["mul_531_531_532.in1","ashr_lgxy_stencil_2_527_531.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_527_529.in0"],
-          ["const_p6__527$1.out","ashr_lgyy_stencil_2_527_529.in1"],
-          ["mul_528_529_530.in1","ashr_lgyy_stencil_2_527_529.out"],
-          ["sub_530_532_533.in0","mul_528_529_530.out"],
-          ["sub_530_532_533.in1","mul_531_531_532.out"],
-          ["sub_533_537_538.out","self.out_cim_stencil"],
-          ["sub_533_537_538.in0","sub_530_532_533.out"]
+          ["ashr_lgxx_stencil_2_665_666.out","add_666_667_672.in0"],
+          ["ashr_lgyy_stencil_2_665_667.out","add_666_667_672.in1"],
+          ["mul_672_672_673.in0","add_666_667_672.out"],
+          ["mul_672_672_673.in1","add_666_667_672.out"],
+          ["mul_672_672_673.out","ashr_673_674_675.in0"],
+          ["const_p4__674.out","ashr_673_674_675.in1"],
+          ["sub_671_675_676.in1","ashr_673_674_675.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_665_666.in0"],
+          ["const_p6__665.out","ashr_lgxx_stencil_2_665_666.in1"],
+          ["mul_666_667_668.in0","ashr_lgxx_stencil_2_665_666.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_665_669.in0"],
+          ["const_p6__665$2.out","ashr_lgxy_stencil_2_665_669.in1"],
+          ["mul_669_669_670.in0","ashr_lgxy_stencil_2_665_669.out"],
+          ["mul_669_669_670.in1","ashr_lgxy_stencil_2_665_669.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_665_667.in0"],
+          ["const_p6__665$1.out","ashr_lgyy_stencil_2_665_667.in1"],
+          ["mul_666_667_668.in1","ashr_lgyy_stencil_2_665_667.out"],
+          ["sub_668_670_671.in0","mul_666_667_668.out"],
+          ["sub_668_670_671.in1","mul_669_669_670.out"],
+          ["sub_671_675_676.out","self.out_cim_stencil"],
+          ["sub_671_675_676.in0","sub_668_670_671.out"]
         ]
       },
       "hcompute_grad_x_stencil":{
@@ -228,31 +228,31 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n255__337":{
+          "const_n255__325":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__335":{
+          "const_p255__323":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "smax_336_337_338":{
+          "smax_324_325_326":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_2_335_336":{
+          "smin_grad_x_unclamp_stencil_2_323_324":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_336_337_338.in1","const_n255__337.out"],
-          ["smin_grad_x_unclamp_stencil_2_335_336.in1","const_p255__335.out"],
-          ["smin_grad_x_unclamp_stencil_2_335_336.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smax_336_337_338.out","self.out_grad_x_stencil"],
-          ["smin_grad_x_unclamp_stencil_2_335_336.out","smax_336_337_338.in0"]
+          ["smax_324_325_326.in1","const_n255__325.out"],
+          ["smin_grad_x_unclamp_stencil_2_323_324.in1","const_p255__323.out"],
+          ["smin_grad_x_unclamp_stencil_2_323_324.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smax_324_325_326.out","self.out_grad_x_stencil"],
+          ["smin_grad_x_unclamp_stencil_2_323_324.out","smax_324_325_326.in0"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil":{
@@ -260,14 +260,14 @@
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__265":{
+          "const_p0__262":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_x_unclamp_stencil","const_p0__265.out"]
+          ["self.out_grad_x_unclamp_stencil","const_p0__262.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil_1":{
@@ -278,27 +278,27 @@
           ["grad_x_unclamp_s1_r_y",["Array",16,"BitIn"]]
         ]],
         "instances":{
-          "add_2923_293":{
+          "add_2803_281":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_2924_297":{
+          "add_2804_285":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_2925_301":{
+          "add_2805_289":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_296_306_307":{
+          "add_284_294_295":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_300_305_306":{
+          "add_288_293_294":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_grad_x_unclamp_stencil_1_304_305":{
+          "add_grad_x_unclamp_stencil_1_292_293":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
@@ -322,31 +322,31 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0005"]}
           },
-          "mul_grad_x_unclamp_s1_r_y3_292":{
+          "mul_grad_x_unclamp_s1_r_y3_280":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_1_295_296":{
+          "mul_padded16_global_wrapper_stencil_1_283_284":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_2_299_300":{
+          "mul_padded16_global_wrapper_stencil_2_287_288":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_3_303_304":{
+          "mul_padded16_global_wrapper_stencil_3_291_292":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
           "rom_kernel_xa0":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[-1,null,1,-2,null,2,-1,null,1]]}
+            "modargs":{"init":["Json",[-1,0,1,-2,0,2,-1,0,1]]}
           },
           "rom_kernel_xa0$1":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[-1,null,1,-2,null,2,-1,null,1]]}
+            "modargs":{"init":["Json",[-1,0,1,-2,0,2,-1,0,1]]}
           },
           "rom_kernel_xa0$1_ren":{
             "modref":"corebit.const",
@@ -355,7 +355,7 @@
           "rom_kernel_xa0$2":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[-1,null,1,-2,null,2,-1,null,1]]}
+            "modargs":{"init":["Json",[-1,0,1,-2,0,2,-1,0,1]]}
           },
           "rom_kernel_xa0$2_ren":{
             "modref":"corebit.const",
@@ -367,30 +367,30 @@
           }
         },
         "connections":[
-          ["mul_grad_x_unclamp_s1_r_y3_292.out","add_2923_293.in0"],
-          ["const_p3_3$1.out","add_2923_293.in1"],
-          ["rom_kernel_xa0.raddr","add_2923_293.out"],
-          ["mul_grad_x_unclamp_s1_r_y3_292.out","add_2924_297.in0"],
-          ["const_p4_4.out","add_2924_297.in1"],
-          ["rom_kernel_xa0$1.raddr","add_2924_297.out"],
-          ["mul_grad_x_unclamp_s1_r_y3_292.out","add_2925_301.in0"],
-          ["const_p5_5.out","add_2925_301.in1"],
-          ["rom_kernel_xa0$2.raddr","add_2925_301.out"],
-          ["mul_padded16_global_wrapper_stencil_1_295_296.out","add_296_306_307.in0"],
-          ["add_300_305_306.out","add_296_306_307.in1"],
-          ["self.out_grad_x_unclamp_stencil","add_296_306_307.out"],
-          ["mul_padded16_global_wrapper_stencil_2_299_300.out","add_300_305_306.in0"],
-          ["add_grad_x_unclamp_stencil_1_304_305.out","add_300_305_306.in1"],
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_304_305.in0"],
-          ["mul_padded16_global_wrapper_stencil_3_303_304.out","add_grad_x_unclamp_stencil_1_304_305.in1"],
-          ["mul_grad_x_unclamp_s1_r_y3_292.in1","const_p3_3.out"],
-          ["self.grad_x_unclamp_s1_r_y","mul_grad_x_unclamp_s1_r_y3_292.in0"],
-          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_295_296.in0"],
-          ["rom_kernel_xa0.rdata","mul_padded16_global_wrapper_stencil_1_295_296.in1"],
-          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_2_299_300.in0"],
-          ["rom_kernel_xa0$1.rdata","mul_padded16_global_wrapper_stencil_2_299_300.in1"],
-          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_303_304.in0"],
-          ["rom_kernel_xa0$2.rdata","mul_padded16_global_wrapper_stencil_3_303_304.in1"],
+          ["mul_grad_x_unclamp_s1_r_y3_280.out","add_2803_281.in0"],
+          ["const_p3_3$1.out","add_2803_281.in1"],
+          ["rom_kernel_xa0.raddr","add_2803_281.out"],
+          ["mul_grad_x_unclamp_s1_r_y3_280.out","add_2804_285.in0"],
+          ["const_p4_4.out","add_2804_285.in1"],
+          ["rom_kernel_xa0$1.raddr","add_2804_285.out"],
+          ["mul_grad_x_unclamp_s1_r_y3_280.out","add_2805_289.in0"],
+          ["const_p5_5.out","add_2805_289.in1"],
+          ["rom_kernel_xa0$2.raddr","add_2805_289.out"],
+          ["mul_padded16_global_wrapper_stencil_1_283_284.out","add_284_294_295.in0"],
+          ["add_288_293_294.out","add_284_294_295.in1"],
+          ["self.out_grad_x_unclamp_stencil","add_284_294_295.out"],
+          ["mul_padded16_global_wrapper_stencil_2_287_288.out","add_288_293_294.in0"],
+          ["add_grad_x_unclamp_stencil_1_292_293.out","add_288_293_294.in1"],
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_292_293.in0"],
+          ["mul_padded16_global_wrapper_stencil_3_291_292.out","add_grad_x_unclamp_stencil_1_292_293.in1"],
+          ["mul_grad_x_unclamp_s1_r_y3_280.in1","const_p3_3.out"],
+          ["self.grad_x_unclamp_s1_r_y","mul_grad_x_unclamp_s1_r_y3_280.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_283_284.in0"],
+          ["rom_kernel_xa0.rdata","mul_padded16_global_wrapper_stencil_1_283_284.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_2_287_288.in0"],
+          ["rom_kernel_xa0$1.rdata","mul_padded16_global_wrapper_stencil_2_287_288.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_291_292.in0"],
+          ["rom_kernel_xa0$2.rdata","mul_padded16_global_wrapper_stencil_3_291_292.in1"],
           ["rom_kernel_xa0$1_ren.out","rom_kernel_xa0$1.ren"],
           ["rom_kernel_xa0$2_ren.out","rom_kernel_xa0$2.ren"],
           ["rom_kernel_xa0_ren.out","rom_kernel_xa0.ren"]
@@ -402,31 +402,31 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n255__449":{
+          "const_n255__479":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__447":{
+          "const_p255__477":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "smax_448_449_450":{
+          "smax_478_479_480":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_2_447_448":{
+          "smin_grad_y_unclamp_stencil_2_477_478":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_448_449_450.in1","const_n255__449.out"],
-          ["smin_grad_y_unclamp_stencil_2_447_448.in1","const_p255__447.out"],
-          ["smin_grad_y_unclamp_stencil_2_447_448.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smax_448_449_450.out","self.out_grad_y_stencil"],
-          ["smin_grad_y_unclamp_stencil_2_447_448.out","smax_448_449_450.in0"]
+          ["smax_478_479_480.in1","const_n255__479.out"],
+          ["smin_grad_y_unclamp_stencil_2_477_478.in1","const_p255__477.out"],
+          ["smin_grad_y_unclamp_stencil_2_477_478.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smax_478_479_480.out","self.out_grad_y_stencil"],
+          ["smin_grad_y_unclamp_stencil_2_477_478.out","smax_478_479_480.in0"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil":{
@@ -434,14 +434,14 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__377":{
+          "const_p0__416":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__377.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__416.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_1":{
@@ -452,27 +452,27 @@
           ["grad_y_unclamp_s1_r_y",["Array",16,"BitIn"]]
         ]],
         "instances":{
-          "add_4043_405":{
+          "add_4343_435":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_4044_409":{
+          "add_4344_439":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_4045_413":{
+          "add_4345_443":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_408_418_419":{
+          "add_438_448_449":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_412_417_418":{
+          "add_442_447_448":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_grad_y_unclamp_stencil_1_416_417":{
+          "add_grad_y_unclamp_stencil_1_446_447":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
@@ -496,31 +496,31 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0005"]}
           },
-          "mul_grad_y_unclamp_s1_r_y3_404":{
+          "mul_grad_y_unclamp_s1_r_y3_434":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_4_407_408":{
+          "mul_padded16_global_wrapper_stencil_4_437_438":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_5_411_412":{
+          "mul_padded16_global_wrapper_stencil_5_441_442":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_6_415_416":{
+          "mul_padded16_global_wrapper_stencil_6_445_446":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
           "rom_kernel_ya1":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[1,2,1,null,null,null,-1,-2,-1]]}
+            "modargs":{"init":["Json",[-1,-2,-1,0,0,0,1,2,1]]}
           },
           "rom_kernel_ya1$1":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[1,2,1,null,null,null,-1,-2,-1]]}
+            "modargs":{"init":["Json",[-1,-2,-1,0,0,0,1,2,1]]}
           },
           "rom_kernel_ya1$1_ren":{
             "modref":"corebit.const",
@@ -529,7 +529,7 @@
           "rom_kernel_ya1$2":{
             "genref":"memory.rom2",
             "genargs":{"depth":["Int",9], "width":["Int",16]},
-            "modargs":{"init":["Json",[1,2,1,null,null,null,-1,-2,-1]]}
+            "modargs":{"init":["Json",[-1,-2,-1,0,0,0,1,2,1]]}
           },
           "rom_kernel_ya1$2_ren":{
             "modref":"corebit.const",
@@ -541,30 +541,30 @@
           }
         },
         "connections":[
-          ["mul_grad_y_unclamp_s1_r_y3_404.out","add_4043_405.in0"],
-          ["const_p3_3$3.out","add_4043_405.in1"],
-          ["rom_kernel_ya1.raddr","add_4043_405.out"],
-          ["mul_grad_y_unclamp_s1_r_y3_404.out","add_4044_409.in0"],
-          ["const_p4_4$1.out","add_4044_409.in1"],
-          ["rom_kernel_ya1$1.raddr","add_4044_409.out"],
-          ["mul_grad_y_unclamp_s1_r_y3_404.out","add_4045_413.in0"],
-          ["const_p5_5$1.out","add_4045_413.in1"],
-          ["rom_kernel_ya1$2.raddr","add_4045_413.out"],
-          ["mul_padded16_global_wrapper_stencil_4_407_408.out","add_408_418_419.in0"],
-          ["add_412_417_418.out","add_408_418_419.in1"],
-          ["self.out_grad_y_unclamp_stencil","add_408_418_419.out"],
-          ["mul_padded16_global_wrapper_stencil_5_411_412.out","add_412_417_418.in0"],
-          ["add_grad_y_unclamp_stencil_1_416_417.out","add_412_417_418.in1"],
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_416_417.in0"],
-          ["mul_padded16_global_wrapper_stencil_6_415_416.out","add_grad_y_unclamp_stencil_1_416_417.in1"],
-          ["mul_grad_y_unclamp_s1_r_y3_404.in1","const_p3_3$2.out"],
-          ["self.grad_y_unclamp_s1_r_y","mul_grad_y_unclamp_s1_r_y3_404.in0"],
-          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_4_407_408.in0"],
-          ["rom_kernel_ya1.rdata","mul_padded16_global_wrapper_stencil_4_407_408.in1"],
-          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_5_411_412.in0"],
-          ["rom_kernel_ya1$1.rdata","mul_padded16_global_wrapper_stencil_5_411_412.in1"],
-          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_6_415_416.in0"],
-          ["rom_kernel_ya1$2.rdata","mul_padded16_global_wrapper_stencil_6_415_416.in1"],
+          ["mul_grad_y_unclamp_s1_r_y3_434.out","add_4343_435.in0"],
+          ["const_p3_3$3.out","add_4343_435.in1"],
+          ["rom_kernel_ya1.raddr","add_4343_435.out"],
+          ["mul_grad_y_unclamp_s1_r_y3_434.out","add_4344_439.in0"],
+          ["const_p4_4$1.out","add_4344_439.in1"],
+          ["rom_kernel_ya1$1.raddr","add_4344_439.out"],
+          ["mul_grad_y_unclamp_s1_r_y3_434.out","add_4345_443.in0"],
+          ["const_p5_5$1.out","add_4345_443.in1"],
+          ["rom_kernel_ya1$2.raddr","add_4345_443.out"],
+          ["mul_padded16_global_wrapper_stencil_4_437_438.out","add_438_448_449.in0"],
+          ["add_442_447_448.out","add_438_448_449.in1"],
+          ["self.out_grad_y_unclamp_stencil","add_438_448_449.out"],
+          ["mul_padded16_global_wrapper_stencil_5_441_442.out","add_442_447_448.in0"],
+          ["add_grad_y_unclamp_stencil_1_446_447.out","add_442_447_448.in1"],
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_446_447.in0"],
+          ["mul_padded16_global_wrapper_stencil_6_445_446.out","add_grad_y_unclamp_stencil_1_446_447.in1"],
+          ["mul_grad_y_unclamp_s1_r_y3_434.in1","const_p3_3$2.out"],
+          ["self.grad_y_unclamp_s1_r_y","mul_grad_y_unclamp_s1_r_y3_434.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_4_437_438.in0"],
+          ["rom_kernel_ya1.rdata","mul_padded16_global_wrapper_stencil_4_437_438.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_5_441_442.in0"],
+          ["rom_kernel_ya1$1.rdata","mul_padded16_global_wrapper_stencil_5_441_442.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_6_445_446.in0"],
+          ["rom_kernel_ya1$2.rdata","mul_padded16_global_wrapper_stencil_6_445_446.in1"],
           ["rom_kernel_ya1$1_ren.out","rom_kernel_ya1$1.ren"],
           ["rom_kernel_ya1$2_ren.out","rom_kernel_ya1$2.ren"],
           ["rom_kernel_ya1_ren.out","rom_kernel_ya1.ren"]
@@ -584,44 +584,164 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__355":{
+          "const_p0__343":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__355.out"]
+          ["self.out_lgxx_stencil","const_p0__343.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__350":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__350.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_2":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__356":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__356.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_3":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__363":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__363.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_4":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__369":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__369.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_5":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__374":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__374.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_6":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__380":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__380.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_7":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__387":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__387.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_8":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__393":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxx_stencil","const_p0__393.out"]
+        ]
+      },
+      "hcompute_lgxx_stencil_9":{
         "type":["Record",[
           ["out_lgxx_stencil",["Array",16,"Bit"]],
           ["in0_lgxx_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_lxx_stencil",["Array",3,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_lxx_stencil_3_360":{
+          "add_lgxx_stencil_1_lxx_stencil_3_402":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_1_361_362":{
+          "add_lxx_stencil_1_403_404":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_2_360_361":{
+          "add_lxx_stencil_2_402_403":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_lxx_stencil_3_360.in0"],
-          ["self.in1_lxx_stencil.2","add_lgxx_stencil_1_lxx_stencil_3_360.in1"],
-          ["add_lxx_stencil_2_360_361.in1","add_lgxx_stencil_1_lxx_stencil_3_360.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_361_362.in0"],
-          ["add_lxx_stencil_2_360_361.out","add_lxx_stencil_1_361_362.in1"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_1_361_362.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_360_361.in0"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_lxx_stencil_3_402.in0"],
+          ["self.in1_lxx_stencil.2","add_lgxx_stencil_1_lxx_stencil_3_402.in1"],
+          ["add_lxx_stencil_2_402_403.in1","add_lgxx_stencil_1_lxx_stencil_3_402.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_403_404.in0"],
+          ["add_lxx_stencil_2_402_403.out","add_lxx_stencil_1_403_404.in1"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_1_403_404.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_402_403.in0"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -629,44 +749,164 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__468":{
+          "const_p0__498":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__468.out"]
+          ["self.out_lgxy_stencil","const_p0__498.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__505":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__505.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_2":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__511":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__511.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_3":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__518":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__518.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_4":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__524":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__524.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_5":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__529":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__529.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_6":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__535":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__535.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_7":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__542":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__542.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_8":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__548":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgxy_stencil","const_p0__548.out"]
+        ]
+      },
+      "hcompute_lgxy_stencil_9":{
         "type":["Record",[
           ["out_lgxy_stencil",["Array",16,"Bit"]],
           ["in0_lgxy_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_lxy_stencil",["Array",3,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_lxy_stencil_3_473":{
+          "add_lgxy_stencil_1_lxy_stencil_3_557":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_1_474_475":{
+          "add_lxy_stencil_1_558_559":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_2_473_474":{
+          "add_lxy_stencil_2_557_558":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_lxy_stencil_3_473.in0"],
-          ["self.in1_lxy_stencil.2","add_lgxy_stencil_1_lxy_stencil_3_473.in1"],
-          ["add_lxy_stencil_2_473_474.in1","add_lgxy_stencil_1_lxy_stencil_3_473.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_474_475.in0"],
-          ["add_lxy_stencil_2_473_474.out","add_lxy_stencil_1_474_475.in1"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_1_474_475.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_473_474.in0"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_lxy_stencil_3_557.in0"],
+          ["self.in1_lxy_stencil.2","add_lgxy_stencil_1_lxy_stencil_3_557.in1"],
+          ["add_lxy_stencil_2_557_558.in1","add_lgxy_stencil_1_lxy_stencil_3_557.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_558_559.in0"],
+          ["add_lxy_stencil_2_557_558.out","add_lxy_stencil_1_558_559.in1"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_1_558_559.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_557_558.in0"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -674,44 +914,164 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__497":{
+          "const_p0__581":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__497.out"]
+          ["self.out_lgyy_stencil","const_p0__581.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__588":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__588.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_2":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__594":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__594.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_3":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__601":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__601.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_4":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__607":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__607.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_5":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__612":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__612.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_6":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__618":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__618.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_7":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__625":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__625.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_8":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]]
+        ]],
+        "instances":{
+          "const_p0__631":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0000"]}
+          }
+        },
+        "connections":[
+          ["self.out_lgyy_stencil","const_p0__631.out"]
+        ]
+      },
+      "hcompute_lgyy_stencil_9":{
         "type":["Record",[
           ["out_lgyy_stencil",["Array",16,"Bit"]],
           ["in0_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_lyy_stencil",["Array",3,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_lyy_stencil_3_502":{
+          "add_lgyy_stencil_1_lyy_stencil_3_640":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_1_503_504":{
+          "add_lyy_stencil_1_641_642":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_2_502_503":{
+          "add_lyy_stencil_2_640_641":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_lyy_stencil_3_502.in0"],
-          ["self.in1_lyy_stencil.2","add_lgyy_stencil_1_lyy_stencil_3_502.in1"],
-          ["add_lyy_stencil_2_502_503.in1","add_lgyy_stencil_1_lyy_stencil_3_502.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_503_504.in0"],
-          ["add_lyy_stencil_2_502_503.out","add_lyy_stencil_1_503_504.in1"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_1_503_504.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_502_503.in0"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_lyy_stencil_3_640.in0"],
+          ["self.in1_lyy_stencil.2","add_lgyy_stencil_1_lyy_stencil_3_640.in1"],
+          ["add_lyy_stencil_2_640_641.in1","add_lgyy_stencil_1_lyy_stencil_3_640.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_641_642.in0"],
+          ["add_lyy_stencil_2_640_641.out","add_lyy_stencil_1_641_642.in1"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_1_641_642.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_640_641.in0"]
         ]
       },
       "hcompute_lxx_stencil":{
@@ -720,26 +1080,26 @@
           ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_347_348_349":{
+          "ashr_335_336_337":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p7__348":{
+          "const_p7__336":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_x_stencil_1_grad_x_stencil_1_347":{
+          "mul_grad_x_stencil_1_grad_x_stencil_1_335":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_1_grad_x_stencil_1_347.out","ashr_347_348_349.in0"],
-          ["const_p7__348.out","ashr_347_348_349.in1"],
-          ["self.out_lxx_stencil","ashr_347_348_349.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_347.in0"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_347.in1"]
+          ["mul_grad_x_stencil_1_grad_x_stencil_1_335.out","ashr_335_336_337.in0"],
+          ["const_p7__336.out","ashr_335_336_337.in1"],
+          ["self.out_lxx_stencil","ashr_335_336_337.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_335.in0"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_335.in1"]
         ]
       },
       "hcompute_lxy_stencil":{
@@ -747,34 +1107,6 @@
           ["out_lxy_stencil",["Array",16,"Bit"]],
           ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]],
           ["in1_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
-        ]],
-        "instances":{
-          "ashr_459_460_461":{
-            "genref":"coreir.ashr",
-            "genargs":{"width":["Int",16]}
-          },
-          "const_p7__460":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0007"]}
-          },
-          "mul_grad_x_stencil_2_grad_y_stencil_1_459":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          }
-        },
-        "connections":[
-          ["mul_grad_x_stencil_2_grad_y_stencil_1_459.out","ashr_459_460_461.in0"],
-          ["const_p7__460.out","ashr_459_460_461.in1"],
-          ["self.out_lxy_stencil","ashr_459_460_461.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_459.in0"],
-          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_459.in1"]
-        ]
-      },
-      "hcompute_lyy_stencil":{
-        "type":["Record",[
-          ["out_lyy_stencil",["Array",16,"Bit"]],
-          ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
           "ashr_489_490_491":{
@@ -786,17 +1118,45 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_grad_y_stencil_2_grad_y_stencil_2_489":{
+          "mul_grad_x_stencil_2_grad_y_stencil_1_489":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_y_stencil_2_grad_y_stencil_2_489.out","ashr_489_490_491.in0"],
+          ["mul_grad_x_stencil_2_grad_y_stencil_1_489.out","ashr_489_490_491.in0"],
           ["const_p7__490.out","ashr_489_490_491.in1"],
-          ["self.out_lyy_stencil","ashr_489_490_491.out"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_489.in0"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_489.in1"]
+          ["self.out_lxy_stencil","ashr_489_490_491.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_489.in0"],
+          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_489.in1"]
+        ]
+      },
+      "hcompute_lyy_stencil":{
+        "type":["Record",[
+          ["out_lyy_stencil",["Array",16,"Bit"]],
+          ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
+        ]],
+        "instances":{
+          "ashr_573_574_575":{
+            "genref":"coreir.ashr",
+            "genargs":{"width":["Int",16]}
+          },
+          "const_p7__574":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0007"]}
+          },
+          "mul_grad_y_stencil_2_grad_y_stencil_2_573":{
+            "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["mul_grad_y_stencil_2_grad_y_stencil_2_573.out","ashr_573_574_575.in0"],
+          ["const_p7__574.out","ashr_573_574_575.in1"],
+          ["self.out_lyy_stencil","ashr_573_574_575.out"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_573.in0"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_573.in1"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{

--- a/coreir_compute/harris_sch6_2ppc_compute.json
+++ b/coreir_compute/harris_sch6_2ppc_compute.json
@@ -8,28 +8,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_771_772_773":{
+          "bitand_982_983_984":{
             "modref":"corebit.and"
           },
-          "bitand_773_774_775":{
+          "bitand_984_985_986":{
             "modref":"corebit.and"
           },
-          "bitand_775_776_777":{
+          "bitand_986_987_988":{
             "modref":"corebit.and"
           },
-          "bitand_777_778_779":{
+          "bitand_988_989_990":{
             "modref":"corebit.and"
           },
-          "bitand_779_780_781":{
+          "bitand_990_991_992":{
             "modref":"corebit.and"
           },
-          "bitand_781_782_783":{
+          "bitand_992_993_994":{
             "modref":"corebit.and"
           },
-          "bitand_783_784_785":{
+          "bitand_994_995_996":{
             "modref":"corebit.and"
           },
-          "bitand_785_787_788":{
+          "bitand_996_998_999":{
             "modref":"corebit.and"
           },
           "const_p0_0":{
@@ -37,7 +37,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__786":{
+          "const_p1__997":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -47,86 +47,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_7882550":{
+          "mux_9992550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_786_cim_stencil_2_787":{
+          "sle_997_cim_stencil_2_998":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_1_cim_stencil_2_771":{
+          "slt_cim_stencil_1_cim_stencil_2_982":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_3_cim_stencil_2_772":{
+          "slt_cim_stencil_3_cim_stencil_2_983":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_4_cim_stencil_2_774":{
+          "slt_cim_stencil_4_cim_stencil_2_985":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_5_cim_stencil_2_776":{
+          "slt_cim_stencil_5_cim_stencil_2_987":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_6_cim_stencil_2_778":{
+          "slt_cim_stencil_6_cim_stencil_2_989":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_7_cim_stencil_2_780":{
+          "slt_cim_stencil_7_cim_stencil_2_991":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_8_cim_stencil_2_782":{
+          "slt_cim_stencil_8_cim_stencil_2_993":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_9_cim_stencil_2_784":{
+          "slt_cim_stencil_9_cim_stencil_2_995":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_1_cim_stencil_2_771.out","bitand_771_772_773.in0"],
-          ["slt_cim_stencil_3_cim_stencil_2_772.out","bitand_771_772_773.in1"],
-          ["bitand_773_774_775.in0","bitand_771_772_773.out"],
-          ["slt_cim_stencil_4_cim_stencil_2_774.out","bitand_773_774_775.in1"],
-          ["bitand_775_776_777.in0","bitand_773_774_775.out"],
-          ["slt_cim_stencil_5_cim_stencil_2_776.out","bitand_775_776_777.in1"],
-          ["bitand_777_778_779.in0","bitand_775_776_777.out"],
-          ["slt_cim_stencil_6_cim_stencil_2_778.out","bitand_777_778_779.in1"],
-          ["bitand_779_780_781.in0","bitand_777_778_779.out"],
-          ["slt_cim_stencil_7_cim_stencil_2_780.out","bitand_779_780_781.in1"],
-          ["bitand_781_782_783.in0","bitand_779_780_781.out"],
-          ["slt_cim_stencil_8_cim_stencil_2_782.out","bitand_781_782_783.in1"],
-          ["bitand_783_784_785.in0","bitand_781_782_783.out"],
-          ["slt_cim_stencil_9_cim_stencil_2_784.out","bitand_783_784_785.in1"],
-          ["bitand_785_787_788.in0","bitand_783_784_785.out"],
-          ["sle_786_cim_stencil_2_787.out","bitand_785_787_788.in1"],
-          ["mux_7882550.sel","bitand_785_787_788.out"],
-          ["mux_7882550.in0","const_p0_0.out"],
-          ["sle_786_cim_stencil_2_787.in0","const_p1__786.out"],
-          ["mux_7882550.in1","const_p255_255.out"],
-          ["self.out_cim_output_stencil","mux_7882550.out"],
-          ["slt_cim_stencil_1_cim_stencil_2_771.in0","self.in0_cim_stencil.0"],
-          ["sle_786_cim_stencil_2_787.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_1_cim_stencil_2_771.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_772.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_4_cim_stencil_2_774.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_5_cim_stencil_2_776.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_6_cim_stencil_2_778.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_7_cim_stencil_2_780.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_8_cim_stencil_2_782.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_9_cim_stencil_2_784.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_772.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_4_cim_stencil_2_774.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_5_cim_stencil_2_776.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_6_cim_stencil_2_778.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_7_cim_stencil_2_780.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_8_cim_stencil_2_782.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_9_cim_stencil_2_784.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_1_cim_stencil_2_982.out","bitand_982_983_984.in0"],
+          ["slt_cim_stencil_3_cim_stencil_2_983.out","bitand_982_983_984.in1"],
+          ["bitand_984_985_986.in0","bitand_982_983_984.out"],
+          ["slt_cim_stencil_4_cim_stencil_2_985.out","bitand_984_985_986.in1"],
+          ["bitand_986_987_988.in0","bitand_984_985_986.out"],
+          ["slt_cim_stencil_5_cim_stencil_2_987.out","bitand_986_987_988.in1"],
+          ["bitand_988_989_990.in0","bitand_986_987_988.out"],
+          ["slt_cim_stencil_6_cim_stencil_2_989.out","bitand_988_989_990.in1"],
+          ["bitand_990_991_992.in0","bitand_988_989_990.out"],
+          ["slt_cim_stencil_7_cim_stencil_2_991.out","bitand_990_991_992.in1"],
+          ["bitand_992_993_994.in0","bitand_990_991_992.out"],
+          ["slt_cim_stencil_8_cim_stencil_2_993.out","bitand_992_993_994.in1"],
+          ["bitand_994_995_996.in0","bitand_992_993_994.out"],
+          ["slt_cim_stencil_9_cim_stencil_2_995.out","bitand_994_995_996.in1"],
+          ["bitand_996_998_999.in0","bitand_994_995_996.out"],
+          ["sle_997_cim_stencil_2_998.out","bitand_996_998_999.in1"],
+          ["mux_9992550.sel","bitand_996_998_999.out"],
+          ["mux_9992550.in0","const_p0_0.out"],
+          ["sle_997_cim_stencil_2_998.in0","const_p1__997.out"],
+          ["mux_9992550.in1","const_p255_255.out"],
+          ["self.out_cim_output_stencil","mux_9992550.out"],
+          ["slt_cim_stencil_1_cim_stencil_2_982.in0","self.in0_cim_stencil.0"],
+          ["sle_997_cim_stencil_2_998.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_1_cim_stencil_2_982.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_983.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_4_cim_stencil_2_985.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_5_cim_stencil_2_987.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_6_cim_stencil_2_989.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_7_cim_stencil_2_991.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_8_cim_stencil_2_993.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_9_cim_stencil_2_995.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_983.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_4_cim_stencil_2_985.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_5_cim_stencil_2_987.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_6_cim_stencil_2_989.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_7_cim_stencil_2_991.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_8_cim_stencil_2_993.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_9_cim_stencil_2_995.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_output_stencil_1":{
@@ -135,28 +135,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_845_846_847":{
+          "bitand_1056_1057_1058":{
             "modref":"corebit.and"
           },
-          "bitand_847_848_849":{
+          "bitand_1058_1059_1060":{
             "modref":"corebit.and"
           },
-          "bitand_849_850_851":{
+          "bitand_1060_1061_1062":{
             "modref":"corebit.and"
           },
-          "bitand_851_852_853":{
+          "bitand_1062_1063_1064":{
             "modref":"corebit.and"
           },
-          "bitand_853_854_855":{
+          "bitand_1064_1065_1066":{
             "modref":"corebit.and"
           },
-          "bitand_855_856_857":{
+          "bitand_1066_1067_1068":{
             "modref":"corebit.and"
           },
-          "bitand_857_858_859":{
+          "bitand_1068_1069_1070":{
             "modref":"corebit.and"
           },
-          "bitand_859_861_862":{
+          "bitand_1070_1072_1073":{
             "modref":"corebit.and"
           },
           "const_p0_0$1":{
@@ -164,7 +164,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__860":{
+          "const_p1__1071":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -174,86 +174,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_8622550":{
+          "mux_10732550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_860_cim_stencil_11_861":{
+          "sle_1071_cim_stencil_11_1072":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_10_cim_stencil_11_845":{
+          "slt_cim_stencil_10_cim_stencil_11_1056":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_12_cim_stencil_11_846":{
+          "slt_cim_stencil_12_cim_stencil_11_1057":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_13_cim_stencil_11_848":{
+          "slt_cim_stencil_13_cim_stencil_11_1059":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_14_cim_stencil_11_850":{
+          "slt_cim_stencil_14_cim_stencil_11_1061":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_15_cim_stencil_11_852":{
+          "slt_cim_stencil_15_cim_stencil_11_1063":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_16_cim_stencil_11_854":{
+          "slt_cim_stencil_16_cim_stencil_11_1065":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_17_cim_stencil_11_856":{
+          "slt_cim_stencil_17_cim_stencil_11_1067":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_18_cim_stencil_11_858":{
+          "slt_cim_stencil_18_cim_stencil_11_1069":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_10_cim_stencil_11_845.out","bitand_845_846_847.in0"],
-          ["slt_cim_stencil_12_cim_stencil_11_846.out","bitand_845_846_847.in1"],
-          ["bitand_847_848_849.in0","bitand_845_846_847.out"],
-          ["slt_cim_stencil_13_cim_stencil_11_848.out","bitand_847_848_849.in1"],
-          ["bitand_849_850_851.in0","bitand_847_848_849.out"],
-          ["slt_cim_stencil_14_cim_stencil_11_850.out","bitand_849_850_851.in1"],
-          ["bitand_851_852_853.in0","bitand_849_850_851.out"],
-          ["slt_cim_stencil_15_cim_stencil_11_852.out","bitand_851_852_853.in1"],
-          ["bitand_853_854_855.in0","bitand_851_852_853.out"],
-          ["slt_cim_stencil_16_cim_stencil_11_854.out","bitand_853_854_855.in1"],
-          ["bitand_855_856_857.in0","bitand_853_854_855.out"],
-          ["slt_cim_stencil_17_cim_stencil_11_856.out","bitand_855_856_857.in1"],
-          ["bitand_857_858_859.in0","bitand_855_856_857.out"],
-          ["slt_cim_stencil_18_cim_stencil_11_858.out","bitand_857_858_859.in1"],
-          ["bitand_859_861_862.in0","bitand_857_858_859.out"],
-          ["sle_860_cim_stencil_11_861.out","bitand_859_861_862.in1"],
-          ["mux_8622550.sel","bitand_859_861_862.out"],
-          ["mux_8622550.in0","const_p0_0$1.out"],
-          ["sle_860_cim_stencil_11_861.in0","const_p1__860.out"],
-          ["mux_8622550.in1","const_p255_255$1.out"],
-          ["self.out_cim_output_stencil","mux_8622550.out"],
-          ["slt_cim_stencil_10_cim_stencil_11_845.in0","self.in0_cim_stencil.0"],
-          ["sle_860_cim_stencil_11_861.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_10_cim_stencil_11_845.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_12_cim_stencil_11_846.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_13_cim_stencil_11_848.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_14_cim_stencil_11_850.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_15_cim_stencil_11_852.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_16_cim_stencil_11_854.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_17_cim_stencil_11_856.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_18_cim_stencil_11_858.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_12_cim_stencil_11_846.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_13_cim_stencil_11_848.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_14_cim_stencil_11_850.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_15_cim_stencil_11_852.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_16_cim_stencil_11_854.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_17_cim_stencil_11_856.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_18_cim_stencil_11_858.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_10_cim_stencil_11_1056.out","bitand_1056_1057_1058.in0"],
+          ["slt_cim_stencil_12_cim_stencil_11_1057.out","bitand_1056_1057_1058.in1"],
+          ["bitand_1058_1059_1060.in0","bitand_1056_1057_1058.out"],
+          ["slt_cim_stencil_13_cim_stencil_11_1059.out","bitand_1058_1059_1060.in1"],
+          ["bitand_1060_1061_1062.in0","bitand_1058_1059_1060.out"],
+          ["slt_cim_stencil_14_cim_stencil_11_1061.out","bitand_1060_1061_1062.in1"],
+          ["bitand_1062_1063_1064.in0","bitand_1060_1061_1062.out"],
+          ["slt_cim_stencil_15_cim_stencil_11_1063.out","bitand_1062_1063_1064.in1"],
+          ["bitand_1064_1065_1066.in0","bitand_1062_1063_1064.out"],
+          ["slt_cim_stencil_16_cim_stencil_11_1065.out","bitand_1064_1065_1066.in1"],
+          ["bitand_1066_1067_1068.in0","bitand_1064_1065_1066.out"],
+          ["slt_cim_stencil_17_cim_stencil_11_1067.out","bitand_1066_1067_1068.in1"],
+          ["bitand_1068_1069_1070.in0","bitand_1066_1067_1068.out"],
+          ["slt_cim_stencil_18_cim_stencil_11_1069.out","bitand_1068_1069_1070.in1"],
+          ["bitand_1070_1072_1073.in0","bitand_1068_1069_1070.out"],
+          ["sle_1071_cim_stencil_11_1072.out","bitand_1070_1072_1073.in1"],
+          ["mux_10732550.sel","bitand_1070_1072_1073.out"],
+          ["mux_10732550.in0","const_p0_0$1.out"],
+          ["sle_1071_cim_stencil_11_1072.in0","const_p1__1071.out"],
+          ["mux_10732550.in1","const_p255_255$1.out"],
+          ["self.out_cim_output_stencil","mux_10732550.out"],
+          ["slt_cim_stencil_10_cim_stencil_11_1056.in0","self.in0_cim_stencil.0"],
+          ["sle_1071_cim_stencil_11_1072.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_10_cim_stencil_11_1056.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_12_cim_stencil_11_1057.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_13_cim_stencil_11_1059.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_14_cim_stencil_11_1061.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_15_cim_stencil_11_1063.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_16_cim_stencil_11_1065.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_17_cim_stencil_11_1067.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_18_cim_stencil_11_1069.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_12_cim_stencil_11_1057.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_13_cim_stencil_11_1059.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_14_cim_stencil_11_1061.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_15_cim_stencil_11_1063.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_16_cim_stencil_11_1065.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_17_cim_stencil_11_1067.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_18_cim_stencil_11_1069.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_stencil":{
@@ -264,89 +264,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_683_684_689":{
+          "add_894_895_900":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_690_691_692":{
+          "ashr_901_902_903":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_2_682_683":{
+          "ashr_lgxx_stencil_3_893_894":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_2_682_686":{
+          "ashr_lgxy_stencil_3_893_897":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_2_682_684":{
+          "ashr_lgyy_stencil_3_893_895":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__691":{
+          "const_p4__902":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__682":{
+          "const_p6__893":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__682$1":{
+          "const_p6__893$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__682$2":{
+          "const_p6__893$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_683_684_685":{
+          "mul_894_895_896":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_686_686_687":{
+          "mul_897_897_898":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_689_689_690":{
+          "mul_900_900_901":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_685_687_688":{
+          "sub_896_898_899":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_688_692_693":{
+          "sub_899_903_904":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_2_682_683.out","add_683_684_689.in0"],
-          ["ashr_lgyy_stencil_2_682_684.out","add_683_684_689.in1"],
-          ["mul_689_689_690.in0","add_683_684_689.out"],
-          ["mul_689_689_690.in1","add_683_684_689.out"],
-          ["mul_689_689_690.out","ashr_690_691_692.in0"],
-          ["const_p4__691.out","ashr_690_691_692.in1"],
-          ["sub_688_692_693.in1","ashr_690_691_692.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_682_683.in0"],
-          ["const_p6__682.out","ashr_lgxx_stencil_2_682_683.in1"],
-          ["mul_683_684_685.in0","ashr_lgxx_stencil_2_682_683.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_682_686.in0"],
-          ["const_p6__682$2.out","ashr_lgxy_stencil_2_682_686.in1"],
-          ["mul_686_686_687.in0","ashr_lgxy_stencil_2_682_686.out"],
-          ["mul_686_686_687.in1","ashr_lgxy_stencil_2_682_686.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_682_684.in0"],
-          ["const_p6__682$1.out","ashr_lgyy_stencil_2_682_684.in1"],
-          ["mul_683_684_685.in1","ashr_lgyy_stencil_2_682_684.out"],
-          ["sub_685_687_688.in0","mul_683_684_685.out"],
-          ["sub_685_687_688.in1","mul_686_686_687.out"],
-          ["sub_688_692_693.out","self.out_cim_stencil"],
-          ["sub_688_692_693.in0","sub_685_687_688.out"]
+          ["ashr_lgxx_stencil_3_893_894.out","add_894_895_900.in0"],
+          ["ashr_lgyy_stencil_3_893_895.out","add_894_895_900.in1"],
+          ["mul_900_900_901.in0","add_894_895_900.out"],
+          ["mul_900_900_901.in1","add_894_895_900.out"],
+          ["mul_900_900_901.out","ashr_901_902_903.in0"],
+          ["const_p4__902.out","ashr_901_902_903.in1"],
+          ["sub_899_903_904.in1","ashr_901_902_903.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_3_893_894.in0"],
+          ["const_p6__893.out","ashr_lgxx_stencil_3_893_894.in1"],
+          ["mul_894_895_896.in0","ashr_lgxx_stencil_3_893_894.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_3_893_897.in0"],
+          ["const_p6__893$2.out","ashr_lgxy_stencil_3_893_897.in1"],
+          ["mul_897_897_898.in0","ashr_lgxy_stencil_3_893_897.out"],
+          ["mul_897_897_898.in1","ashr_lgxy_stencil_3_893_897.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_3_893_895.in0"],
+          ["const_p6__893$1.out","ashr_lgyy_stencil_3_893_895.in1"],
+          ["mul_894_895_896.in1","ashr_lgyy_stencil_3_893_895.out"],
+          ["sub_896_898_899.in0","mul_894_895_896.out"],
+          ["sub_896_898_899.in1","mul_897_897_898.out"],
+          ["sub_899_903_904.out","self.out_cim_stencil"],
+          ["sub_899_903_904.in0","sub_896_898_899.out"]
         ]
       },
       "hcompute_cim_stencil_1":{
@@ -357,89 +357,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_724_725_730":{
+          "add_935_936_941":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_731_732_733":{
+          "ashr_942_943_944":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_3_723_724":{
+          "ashr_lgxx_stencil_4_934_935":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_3_723_727":{
+          "ashr_lgxy_stencil_4_934_938":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_3_723_725":{
+          "ashr_lgyy_stencil_4_934_936":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__732":{
+          "const_p4__943":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__723":{
+          "const_p6__934":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__723$1":{
+          "const_p6__934$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__723$2":{
+          "const_p6__934$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_724_725_726":{
+          "mul_935_936_937":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_727_727_728":{
+          "mul_938_938_939":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_730_730_731":{
+          "mul_941_941_942":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_726_728_729":{
+          "sub_937_939_940":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_729_733_734":{
+          "sub_940_944_945":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_3_723_724.out","add_724_725_730.in0"],
-          ["ashr_lgyy_stencil_3_723_725.out","add_724_725_730.in1"],
-          ["mul_730_730_731.in0","add_724_725_730.out"],
-          ["mul_730_730_731.in1","add_724_725_730.out"],
-          ["mul_730_730_731.out","ashr_731_732_733.in0"],
-          ["const_p4__732.out","ashr_731_732_733.in1"],
-          ["sub_729_733_734.in1","ashr_731_732_733.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_3_723_724.in0"],
-          ["const_p6__723.out","ashr_lgxx_stencil_3_723_724.in1"],
-          ["mul_724_725_726.in0","ashr_lgxx_stencil_3_723_724.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_3_723_727.in0"],
-          ["const_p6__723$2.out","ashr_lgxy_stencil_3_723_727.in1"],
-          ["mul_727_727_728.in0","ashr_lgxy_stencil_3_723_727.out"],
-          ["mul_727_727_728.in1","ashr_lgxy_stencil_3_723_727.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_3_723_725.in0"],
-          ["const_p6__723$1.out","ashr_lgyy_stencil_3_723_725.in1"],
-          ["mul_724_725_726.in1","ashr_lgyy_stencil_3_723_725.out"],
-          ["sub_726_728_729.in0","mul_724_725_726.out"],
-          ["sub_726_728_729.in1","mul_727_727_728.out"],
-          ["sub_729_733_734.out","self.out_cim_stencil"],
-          ["sub_729_733_734.in0","sub_726_728_729.out"]
+          ["ashr_lgxx_stencil_4_934_935.out","add_935_936_941.in0"],
+          ["ashr_lgyy_stencil_4_934_936.out","add_935_936_941.in1"],
+          ["mul_941_941_942.in0","add_935_936_941.out"],
+          ["mul_941_941_942.in1","add_935_936_941.out"],
+          ["mul_941_941_942.out","ashr_942_943_944.in0"],
+          ["const_p4__943.out","ashr_942_943_944.in1"],
+          ["sub_940_944_945.in1","ashr_942_943_944.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_4_934_935.in0"],
+          ["const_p6__934.out","ashr_lgxx_stencil_4_934_935.in1"],
+          ["mul_935_936_937.in0","ashr_lgxx_stencil_4_934_935.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_4_934_938.in0"],
+          ["const_p6__934$2.out","ashr_lgxy_stencil_4_934_938.in1"],
+          ["mul_938_938_939.in0","ashr_lgxy_stencil_4_934_938.out"],
+          ["mul_938_938_939.in1","ashr_lgxy_stencil_4_934_938.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_4_934_936.in0"],
+          ["const_p6__934$1.out","ashr_lgyy_stencil_4_934_936.in1"],
+          ["mul_935_936_937.in1","ashr_lgyy_stencil_4_934_936.out"],
+          ["sub_937_939_940.in0","mul_935_936_937.out"],
+          ["sub_937_939_940.in1","mul_938_938_939.out"],
+          ["sub_940_944_945.out","self.out_cim_stencil"],
+          ["sub_940_944_945.in0","sub_937_939_940.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil":{
@@ -542,19 +542,89 @@
           ["sub_292_padded16_global_wrapper_stencil_6_293.in0","sub_290_291_292.out"]
         ]
       },
+      "hcompute_grad_x_unclamp_stencil_3":{
+        "type":["Record",[
+          ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]],
+          ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
+        ]],
+        "instances":{
+          "add_grad_x_unclamp_stencil_2_328_329":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_padded16_global_wrapper_stencil_7_327_328":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_padded16_global_wrapper_stencil_8_326_327":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "const_p2__325":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
+          },
+          "const_p2__325$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
+          },
+          "mul_padded16_global_wrapper_stencil_11_325_331":{
+            "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "mul_padded16_global_wrapper_stencil_9_325_326":{
+            "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_329_padded16_global_wrapper_stencil_10_330":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_330_331_332":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_332_padded16_global_wrapper_stencil_12_333":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_2_328_329.in0"],
+          ["add_padded16_global_wrapper_stencil_7_327_328.out","add_grad_x_unclamp_stencil_2_328_329.in1"],
+          ["sub_329_padded16_global_wrapper_stencil_10_330.in0","add_grad_x_unclamp_stencil_2_328_329.out"],
+          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_327_328.in0"],
+          ["add_padded16_global_wrapper_stencil_8_326_327.out","add_padded16_global_wrapper_stencil_7_327_328.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_326_327.in0"],
+          ["mul_padded16_global_wrapper_stencil_9_325_326.out","add_padded16_global_wrapper_stencil_8_326_327.in1"],
+          ["mul_padded16_global_wrapper_stencil_11_325_331.in1","const_p2__325$1.out"],
+          ["mul_padded16_global_wrapper_stencil_9_325_326.in1","const_p2__325.out"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_325_331.in0"],
+          ["sub_330_331_332.in1","mul_padded16_global_wrapper_stencil_11_325_331.out"],
+          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_325_326.in0"],
+          ["sub_329_padded16_global_wrapper_stencil_10_330.in1","self.in1_padded16_global_wrapper_stencil.0"],
+          ["sub_332_padded16_global_wrapper_stencil_12_333.in1","self.in1_padded16_global_wrapper_stencil.2"],
+          ["sub_332_padded16_global_wrapper_stencil_12_333.out","self.out_grad_x_unclamp_stencil"],
+          ["sub_330_331_332.in0","sub_329_padded16_global_wrapper_stencil_10_330.out"],
+          ["sub_332_padded16_global_wrapper_stencil_12_333.in0","sub_330_331_332.out"]
+        ]
+      },
       "hcompute_grad_y_unclamp_stencil":{
         "type":["Record",[
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__413":{
+          "const_p0__497":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__413.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__497.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_1":{
@@ -562,14 +632,14 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__418":{
+          "const_p0__502":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__418.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__502.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_2":{
@@ -579,67 +649,137 @@
           ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_grad_y_unclamp_stencil_1_433_434":{
+          "add_grad_y_unclamp_stencil_1_518_519":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_padded16_global_wrapper_stencil_7_434_435":{
+          "add_padded16_global_wrapper_stencil_13_517_518":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_padded16_global_wrapper_stencil_8_432_433":{
+          "add_padded16_global_wrapper_stencil_14_516_517":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "const_p2__431":{
+          "const_p2__515":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "const_p2__431$1":{
+          "const_p2__515$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "mul_padded16_global_wrapper_stencil_11_431_437":{
+          "mul_padded16_global_wrapper_stencil_15_515_516":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_9_431_432":{
+          "mul_padded16_global_wrapper_stencil_17_515_521":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_435_padded16_global_wrapper_stencil_10_436":{
+          "sub_519_padded16_global_wrapper_stencil_16_520":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_436_437_438":{
+          "sub_520_521_522":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_438_padded16_global_wrapper_stencil_12_439":{
+          "sub_522_padded16_global_wrapper_stencil_18_523":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_433_434.in0"],
-          ["add_padded16_global_wrapper_stencil_8_432_433.out","add_grad_y_unclamp_stencil_1_433_434.in1"],
-          ["add_padded16_global_wrapper_stencil_7_434_435.in1","add_grad_y_unclamp_stencil_1_433_434.out"],
-          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_434_435.in0"],
-          ["sub_435_padded16_global_wrapper_stencil_10_436.in0","add_padded16_global_wrapper_stencil_7_434_435.out"],
-          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_432_433.in0"],
-          ["mul_padded16_global_wrapper_stencil_9_431_432.out","add_padded16_global_wrapper_stencil_8_432_433.in1"],
-          ["mul_padded16_global_wrapper_stencil_11_431_437.in1","const_p2__431$1.out"],
-          ["mul_padded16_global_wrapper_stencil_9_431_432.in1","const_p2__431.out"],
-          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_431_437.in0"],
-          ["sub_436_437_438.in1","mul_padded16_global_wrapper_stencil_11_431_437.out"],
-          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_431_432.in0"],
-          ["sub_435_padded16_global_wrapper_stencil_10_436.in1","self.in1_padded16_global_wrapper_stencil.0"],
-          ["sub_438_padded16_global_wrapper_stencil_12_439.in1","self.in1_padded16_global_wrapper_stencil.2"],
-          ["sub_438_padded16_global_wrapper_stencil_12_439.out","self.out_grad_y_unclamp_stencil"],
-          ["sub_436_437_438.in0","sub_435_padded16_global_wrapper_stencil_10_436.out"],
-          ["sub_438_padded16_global_wrapper_stencil_12_439.in0","sub_436_437_438.out"]
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_518_519.in0"],
+          ["add_padded16_global_wrapper_stencil_13_517_518.out","add_grad_y_unclamp_stencil_1_518_519.in1"],
+          ["sub_519_padded16_global_wrapper_stencil_16_520.in0","add_grad_y_unclamp_stencil_1_518_519.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_13_517_518.in0"],
+          ["add_padded16_global_wrapper_stencil_14_516_517.out","add_padded16_global_wrapper_stencil_13_517_518.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_14_516_517.in0"],
+          ["mul_padded16_global_wrapper_stencil_15_515_516.out","add_padded16_global_wrapper_stencil_14_516_517.in1"],
+          ["mul_padded16_global_wrapper_stencil_17_515_521.in1","const_p2__515$1.out"],
+          ["mul_padded16_global_wrapper_stencil_15_515_516.in1","const_p2__515.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_15_515_516.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_17_515_521.in0"],
+          ["sub_520_521_522.in1","mul_padded16_global_wrapper_stencil_17_515_521.out"],
+          ["sub_519_padded16_global_wrapper_stencil_16_520.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_522_padded16_global_wrapper_stencil_18_523.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_522_padded16_global_wrapper_stencil_18_523.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_520_521_522.in0","sub_519_padded16_global_wrapper_stencil_16_520.out"],
+          ["sub_522_padded16_global_wrapper_stencil_18_523.in0","sub_520_521_522.out"]
+        ]
+      },
+      "hcompute_grad_y_unclamp_stencil_3":{
+        "type":["Record",[
+          ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]],
+          ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
+        ]],
+        "instances":{
+          "add_grad_y_unclamp_stencil_2_558_559":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_padded16_global_wrapper_stencil_19_557_558":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_padded16_global_wrapper_stencil_20_556_557":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "const_p2__555":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
+          },
+          "const_p2__555$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
+          },
+          "mul_padded16_global_wrapper_stencil_21_555_556":{
+            "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "mul_padded16_global_wrapper_stencil_23_555_561":{
+            "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_559_padded16_global_wrapper_stencil_22_560":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_560_561_562":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_562_padded16_global_wrapper_stencil_24_563":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_2_558_559.in0"],
+          ["add_padded16_global_wrapper_stencil_19_557_558.out","add_grad_y_unclamp_stencil_2_558_559.in1"],
+          ["sub_559_padded16_global_wrapper_stencil_22_560.in0","add_grad_y_unclamp_stencil_2_558_559.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_19_557_558.in0"],
+          ["add_padded16_global_wrapper_stencil_20_556_557.out","add_padded16_global_wrapper_stencil_19_557_558.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_20_556_557.in0"],
+          ["mul_padded16_global_wrapper_stencil_21_555_556.out","add_padded16_global_wrapper_stencil_20_556_557.in1"],
+          ["mul_padded16_global_wrapper_stencil_23_555_561.in1","const_p2__555$1.out"],
+          ["mul_padded16_global_wrapper_stencil_21_555_556.in1","const_p2__555.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_21_555_556.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_23_555_561.in0"],
+          ["sub_560_561_562.in1","mul_padded16_global_wrapper_stencil_23_555_561.out"],
+          ["sub_559_padded16_global_wrapper_stencil_22_560.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_562_padded16_global_wrapper_stencil_24_563.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_562_padded16_global_wrapper_stencil_24_563.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_560_561_562.in0","sub_559_padded16_global_wrapper_stencil_22_560.out"],
+          ["sub_562_padded16_global_wrapper_stencil_24_563.in0","sub_560_561_562.out"]
         ]
       },
       "hcompute_hw_output_stencil":{
@@ -665,14 +805,14 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__363":{
+          "const_p0__404":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__363.out"]
+          ["self.out_lgxx_stencil","const_p0__404.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
@@ -680,14 +820,14 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__368":{
+          "const_p0__409":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__368.out"]
+          ["self.out_lgxx_stencil","const_p0__409.out"]
         ]
       },
       "hcompute_lgxx_stencil_2":{
@@ -697,63 +837,129 @@
           ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_386_387":{
+          "add_lgxx_stencil_1_427_428":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_1_387_388":{
+          "add_lxx_stencil_1_428_429":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_2_385_386":{
+          "add_lxx_stencil_2_426_427":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_3_384_385":{
+          "add_lxx_stencil_3_425_426":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_4_383_384":{
+          "add_lxx_stencil_4_424_425":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_5_382_383":{
+          "add_lxx_stencil_5_423_424":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_6_381_382":{
+          "add_lxx_stencil_6_422_423":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_7_380_381":{
+          "add_lxx_stencil_7_421_422":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_8_lxx_stencil_9_380":{
+          "add_lxx_stencil_8_lxx_stencil_9_421":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_386_387.in0"],
-          ["add_lxx_stencil_2_385_386.out","add_lgxx_stencil_1_386_387.in1"],
-          ["add_lxx_stencil_1_387_388.in1","add_lgxx_stencil_1_386_387.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_387_388.in0"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_1_387_388.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_385_386.in0"],
-          ["add_lxx_stencil_3_384_385.out","add_lxx_stencil_2_385_386.in1"],
-          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_384_385.in0"],
-          ["add_lxx_stencil_4_383_384.out","add_lxx_stencil_3_384_385.in1"],
-          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_383_384.in0"],
-          ["add_lxx_stencil_5_382_383.out","add_lxx_stencil_4_383_384.in1"],
-          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_382_383.in0"],
-          ["add_lxx_stencil_6_381_382.out","add_lxx_stencil_5_382_383.in1"],
-          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_381_382.in0"],
-          ["add_lxx_stencil_7_380_381.out","add_lxx_stencil_6_381_382.in1"],
-          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_380_381.in0"],
-          ["add_lxx_stencil_8_lxx_stencil_9_380.out","add_lxx_stencil_7_380_381.in1"],
-          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_380.in0"],
-          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_380.in1"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_427_428.in0"],
+          ["add_lxx_stencil_2_426_427.out","add_lgxx_stencil_1_427_428.in1"],
+          ["add_lxx_stencil_1_428_429.in1","add_lgxx_stencil_1_427_428.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_428_429.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_1_428_429.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_426_427.in0"],
+          ["add_lxx_stencil_3_425_426.out","add_lxx_stencil_2_426_427.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_425_426.in0"],
+          ["add_lxx_stencil_4_424_425.out","add_lxx_stencil_3_425_426.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_424_425.in0"],
+          ["add_lxx_stencil_5_423_424.out","add_lxx_stencil_4_424_425.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_423_424.in0"],
+          ["add_lxx_stencil_6_422_423.out","add_lxx_stencil_5_423_424.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_422_423.in0"],
+          ["add_lxx_stencil_7_421_422.out","add_lxx_stencil_6_422_423.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_421_422.in0"],
+          ["add_lxx_stencil_8_lxx_stencil_9_421.out","add_lxx_stencil_7_421_422.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_421.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_421.in1"]
+        ]
+      },
+      "hcompute_lgxx_stencil_3":{
+        "type":["Record",[
+          ["out_lgxx_stencil",["Array",16,"Bit"]],
+          ["in0_lgxx_stencil",["Array",1,["Array",16,"BitIn"]]],
+          ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
+        ]],
+        "instances":{
+          "add_lgxx_stencil_2_469_470":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_10_470_471":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_11_468_469":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_12_467_468":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_13_466_467":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_14_465_466":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_15_464_465":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_16_463_464":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxx_stencil_17_lxx_stencil_18_463":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_2_469_470.in0"],
+          ["add_lxx_stencil_11_468_469.out","add_lgxx_stencil_2_469_470.in1"],
+          ["add_lxx_stencil_10_470_471.in1","add_lgxx_stencil_2_469_470.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_10_470_471.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_10_470_471.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_11_468_469.in0"],
+          ["add_lxx_stencil_12_467_468.out","add_lxx_stencil_11_468_469.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_12_467_468.in0"],
+          ["add_lxx_stencil_13_466_467.out","add_lxx_stencil_12_467_468.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_13_466_467.in0"],
+          ["add_lxx_stencil_14_465_466.out","add_lxx_stencil_13_466_467.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_14_465_466.in0"],
+          ["add_lxx_stencil_15_464_465.out","add_lxx_stencil_14_465_466.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_15_464_465.in0"],
+          ["add_lxx_stencil_16_463_464.out","add_lxx_stencil_15_464_465.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_16_463_464.in0"],
+          ["add_lxx_stencil_17_lxx_stencil_18_463.out","add_lxx_stencil_16_463_464.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_17_lxx_stencil_18_463.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_17_lxx_stencil_18_463.in1"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -761,14 +967,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__523":{
+          "const_p0__648":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__523.out"]
+          ["self.out_lgxy_stencil","const_p0__648.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
@@ -776,14 +982,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__528":{
+          "const_p0__653":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__528.out"]
+          ["self.out_lgxy_stencil","const_p0__653.out"]
         ]
       },
       "hcompute_lgxy_stencil_2":{
@@ -793,63 +999,129 @@
           ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_546_547":{
+          "add_lgxy_stencil_1_671_672":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_1_547_548":{
+          "add_lxy_stencil_1_672_673":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_2_545_546":{
+          "add_lxy_stencil_2_670_671":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_3_544_545":{
+          "add_lxy_stencil_3_669_670":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_4_543_544":{
+          "add_lxy_stencil_4_668_669":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_5_542_543":{
+          "add_lxy_stencil_5_667_668":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_6_541_542":{
+          "add_lxy_stencil_6_666_667":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_7_540_541":{
+          "add_lxy_stencil_7_665_666":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_8_lxy_stencil_9_540":{
+          "add_lxy_stencil_8_lxy_stencil_9_665":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_546_547.in0"],
-          ["add_lxy_stencil_2_545_546.out","add_lgxy_stencil_1_546_547.in1"],
-          ["add_lxy_stencil_1_547_548.in1","add_lgxy_stencil_1_546_547.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_547_548.in0"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_1_547_548.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_545_546.in0"],
-          ["add_lxy_stencil_3_544_545.out","add_lxy_stencil_2_545_546.in1"],
-          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_544_545.in0"],
-          ["add_lxy_stencil_4_543_544.out","add_lxy_stencil_3_544_545.in1"],
-          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_543_544.in0"],
-          ["add_lxy_stencil_5_542_543.out","add_lxy_stencil_4_543_544.in1"],
-          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_542_543.in0"],
-          ["add_lxy_stencil_6_541_542.out","add_lxy_stencil_5_542_543.in1"],
-          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_541_542.in0"],
-          ["add_lxy_stencil_7_540_541.out","add_lxy_stencil_6_541_542.in1"],
-          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_540_541.in0"],
-          ["add_lxy_stencil_8_lxy_stencil_9_540.out","add_lxy_stencil_7_540_541.in1"],
-          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_540.in0"],
-          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_540.in1"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_671_672.in0"],
+          ["add_lxy_stencil_2_670_671.out","add_lgxy_stencil_1_671_672.in1"],
+          ["add_lxy_stencil_1_672_673.in1","add_lgxy_stencil_1_671_672.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_672_673.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_1_672_673.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_670_671.in0"],
+          ["add_lxy_stencil_3_669_670.out","add_lxy_stencil_2_670_671.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_669_670.in0"],
+          ["add_lxy_stencil_4_668_669.out","add_lxy_stencil_3_669_670.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_668_669.in0"],
+          ["add_lxy_stencil_5_667_668.out","add_lxy_stencil_4_668_669.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_667_668.in0"],
+          ["add_lxy_stencil_6_666_667.out","add_lxy_stencil_5_667_668.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_666_667.in0"],
+          ["add_lxy_stencil_7_665_666.out","add_lxy_stencil_6_666_667.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_665_666.in0"],
+          ["add_lxy_stencil_8_lxy_stencil_9_665.out","add_lxy_stencil_7_665_666.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_665.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_665.in1"]
+        ]
+      },
+      "hcompute_lgxy_stencil_3":{
+        "type":["Record",[
+          ["out_lgxy_stencil",["Array",16,"Bit"]],
+          ["in0_lgxy_stencil",["Array",1,["Array",16,"BitIn"]]],
+          ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
+        ]],
+        "instances":{
+          "add_lgxy_stencil_2_713_714":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_10_714_715":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_11_712_713":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_12_711_712":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_13_710_711":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_14_709_710":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_15_708_709":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_16_707_708":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lxy_stencil_17_lxy_stencil_18_707":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_2_713_714.in0"],
+          ["add_lxy_stencil_11_712_713.out","add_lgxy_stencil_2_713_714.in1"],
+          ["add_lxy_stencil_10_714_715.in1","add_lgxy_stencil_2_713_714.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_10_714_715.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_10_714_715.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_11_712_713.in0"],
+          ["add_lxy_stencil_12_711_712.out","add_lxy_stencil_11_712_713.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_12_711_712.in0"],
+          ["add_lxy_stencil_13_710_711.out","add_lxy_stencil_12_711_712.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_13_710_711.in0"],
+          ["add_lxy_stencil_14_709_710.out","add_lxy_stencil_13_710_711.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_14_709_710.in0"],
+          ["add_lxy_stencil_15_708_709.out","add_lxy_stencil_14_709_710.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_15_708_709.in0"],
+          ["add_lxy_stencil_16_707_708.out","add_lxy_stencil_15_708_709.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_16_707_708.in0"],
+          ["add_lxy_stencil_17_lxy_stencil_18_707.out","add_lxy_stencil_16_707_708.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_17_lxy_stencil_18_707.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_17_lxy_stencil_18_707.in1"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -857,14 +1129,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__621":{
+          "const_p0__789":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__621.out"]
+          ["self.out_lgyy_stencil","const_p0__789.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
@@ -872,14 +1144,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__626":{
+          "const_p0__794":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__626.out"]
+          ["self.out_lgyy_stencil","const_p0__794.out"]
         ]
       },
       "hcompute_lgyy_stencil_2":{
@@ -889,63 +1161,129 @@
           ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_644_645":{
+          "add_lgyy_stencil_1_812_813":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_1_645_646":{
+          "add_lyy_stencil_1_813_814":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_2_643_644":{
+          "add_lyy_stencil_2_811_812":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_3_642_643":{
+          "add_lyy_stencil_3_810_811":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_4_641_642":{
+          "add_lyy_stencil_4_809_810":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_5_640_641":{
+          "add_lyy_stencil_5_808_809":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_6_639_640":{
+          "add_lyy_stencil_6_807_808":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_7_638_639":{
+          "add_lyy_stencil_7_806_807":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_8_lyy_stencil_9_638":{
+          "add_lyy_stencil_8_lyy_stencil_9_806":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_644_645.in0"],
-          ["add_lyy_stencil_2_643_644.out","add_lgyy_stencil_1_644_645.in1"],
-          ["add_lyy_stencil_1_645_646.in1","add_lgyy_stencil_1_644_645.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_645_646.in0"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_1_645_646.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_643_644.in0"],
-          ["add_lyy_stencil_3_642_643.out","add_lyy_stencil_2_643_644.in1"],
-          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_642_643.in0"],
-          ["add_lyy_stencil_4_641_642.out","add_lyy_stencil_3_642_643.in1"],
-          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_641_642.in0"],
-          ["add_lyy_stencil_5_640_641.out","add_lyy_stencil_4_641_642.in1"],
-          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_640_641.in0"],
-          ["add_lyy_stencil_6_639_640.out","add_lyy_stencil_5_640_641.in1"],
-          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_639_640.in0"],
-          ["add_lyy_stencil_7_638_639.out","add_lyy_stencil_6_639_640.in1"],
-          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_638_639.in0"],
-          ["add_lyy_stencil_8_lyy_stencil_9_638.out","add_lyy_stencil_7_638_639.in1"],
-          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_638.in0"],
-          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_638.in1"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_812_813.in0"],
+          ["add_lyy_stencil_2_811_812.out","add_lgyy_stencil_1_812_813.in1"],
+          ["add_lyy_stencil_1_813_814.in1","add_lgyy_stencil_1_812_813.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_813_814.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_1_813_814.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_811_812.in0"],
+          ["add_lyy_stencil_3_810_811.out","add_lyy_stencil_2_811_812.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_810_811.in0"],
+          ["add_lyy_stencil_4_809_810.out","add_lyy_stencil_3_810_811.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_809_810.in0"],
+          ["add_lyy_stencil_5_808_809.out","add_lyy_stencil_4_809_810.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_808_809.in0"],
+          ["add_lyy_stencil_6_807_808.out","add_lyy_stencil_5_808_809.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_807_808.in0"],
+          ["add_lyy_stencil_7_806_807.out","add_lyy_stencil_6_807_808.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_806_807.in0"],
+          ["add_lyy_stencil_8_lyy_stencil_9_806.out","add_lyy_stencil_7_806_807.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_806.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_806.in1"]
+        ]
+      },
+      "hcompute_lgyy_stencil_3":{
+        "type":["Record",[
+          ["out_lgyy_stencil",["Array",16,"Bit"]],
+          ["in0_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]],
+          ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
+        ]],
+        "instances":{
+          "add_lgyy_stencil_2_854_855":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_10_855_856":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_11_853_854":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_12_852_853":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_13_851_852":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_14_850_851":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_15_849_850":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_16_848_849":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          },
+          "add_lyy_stencil_17_lyy_stencil_18_848":{
+            "genref":"coreir.add",
+            "genargs":{"width":["Int",16]}
+          }
+        },
+        "connections":[
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_2_854_855.in0"],
+          ["add_lyy_stencil_11_853_854.out","add_lgyy_stencil_2_854_855.in1"],
+          ["add_lyy_stencil_10_855_856.in1","add_lgyy_stencil_2_854_855.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_10_855_856.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_10_855_856.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_11_853_854.in0"],
+          ["add_lyy_stencil_12_852_853.out","add_lyy_stencil_11_853_854.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_12_852_853.in0"],
+          ["add_lyy_stencil_13_851_852.out","add_lyy_stencil_12_852_853.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_13_851_852.in0"],
+          ["add_lyy_stencil_14_850_851.out","add_lyy_stencil_13_851_852.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_14_850_851.in0"],
+          ["add_lyy_stencil_15_849_850.out","add_lyy_stencil_14_850_851.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_15_849_850.in0"],
+          ["add_lyy_stencil_16_848_849.out","add_lyy_stencil_15_849_850.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_16_848_849.in0"],
+          ["add_lyy_stencil_17_lyy_stencil_18_848.out","add_lyy_stencil_16_848_849.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_17_lyy_stencil_18_848.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_17_lyy_stencil_18_848.in1"]
         ]
       },
       "hcompute_lxx_stencil":{
@@ -954,48 +1292,48 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_325_326_327":{
+          "ashr_366_367_368":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__323":{
+          "const_n255__364":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__321":{
+          "const_p255__362":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p7__326":{
+          "const_p7__367":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_324_324_325":{
+          "mul_365_365_366":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_322_323_324":{
+          "smax_363_364_365":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_2_321_322":{
+          "smin_grad_x_unclamp_stencil_3_362_363":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_324_324_325.out","ashr_325_326_327.in0"],
-          ["const_p7__326.out","ashr_325_326_327.in1"],
-          ["self.out_lxx_stencil","ashr_325_326_327.out"],
-          ["smax_322_323_324.in1","const_n255__323.out"],
-          ["smin_grad_x_unclamp_stencil_2_321_322.in1","const_p255__321.out"],
-          ["smax_322_323_324.out","mul_324_324_325.in0"],
-          ["smax_322_323_324.out","mul_324_324_325.in1"],
-          ["smin_grad_x_unclamp_stencil_2_321_322.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_2_321_322.out","smax_322_323_324.in0"]
+          ["mul_365_365_366.out","ashr_366_367_368.in0"],
+          ["const_p7__367.out","ashr_366_367_368.in1"],
+          ["self.out_lxx_stencil","ashr_366_367_368.out"],
+          ["smax_363_364_365.in1","const_n255__364.out"],
+          ["smin_grad_x_unclamp_stencil_3_362_363.in1","const_p255__362.out"],
+          ["smax_363_364_365.out","mul_365_365_366.in0"],
+          ["smax_363_364_365.out","mul_365_365_366.in1"],
+          ["smin_grad_x_unclamp_stencil_3_362_363.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_3_362_363.out","smax_363_364_365.in0"]
         ]
       },
       "hcompute_lxx_stencil_1":{
@@ -1004,48 +1342,48 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_349_350_351":{
+          "ashr_390_391_392":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__347":{
+          "const_n255__388":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__345":{
+          "const_p255__386":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p7__350":{
+          "const_p7__391":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_348_348_349":{
+          "mul_389_389_390":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_346_347_348":{
+          "smax_387_388_389":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_3_345_346":{
+          "smin_grad_x_unclamp_stencil_4_386_387":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_348_348_349.out","ashr_349_350_351.in0"],
-          ["const_p7__350.out","ashr_349_350_351.in1"],
-          ["self.out_lxx_stencil","ashr_349_350_351.out"],
-          ["smax_346_347_348.in1","const_n255__347.out"],
-          ["smin_grad_x_unclamp_stencil_3_345_346.in1","const_p255__345.out"],
-          ["smax_346_347_348.out","mul_348_348_349.in0"],
-          ["smax_346_347_348.out","mul_348_348_349.in1"],
-          ["smin_grad_x_unclamp_stencil_3_345_346.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_3_345_346.out","smax_346_347_348.in0"]
+          ["mul_389_389_390.out","ashr_390_391_392.in0"],
+          ["const_p7__391.out","ashr_390_391_392.in1"],
+          ["self.out_lxx_stencil","ashr_390_391_392.out"],
+          ["smax_387_388_389.in1","const_n255__388.out"],
+          ["smin_grad_x_unclamp_stencil_4_386_387.in1","const_p255__386.out"],
+          ["smax_387_388_389.out","mul_389_389_390.in0"],
+          ["smax_387_388_389.out","mul_389_389_390.in1"],
+          ["smin_grad_x_unclamp_stencil_4_386_387.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_4_386_387.out","smax_387_388_389.in0"]
         ]
       },
       "hcompute_lxy_stencil":{
@@ -1055,70 +1393,70 @@
           ["in1_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_475_476_477":{
+          "ashr_600_601_602":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__471":{
+          "const_n255__596":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_n255__471$1":{
+          "const_n255__596$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__469":{
+          "const_p255__594":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p255__469$1":{
+          "const_p255__594$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p7__476":{
+          "const_p7__601":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_472_474_475":{
+          "mul_597_599_600":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_470_471_472":{
+          "smax_595_596_597":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smax_473_471_474":{
+          "smax_598_596_599":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_4_469_470":{
+          "smin_grad_x_unclamp_stencil_5_594_595":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_2_469_473":{
+          "smin_grad_y_unclamp_stencil_3_594_598":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_472_474_475.out","ashr_475_476_477.in0"],
-          ["const_p7__476.out","ashr_475_476_477.in1"],
-          ["self.out_lxy_stencil","ashr_475_476_477.out"],
-          ["smax_473_471_474.in1","const_n255__471$1.out"],
-          ["smax_470_471_472.in1","const_n255__471.out"],
-          ["smin_grad_y_unclamp_stencil_2_469_473.in1","const_p255__469$1.out"],
-          ["smin_grad_x_unclamp_stencil_4_469_470.in1","const_p255__469.out"],
-          ["smax_470_471_472.out","mul_472_474_475.in0"],
-          ["smax_473_471_474.out","mul_472_474_475.in1"],
-          ["smin_grad_x_unclamp_stencil_4_469_470.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_2_469_473.in0","self.in1_grad_y_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_4_469_470.out","smax_470_471_472.in0"],
-          ["smin_grad_y_unclamp_stencil_2_469_473.out","smax_473_471_474.in0"]
+          ["mul_597_599_600.out","ashr_600_601_602.in0"],
+          ["const_p7__601.out","ashr_600_601_602.in1"],
+          ["self.out_lxy_stencil","ashr_600_601_602.out"],
+          ["smax_598_596_599.in1","const_n255__596$1.out"],
+          ["smax_595_596_597.in1","const_n255__596.out"],
+          ["smin_grad_y_unclamp_stencil_3_594_598.in1","const_p255__594$1.out"],
+          ["smin_grad_x_unclamp_stencil_5_594_595.in1","const_p255__594.out"],
+          ["smax_595_596_597.out","mul_597_599_600.in0"],
+          ["smax_598_596_599.out","mul_597_599_600.in1"],
+          ["smin_grad_x_unclamp_stencil_5_594_595.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_3_594_598.in0","self.in1_grad_y_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_5_594_595.out","smax_595_596_597.in0"],
+          ["smin_grad_y_unclamp_stencil_3_594_598.out","smax_598_596_599.in0"]
         ]
       },
       "hcompute_lxy_stencil_1":{
@@ -1128,70 +1466,70 @@
           ["in1_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_506_507_508":{
+          "ashr_631_632_633":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__502":{
+          "const_n255__627":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_n255__502$1":{
+          "const_n255__627$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__500":{
+          "const_p255__625":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p255__500$1":{
+          "const_p255__625$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p7__507":{
+          "const_p7__632":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_503_505_506":{
+          "mul_628_630_631":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_501_502_503":{
+          "smax_626_627_628":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smax_504_502_505":{
+          "smax_629_627_630":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_5_500_501":{
+          "smin_grad_x_unclamp_stencil_6_625_626":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_3_500_504":{
+          "smin_grad_y_unclamp_stencil_4_625_629":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_503_505_506.out","ashr_506_507_508.in0"],
-          ["const_p7__507.out","ashr_506_507_508.in1"],
-          ["self.out_lxy_stencil","ashr_506_507_508.out"],
-          ["smax_504_502_505.in1","const_n255__502$1.out"],
-          ["smax_501_502_503.in1","const_n255__502.out"],
-          ["smin_grad_y_unclamp_stencil_3_500_504.in1","const_p255__500$1.out"],
-          ["smin_grad_x_unclamp_stencil_5_500_501.in1","const_p255__500.out"],
-          ["smax_501_502_503.out","mul_503_505_506.in0"],
-          ["smax_504_502_505.out","mul_503_505_506.in1"],
-          ["smin_grad_x_unclamp_stencil_5_500_501.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_3_500_504.in0","self.in1_grad_y_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_5_500_501.out","smax_501_502_503.in0"],
-          ["smin_grad_y_unclamp_stencil_3_500_504.out","smax_504_502_505.in0"]
+          ["mul_628_630_631.out","ashr_631_632_633.in0"],
+          ["const_p7__632.out","ashr_631_632_633.in1"],
+          ["self.out_lxy_stencil","ashr_631_632_633.out"],
+          ["smax_629_627_630.in1","const_n255__627$1.out"],
+          ["smax_626_627_628.in1","const_n255__627.out"],
+          ["smin_grad_y_unclamp_stencil_4_625_629.in1","const_p255__625$1.out"],
+          ["smin_grad_x_unclamp_stencil_6_625_626.in1","const_p255__625.out"],
+          ["smax_626_627_628.out","mul_628_630_631.in0"],
+          ["smax_629_627_630.out","mul_628_630_631.in1"],
+          ["smin_grad_x_unclamp_stencil_6_625_626.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_4_625_629.in0","self.in1_grad_y_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_6_625_626.out","smax_626_627_628.in0"],
+          ["smin_grad_y_unclamp_stencil_4_625_629.out","smax_629_627_630.in0"]
         ]
       },
       "hcompute_lyy_stencil":{
@@ -1200,48 +1538,48 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_583_584_585":{
+          "ashr_751_752_753":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__581":{
+          "const_n255__749":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__579":{
+          "const_p255__747":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p7__584":{
+          "const_p7__752":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_582_582_583":{
+          "mul_750_750_751":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_580_581_582":{
+          "smax_748_749_750":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_4_579_580":{
+          "smin_grad_y_unclamp_stencil_5_747_748":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_582_582_583.out","ashr_583_584_585.in0"],
-          ["const_p7__584.out","ashr_583_584_585.in1"],
-          ["self.out_lyy_stencil","ashr_583_584_585.out"],
-          ["smax_580_581_582.in1","const_n255__581.out"],
-          ["smin_grad_y_unclamp_stencil_4_579_580.in1","const_p255__579.out"],
-          ["smax_580_581_582.out","mul_582_582_583.in0"],
-          ["smax_580_581_582.out","mul_582_582_583.in1"],
-          ["smin_grad_y_unclamp_stencil_4_579_580.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_4_579_580.out","smax_580_581_582.in0"]
+          ["mul_750_750_751.out","ashr_751_752_753.in0"],
+          ["const_p7__752.out","ashr_751_752_753.in1"],
+          ["self.out_lyy_stencil","ashr_751_752_753.out"],
+          ["smax_748_749_750.in1","const_n255__749.out"],
+          ["smin_grad_y_unclamp_stencil_5_747_748.in1","const_p255__747.out"],
+          ["smax_748_749_750.out","mul_750_750_751.in0"],
+          ["smax_748_749_750.out","mul_750_750_751.in1"],
+          ["smin_grad_y_unclamp_stencil_5_747_748.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_5_747_748.out","smax_748_749_750.in0"]
         ]
       },
       "hcompute_lyy_stencil_1":{
@@ -1250,48 +1588,48 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_607_608_609":{
+          "ashr_775_776_777":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n255__605":{
+          "const_n255__773":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff01"]}
           },
-          "const_p255__603":{
+          "const_p255__771":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "const_p7__608":{
+          "const_p7__776":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0007"]}
           },
-          "mul_606_606_607":{
+          "mul_774_774_775":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_604_605_606":{
+          "smax_772_773_774":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_5_603_604":{
+          "smin_grad_y_unclamp_stencil_6_771_772":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_606_606_607.out","ashr_607_608_609.in0"],
-          ["const_p7__608.out","ashr_607_608_609.in1"],
-          ["self.out_lyy_stencil","ashr_607_608_609.out"],
-          ["smax_604_605_606.in1","const_n255__605.out"],
-          ["smin_grad_y_unclamp_stencil_5_603_604.in1","const_p255__603.out"],
-          ["smax_604_605_606.out","mul_606_606_607.in0"],
-          ["smax_604_605_606.out","mul_606_606_607.in1"],
-          ["smin_grad_y_unclamp_stencil_5_603_604.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_5_603_604.out","smax_604_605_606.in0"]
+          ["mul_774_774_775.out","ashr_775_776_777.in0"],
+          ["const_p7__776.out","ashr_775_776_777.in1"],
+          ["self.out_lyy_stencil","ashr_775_776_777.out"],
+          ["smax_772_773_774.in1","const_n255__773.out"],
+          ["smin_grad_y_unclamp_stencil_6_771_772.in1","const_p255__771.out"],
+          ["smax_772_773_774.out","mul_774_774_775.in0"],
+          ["smax_772_773_774.out","mul_774_774_775.in1"],
+          ["smin_grad_y_unclamp_stencil_6_771_772.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_6_771_772.out","smax_772_773_774.in0"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{

--- a/example_progs.cpp
+++ b/example_progs.cpp
@@ -4208,6 +4208,9 @@ prog harris_sch3_1pp9c() {
   prg.add_output("hw_output_stencil");
   prg.buffer_port_widths["hw_output_stencil"] = 16;
 
+////producing kernel_xa0
+
+//consuming kernel_xa0
 ////producing padded16_global_wrapper.stencil
   auto padded16_global_wrapper_s0_y = prg.add_loop("padded16_global_wrapper_s0_y", -3, 61);
   auto padded16_global_wrapper_s0_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x", -3, 61);
@@ -4232,9 +4235,6 @@ prog harris_sch3_1pp9c() {
   hcompute_grad_x_unclamp_stencil->add_store("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
   auto grad_x_unclamp_s1_r_y = grad_x_s0_x->add_loop("grad_x_unclamp_s1_r_y", -1, 2);
   auto grad_x_unclamp_s1_r_x = grad_x_unclamp_s1_r_y->add_loop("grad_x_unclamp_s1_r_x", -1, 2);
-////producing kernel_xa0
-
-//consuming kernel_xa0
 
 //store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + grad_x_unclamp_s1_r_x), (grad_x_s0_y + grad_x_unclamp_s1_r_y))*int16(kernel_xa0[(grad_x_unclamp_s1_r_x + ((grad_x_unclamp_s1_r_y*3) + 4))])))
   auto hcompute_grad_x_unclamp_stencil_1 = grad_x_unclamp_s1_r_x->add_op("op_hcompute_grad_x_unclamp_stencil_1");
@@ -4268,27 +4268,72 @@ prog harris_sch3_1pp9c() {
 
 //consuming lxx.stencil
 ////producing lgxx.stencil
-  auto lgxx_s0_y = prg.add_loop("lgxx_s0_y", -1, 59);
-  auto lgxx_s0_x = lgxx_s0_y->add_loop("lgxx_s0_x", -1, 59);
+  auto lgxx_s0_y_y = prg.add_loop("lgxx_s0_y_y", 0, 20);
+  auto lgxx_s0_x_x = lgxx_s0_y_y->add_loop("lgxx_s0_x_x", 0, 20);
 
-//store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
-  auto hcompute_lgxx_stencil = lgxx_s0_x->add_op("op_hcompute_lgxx_stencil");
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + -1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxx_stencil = lgxx_s0_x_x->add_op("op_hcompute_lgxx_stencil");
   hcompute_lgxx_stencil->add_function("hcompute_lgxx_stencil");
   prg.buffer_port_widths["lgxx_stencil"] = 16;
-  hcompute_lgxx_stencil->add_store("lgxx_stencil", "lgxx_s0_y", "lgxx_s0_x");
+  hcompute_lgxx_stencil->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + -1)", "((lgxx_s0_x_x*3) + -1)");
+
+//store is: lgxx.stencil((lgxx_s0_x_x*3), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxx_stencil_1 = lgxx_s0_x_x->add_op("op_hcompute_lgxx_stencil_1");
+  hcompute_lgxx_stencil_1->add_function("hcompute_lgxx_stencil_1");
+  hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + -1)", "(lgxx_s0_x_x*3)");
+
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + 1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxx_stencil_2 = lgxx_s0_x_x->add_op("op_hcompute_lgxx_stencil_2");
+  hcompute_lgxx_stencil_2->add_function("hcompute_lgxx_stencil_2");
+  hcompute_lgxx_stencil_2->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + -1)", "((lgxx_s0_x_x*3) + 1)");
+  auto lgxx_s0_x_x_1 = lgxx_s0_y_y->add_loop("lgxx_s0_x_x_1", 0, 20);
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + -1), (lgxx_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxx_stencil_3 = lgxx_s0_x_x_1->add_op("op_hcompute_lgxx_stencil_3");
+  hcompute_lgxx_stencil_3->add_function("hcompute_lgxx_stencil_3");
+  hcompute_lgxx_stencil_3->add_store("lgxx_stencil", "(lgxx_s0_y_y*3)", "((lgxx_s0_x_x_1*3) + -1)");
+
+//store is: lgxx.stencil((lgxx_s0_x_x_1*3), (lgxx_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxx_stencil_4 = lgxx_s0_x_x_1->add_op("op_hcompute_lgxx_stencil_4");
+  hcompute_lgxx_stencil_4->add_function("hcompute_lgxx_stencil_4");
+  hcompute_lgxx_stencil_4->add_store("lgxx_stencil", "(lgxx_s0_y_y*3)", "(lgxx_s0_x_x_1*3)");
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + 1), (lgxx_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxx_stencil_5 = lgxx_s0_x_x_1->add_op("op_hcompute_lgxx_stencil_5");
+  hcompute_lgxx_stencil_5->add_function("hcompute_lgxx_stencil_5");
+  hcompute_lgxx_stencil_5->add_store("lgxx_stencil", "(lgxx_s0_y_y*3)", "((lgxx_s0_x_x_1*3) + 1)");
+  auto lgxx_s0_x_x_2 = lgxx_s0_y_y->add_loop("lgxx_s0_x_x_2", 0, 20);
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + -1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxx_stencil_6 = lgxx_s0_x_x_2->add_op("op_hcompute_lgxx_stencil_6");
+  hcompute_lgxx_stencil_6->add_function("hcompute_lgxx_stencil_6");
+  hcompute_lgxx_stencil_6->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + 1)", "((lgxx_s0_x_x_2*3) + -1)");
+
+//store is: lgxx.stencil((lgxx_s0_x_x_2*3), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxx_stencil_7 = lgxx_s0_x_x_2->add_op("op_hcompute_lgxx_stencil_7");
+  hcompute_lgxx_stencil_7->add_function("hcompute_lgxx_stencil_7");
+  hcompute_lgxx_stencil_7->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + 1)", "(lgxx_s0_x_x_2*3)");
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + 1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxx_stencil_8 = lgxx_s0_x_x_2->add_op("op_hcompute_lgxx_stencil_8");
+  hcompute_lgxx_stencil_8->add_function("hcompute_lgxx_stencil_8");
+  hcompute_lgxx_stencil_8->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + 1)", "((lgxx_s0_x_x_2*3) + 1)");
   auto lgxx_s1_y = prg.add_loop("lgxx_s1_y", -1, 59);
   auto lgxx_s1_x = lgxx_s1_y->add_loop("lgxx_s1_x", -1, 59);
   auto lgxx_s1_box_y = lgxx_s1_x->add_loop("lgxx_s1_box_y", -1, 2);
   auto lgxx_s1_box_x = lgxx_s1_box_y->add_loop("lgxx_s1_box_x", -1, 2);
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + lxx.stencil((lgxx_s1_box_x + lgxx_s1_x), (lgxx_s1_box_y + lgxx_s1_y)))
-  auto hcompute_lgxx_stencil_1 = lgxx_s1_box_x->add_op("op_hcompute_lgxx_stencil_1");
-  hcompute_lgxx_stencil_1->add_function("hcompute_lgxx_stencil_1");
-  hcompute_lgxx_stencil_1->add_load("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
-  hcompute_lgxx_stencil_1->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "(lgxx_s1_box_x + lgxx_s1_x)");
-  hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
+  auto hcompute_lgxx_stencil_9 = lgxx_s1_box_x->add_op("op_hcompute_lgxx_stencil_9");
+  hcompute_lgxx_stencil_9->add_function("hcompute_lgxx_stencil_9");
+  hcompute_lgxx_stencil_9->add_load("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
+  hcompute_lgxx_stencil_9->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "(lgxx_s1_box_x + lgxx_s1_x)");
+  hcompute_lgxx_stencil_9->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
 
 //consuming lgxx.stencil
+////producing kernel_ya1
+
+//consuming kernel_ya1
 ////producing grad_y.stencil
   auto grad_y_s0_y = prg.add_loop("grad_y_s0_y", -2, 60);
   auto grad_y_s0_x = grad_y_s0_y->add_loop("grad_y_s0_x", -2, 60);
@@ -4301,9 +4346,6 @@ prog harris_sch3_1pp9c() {
   hcompute_grad_y_unclamp_stencil->add_store("grad_y_unclamp_stencil", "grad_y_s0_y", "grad_y_s0_x");
   auto grad_y_unclamp_s1_r_y = grad_y_s0_x->add_loop("grad_y_unclamp_s1_r_y", -1, 2);
   auto grad_y_unclamp_s1_r_x = grad_y_unclamp_s1_r_y->add_loop("grad_y_unclamp_s1_r_x", -1, 2);
-////producing kernel_ya1
-
-//consuming kernel_ya1
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + grad_y_unclamp_s1_r_x), (grad_y_s0_y + grad_y_unclamp_s1_r_y))*int16(kernel_ya1[(grad_y_unclamp_s1_r_x + ((grad_y_unclamp_s1_r_y*3) + 4))])))
   auto hcompute_grad_y_unclamp_stencil_1 = grad_y_unclamp_s1_r_x->add_op("op_hcompute_grad_y_unclamp_stencil_1");
@@ -4338,25 +4380,67 @@ prog harris_sch3_1pp9c() {
 
 //consuming lxy.stencil
 ////producing lgxy.stencil
-  auto lgxy_s0_y = prg.add_loop("lgxy_s0_y", -1, 59);
-  auto lgxy_s0_x = lgxy_s0_y->add_loop("lgxy_s0_x", -1, 59);
+  auto lgxy_s0_y_y = prg.add_loop("lgxy_s0_y_y", 0, 20);
+  auto lgxy_s0_x_x = lgxy_s0_y_y->add_loop("lgxy_s0_x_x", 0, 20);
 
-//store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
-  auto hcompute_lgxy_stencil = lgxy_s0_x->add_op("op_hcompute_lgxy_stencil");
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + -1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxy_stencil = lgxy_s0_x_x->add_op("op_hcompute_lgxy_stencil");
   hcompute_lgxy_stencil->add_function("hcompute_lgxy_stencil");
   prg.buffer_port_widths["lgxy_stencil"] = 16;
-  hcompute_lgxy_stencil->add_store("lgxy_stencil", "lgxy_s0_y", "lgxy_s0_x");
+  hcompute_lgxy_stencil->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + -1)", "((lgxy_s0_x_x*3) + -1)");
+
+//store is: lgxy.stencil((lgxy_s0_x_x*3), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxy_stencil_1 = lgxy_s0_x_x->add_op("op_hcompute_lgxy_stencil_1");
+  hcompute_lgxy_stencil_1->add_function("hcompute_lgxy_stencil_1");
+  hcompute_lgxy_stencil_1->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + -1)", "(lgxy_s0_x_x*3)");
+
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + 1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxy_stencil_2 = lgxy_s0_x_x->add_op("op_hcompute_lgxy_stencil_2");
+  hcompute_lgxy_stencil_2->add_function("hcompute_lgxy_stencil_2");
+  hcompute_lgxy_stencil_2->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + -1)", "((lgxy_s0_x_x*3) + 1)");
+  auto lgxy_s0_x_x_1 = lgxy_s0_y_y->add_loop("lgxy_s0_x_x_1", 0, 20);
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + -1), (lgxy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxy_stencil_3 = lgxy_s0_x_x_1->add_op("op_hcompute_lgxy_stencil_3");
+  hcompute_lgxy_stencil_3->add_function("hcompute_lgxy_stencil_3");
+  hcompute_lgxy_stencil_3->add_store("lgxy_stencil", "(lgxy_s0_y_y*3)", "((lgxy_s0_x_x_1*3) + -1)");
+
+//store is: lgxy.stencil((lgxy_s0_x_x_1*3), (lgxy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxy_stencil_4 = lgxy_s0_x_x_1->add_op("op_hcompute_lgxy_stencil_4");
+  hcompute_lgxy_stencil_4->add_function("hcompute_lgxy_stencil_4");
+  hcompute_lgxy_stencil_4->add_store("lgxy_stencil", "(lgxy_s0_y_y*3)", "(lgxy_s0_x_x_1*3)");
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + 1), (lgxy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxy_stencil_5 = lgxy_s0_x_x_1->add_op("op_hcompute_lgxy_stencil_5");
+  hcompute_lgxy_stencil_5->add_function("hcompute_lgxy_stencil_5");
+  hcompute_lgxy_stencil_5->add_store("lgxy_stencil", "(lgxy_s0_y_y*3)", "((lgxy_s0_x_x_1*3) + 1)");
+  auto lgxy_s0_x_x_2 = lgxy_s0_y_y->add_loop("lgxy_s0_x_x_2", 0, 20);
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + -1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxy_stencil_6 = lgxy_s0_x_x_2->add_op("op_hcompute_lgxy_stencil_6");
+  hcompute_lgxy_stencil_6->add_function("hcompute_lgxy_stencil_6");
+  hcompute_lgxy_stencil_6->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + 1)", "((lgxy_s0_x_x_2*3) + -1)");
+
+//store is: lgxy.stencil((lgxy_s0_x_x_2*3), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxy_stencil_7 = lgxy_s0_x_x_2->add_op("op_hcompute_lgxy_stencil_7");
+  hcompute_lgxy_stencil_7->add_function("hcompute_lgxy_stencil_7");
+  hcompute_lgxy_stencil_7->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + 1)", "(lgxy_s0_x_x_2*3)");
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + 1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxy_stencil_8 = lgxy_s0_x_x_2->add_op("op_hcompute_lgxy_stencil_8");
+  hcompute_lgxy_stencil_8->add_function("hcompute_lgxy_stencil_8");
+  hcompute_lgxy_stencil_8->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + 1)", "((lgxy_s0_x_x_2*3) + 1)");
   auto lgxy_s1_y = prg.add_loop("lgxy_s1_y", -1, 59);
   auto lgxy_s1_x = lgxy_s1_y->add_loop("lgxy_s1_x", -1, 59);
   auto lgxy_s1_box_y = lgxy_s1_x->add_loop("lgxy_s1_box_y", -1, 2);
   auto lgxy_s1_box_x = lgxy_s1_box_y->add_loop("lgxy_s1_box_x", -1, 2);
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + lxy.stencil((lgxy_s1_box_x + lgxy_s1_x), (lgxy_s1_box_y + lgxy_s1_y)))
-  auto hcompute_lgxy_stencil_1 = lgxy_s1_box_x->add_op("op_hcompute_lgxy_stencil_1");
-  hcompute_lgxy_stencil_1->add_function("hcompute_lgxy_stencil_1");
-  hcompute_lgxy_stencil_1->add_load("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
-  hcompute_lgxy_stencil_1->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "(lgxy_s1_box_x + lgxy_s1_x)");
-  hcompute_lgxy_stencil_1->add_store("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
+  auto hcompute_lgxy_stencil_9 = lgxy_s1_box_x->add_op("op_hcompute_lgxy_stencil_9");
+  hcompute_lgxy_stencil_9->add_function("hcompute_lgxy_stencil_9");
+  hcompute_lgxy_stencil_9->add_load("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
+  hcompute_lgxy_stencil_9->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "(lgxy_s1_box_x + lgxy_s1_x)");
+  hcompute_lgxy_stencil_9->add_store("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
 
 //consuming lgxy.stencil
 ////producing lyy.stencil
@@ -4372,25 +4456,67 @@ prog harris_sch3_1pp9c() {
 
 //consuming lyy.stencil
 ////producing lgyy.stencil
-  auto lgyy_s0_y = prg.add_loop("lgyy_s0_y", -1, 59);
-  auto lgyy_s0_x = lgyy_s0_y->add_loop("lgyy_s0_x", -1, 59);
+  auto lgyy_s0_y_y = prg.add_loop("lgyy_s0_y_y", 0, 20);
+  auto lgyy_s0_x_x = lgyy_s0_y_y->add_loop("lgyy_s0_x_x", 0, 20);
 
-//store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
-  auto hcompute_lgyy_stencil = lgyy_s0_x->add_op("op_hcompute_lgyy_stencil");
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + -1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgyy_stencil = lgyy_s0_x_x->add_op("op_hcompute_lgyy_stencil");
   hcompute_lgyy_stencil->add_function("hcompute_lgyy_stencil");
   prg.buffer_port_widths["lgyy_stencil"] = 16;
-  hcompute_lgyy_stencil->add_store("lgyy_stencil", "lgyy_s0_y", "lgyy_s0_x");
+  hcompute_lgyy_stencil->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + -1)", "((lgyy_s0_x_x*3) + -1)");
+
+//store is: lgyy.stencil((lgyy_s0_x_x*3), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgyy_stencil_1 = lgyy_s0_x_x->add_op("op_hcompute_lgyy_stencil_1");
+  hcompute_lgyy_stencil_1->add_function("hcompute_lgyy_stencil_1");
+  hcompute_lgyy_stencil_1->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + -1)", "(lgyy_s0_x_x*3)");
+
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + 1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgyy_stencil_2 = lgyy_s0_x_x->add_op("op_hcompute_lgyy_stencil_2");
+  hcompute_lgyy_stencil_2->add_function("hcompute_lgyy_stencil_2");
+  hcompute_lgyy_stencil_2->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + -1)", "((lgyy_s0_x_x*3) + 1)");
+  auto lgyy_s0_x_x_1 = lgyy_s0_y_y->add_loop("lgyy_s0_x_x_1", 0, 20);
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + -1), (lgyy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgyy_stencil_3 = lgyy_s0_x_x_1->add_op("op_hcompute_lgyy_stencil_3");
+  hcompute_lgyy_stencil_3->add_function("hcompute_lgyy_stencil_3");
+  hcompute_lgyy_stencil_3->add_store("lgyy_stencil", "(lgyy_s0_y_y*3)", "((lgyy_s0_x_x_1*3) + -1)");
+
+//store is: lgyy.stencil((lgyy_s0_x_x_1*3), (lgyy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgyy_stencil_4 = lgyy_s0_x_x_1->add_op("op_hcompute_lgyy_stencil_4");
+  hcompute_lgyy_stencil_4->add_function("hcompute_lgyy_stencil_4");
+  hcompute_lgyy_stencil_4->add_store("lgyy_stencil", "(lgyy_s0_y_y*3)", "(lgyy_s0_x_x_1*3)");
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + 1), (lgyy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgyy_stencil_5 = lgyy_s0_x_x_1->add_op("op_hcompute_lgyy_stencil_5");
+  hcompute_lgyy_stencil_5->add_function("hcompute_lgyy_stencil_5");
+  hcompute_lgyy_stencil_5->add_store("lgyy_stencil", "(lgyy_s0_y_y*3)", "((lgyy_s0_x_x_1*3) + 1)");
+  auto lgyy_s0_x_x_2 = lgyy_s0_y_y->add_loop("lgyy_s0_x_x_2", 0, 20);
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + -1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgyy_stencil_6 = lgyy_s0_x_x_2->add_op("op_hcompute_lgyy_stencil_6");
+  hcompute_lgyy_stencil_6->add_function("hcompute_lgyy_stencil_6");
+  hcompute_lgyy_stencil_6->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + 1)", "((lgyy_s0_x_x_2*3) + -1)");
+
+//store is: lgyy.stencil((lgyy_s0_x_x_2*3), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgyy_stencil_7 = lgyy_s0_x_x_2->add_op("op_hcompute_lgyy_stencil_7");
+  hcompute_lgyy_stencil_7->add_function("hcompute_lgyy_stencil_7");
+  hcompute_lgyy_stencil_7->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + 1)", "(lgyy_s0_x_x_2*3)");
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + 1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgyy_stencil_8 = lgyy_s0_x_x_2->add_op("op_hcompute_lgyy_stencil_8");
+  hcompute_lgyy_stencil_8->add_function("hcompute_lgyy_stencil_8");
+  hcompute_lgyy_stencil_8->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + 1)", "((lgyy_s0_x_x_2*3) + 1)");
   auto lgyy_s1_y = prg.add_loop("lgyy_s1_y", -1, 59);
   auto lgyy_s1_x = lgyy_s1_y->add_loop("lgyy_s1_x", -1, 59);
   auto lgyy_s1_box_y = lgyy_s1_x->add_loop("lgyy_s1_box_y", -1, 2);
   auto lgyy_s1_box_x = lgyy_s1_box_y->add_loop("lgyy_s1_box_x", -1, 2);
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + lyy.stencil((lgyy_s1_box_x + lgyy_s1_x), (lgyy_s1_box_y + lgyy_s1_y)))
-  auto hcompute_lgyy_stencil_1 = lgyy_s1_box_x->add_op("op_hcompute_lgyy_stencil_1");
-  hcompute_lgyy_stencil_1->add_function("hcompute_lgyy_stencil_1");
-  hcompute_lgyy_stencil_1->add_load("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
-  hcompute_lgyy_stencil_1->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "(lgyy_s1_box_x + lgyy_s1_x)");
-  hcompute_lgyy_stencil_1->add_store("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
+  auto hcompute_lgyy_stencil_9 = lgyy_s1_box_x->add_op("op_hcompute_lgyy_stencil_9");
+  hcompute_lgyy_stencil_9->add_function("hcompute_lgyy_stencil_9");
+  hcompute_lgyy_stencil_9->add_load("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
+  hcompute_lgyy_stencil_9->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "(lgyy_s1_box_x + lgyy_s1_x)");
+  hcompute_lgyy_stencil_9->add_store("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
 
 //consuming lgyy.stencil
 ////producing cim.stencil
@@ -4452,8 +4578,6 @@ prog harris_sch4_1pp3c() {
   prg.buffer_port_widths["hw_output_stencil"] = 16;
 
 ////producing kernel_xa0
-  auto kernel_x_s0_y = prg.add_loop("kernel_x_s0_y", -1, 2);
-  auto kernel_x_s0_x = kernel_x_s0_y->add_loop("kernel_x_s0_x", -1, 2);
 
 //consuming kernel_xa0
 ////producing padded16_global_wrapper.stencil
@@ -4513,31 +4637,71 @@ prog harris_sch4_1pp3c() {
 
 //consuming lxx.stencil
 ////producing lgxx.stencil
-  auto lgxx_s0_y = prg.add_loop("lgxx_s0_y", -1, 59);
-  auto lgxx_s0_x = lgxx_s0_y->add_loop("lgxx_s0_x", -1, 59);
+  auto lgxx_s0_y_y = prg.add_loop("lgxx_s0_y_y", 0, 20);
+  auto lgxx_s0_x_x = lgxx_s0_y_y->add_loop("lgxx_s0_x_x", 0, 20);
 
-//store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
-  auto hcompute_lgxx_stencil = lgxx_s0_x->add_op("op_hcompute_lgxx_stencil");
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + -1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxx_stencil = lgxx_s0_x_x->add_op("op_hcompute_lgxx_stencil");
   hcompute_lgxx_stencil->add_function("hcompute_lgxx_stencil");
   prg.buffer_port_widths["lgxx_stencil"] = 16;
-  hcompute_lgxx_stencil->add_store("lgxx_stencil", "lgxx_s0_y", "lgxx_s0_x");
+  hcompute_lgxx_stencil->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + -1)", "((lgxx_s0_x_x*3) + -1)");
+
+//store is: lgxx.stencil((lgxx_s0_x_x*3), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxx_stencil_1 = lgxx_s0_x_x->add_op("op_hcompute_lgxx_stencil_1");
+  hcompute_lgxx_stencil_1->add_function("hcompute_lgxx_stencil_1");
+  hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + -1)", "(lgxx_s0_x_x*3)");
+
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + 1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxx_stencil_2 = lgxx_s0_x_x->add_op("op_hcompute_lgxx_stencil_2");
+  hcompute_lgxx_stencil_2->add_function("hcompute_lgxx_stencil_2");
+  hcompute_lgxx_stencil_2->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + -1)", "((lgxx_s0_x_x*3) + 1)");
+  auto lgxx_s0_x_x_1 = lgxx_s0_y_y->add_loop("lgxx_s0_x_x_1", 0, 20);
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + -1), (lgxx_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxx_stencil_3 = lgxx_s0_x_x_1->add_op("op_hcompute_lgxx_stencil_3");
+  hcompute_lgxx_stencil_3->add_function("hcompute_lgxx_stencil_3");
+  hcompute_lgxx_stencil_3->add_store("lgxx_stencil", "(lgxx_s0_y_y*3)", "((lgxx_s0_x_x_1*3) + -1)");
+
+//store is: lgxx.stencil((lgxx_s0_x_x_1*3), (lgxx_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxx_stencil_4 = lgxx_s0_x_x_1->add_op("op_hcompute_lgxx_stencil_4");
+  hcompute_lgxx_stencil_4->add_function("hcompute_lgxx_stencil_4");
+  hcompute_lgxx_stencil_4->add_store("lgxx_stencil", "(lgxx_s0_y_y*3)", "(lgxx_s0_x_x_1*3)");
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + 1), (lgxx_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxx_stencil_5 = lgxx_s0_x_x_1->add_op("op_hcompute_lgxx_stencil_5");
+  hcompute_lgxx_stencil_5->add_function("hcompute_lgxx_stencil_5");
+  hcompute_lgxx_stencil_5->add_store("lgxx_stencil", "(lgxx_s0_y_y*3)", "((lgxx_s0_x_x_1*3) + 1)");
+  auto lgxx_s0_x_x_2 = lgxx_s0_y_y->add_loop("lgxx_s0_x_x_2", 0, 20);
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + -1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxx_stencil_6 = lgxx_s0_x_x_2->add_op("op_hcompute_lgxx_stencil_6");
+  hcompute_lgxx_stencil_6->add_function("hcompute_lgxx_stencil_6");
+  hcompute_lgxx_stencil_6->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + 1)", "((lgxx_s0_x_x_2*3) + -1)");
+
+//store is: lgxx.stencil((lgxx_s0_x_x_2*3), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxx_stencil_7 = lgxx_s0_x_x_2->add_op("op_hcompute_lgxx_stencil_7");
+  hcompute_lgxx_stencil_7->add_function("hcompute_lgxx_stencil_7");
+  hcompute_lgxx_stencil_7->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + 1)", "(lgxx_s0_x_x_2*3)");
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + 1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxx_stencil_8 = lgxx_s0_x_x_2->add_op("op_hcompute_lgxx_stencil_8");
+  hcompute_lgxx_stencil_8->add_function("hcompute_lgxx_stencil_8");
+  hcompute_lgxx_stencil_8->add_store("lgxx_stencil", "((lgxx_s0_y_y*3) + 1)", "((lgxx_s0_x_x_2*3) + 1)");
   auto lgxx_s1_y = prg.add_loop("lgxx_s1_y", -1, 59);
   auto lgxx_s1_x = lgxx_s1_y->add_loop("lgxx_s1_x", -1, 59);
   auto lgxx_s1_box_y = lgxx_s1_x->add_loop("lgxx_s1_box_y", -1, 2);
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_box_y + lgxx_s1_y)) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_box_y + lgxx_s1_y)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_box_y + lgxx_s1_y)))))
-  auto hcompute_lgxx_stencil_1 = lgxx_s1_box_y->add_op("op_hcompute_lgxx_stencil_1");
-  hcompute_lgxx_stencil_1->add_function("hcompute_lgxx_stencil_1");
-  hcompute_lgxx_stencil_1->add_load("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
-  hcompute_lgxx_stencil_1->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "(lgxx_s1_x + -1)");
-  hcompute_lgxx_stencil_1->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "lgxx_s1_x");
-  hcompute_lgxx_stencil_1->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "(lgxx_s1_x + 1)");
-  hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
+  auto hcompute_lgxx_stencil_9 = lgxx_s1_box_y->add_op("op_hcompute_lgxx_stencil_9");
+  hcompute_lgxx_stencil_9->add_function("hcompute_lgxx_stencil_9");
+  hcompute_lgxx_stencil_9->add_load("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
+  hcompute_lgxx_stencil_9->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "(lgxx_s1_x + -1)");
+  hcompute_lgxx_stencil_9->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "lgxx_s1_x");
+  hcompute_lgxx_stencil_9->add_load("lxx_stencil", "(lgxx_s1_box_y + lgxx_s1_y)", "(lgxx_s1_x + 1)");
+  hcompute_lgxx_stencil_9->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
 
 //consuming lgxx.stencil
 ////producing kernel_ya1
-  auto kernel_y_s0_y = prg.add_loop("kernel_y_s0_y", -1, 2);
-  auto kernel_y_s0_x = kernel_y_s0_y->add_loop("kernel_y_s0_x", -1, 2);
 
 //consuming kernel_ya1
 ////producing grad_y.stencil
@@ -4586,26 +4750,68 @@ prog harris_sch4_1pp3c() {
 
 //consuming lxy.stencil
 ////producing lgxy.stencil
-  auto lgxy_s0_y = prg.add_loop("lgxy_s0_y", -1, 59);
-  auto lgxy_s0_x = lgxy_s0_y->add_loop("lgxy_s0_x", -1, 59);
+  auto lgxy_s0_y_y = prg.add_loop("lgxy_s0_y_y", 0, 20);
+  auto lgxy_s0_x_x = lgxy_s0_y_y->add_loop("lgxy_s0_x_x", 0, 20);
 
-//store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
-  auto hcompute_lgxy_stencil = lgxy_s0_x->add_op("op_hcompute_lgxy_stencil");
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + -1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxy_stencil = lgxy_s0_x_x->add_op("op_hcompute_lgxy_stencil");
   hcompute_lgxy_stencil->add_function("hcompute_lgxy_stencil");
   prg.buffer_port_widths["lgxy_stencil"] = 16;
-  hcompute_lgxy_stencil->add_store("lgxy_stencil", "lgxy_s0_y", "lgxy_s0_x");
+  hcompute_lgxy_stencil->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + -1)", "((lgxy_s0_x_x*3) + -1)");
+
+//store is: lgxy.stencil((lgxy_s0_x_x*3), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxy_stencil_1 = lgxy_s0_x_x->add_op("op_hcompute_lgxy_stencil_1");
+  hcompute_lgxy_stencil_1->add_function("hcompute_lgxy_stencil_1");
+  hcompute_lgxy_stencil_1->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + -1)", "(lgxy_s0_x_x*3)");
+
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + 1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgxy_stencil_2 = lgxy_s0_x_x->add_op("op_hcompute_lgxy_stencil_2");
+  hcompute_lgxy_stencil_2->add_function("hcompute_lgxy_stencil_2");
+  hcompute_lgxy_stencil_2->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + -1)", "((lgxy_s0_x_x*3) + 1)");
+  auto lgxy_s0_x_x_1 = lgxy_s0_y_y->add_loop("lgxy_s0_x_x_1", 0, 20);
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + -1), (lgxy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxy_stencil_3 = lgxy_s0_x_x_1->add_op("op_hcompute_lgxy_stencil_3");
+  hcompute_lgxy_stencil_3->add_function("hcompute_lgxy_stencil_3");
+  hcompute_lgxy_stencil_3->add_store("lgxy_stencil", "(lgxy_s0_y_y*3)", "((lgxy_s0_x_x_1*3) + -1)");
+
+//store is: lgxy.stencil((lgxy_s0_x_x_1*3), (lgxy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxy_stencil_4 = lgxy_s0_x_x_1->add_op("op_hcompute_lgxy_stencil_4");
+  hcompute_lgxy_stencil_4->add_function("hcompute_lgxy_stencil_4");
+  hcompute_lgxy_stencil_4->add_store("lgxy_stencil", "(lgxy_s0_y_y*3)", "(lgxy_s0_x_x_1*3)");
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + 1), (lgxy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgxy_stencil_5 = lgxy_s0_x_x_1->add_op("op_hcompute_lgxy_stencil_5");
+  hcompute_lgxy_stencil_5->add_function("hcompute_lgxy_stencil_5");
+  hcompute_lgxy_stencil_5->add_store("lgxy_stencil", "(lgxy_s0_y_y*3)", "((lgxy_s0_x_x_1*3) + 1)");
+  auto lgxy_s0_x_x_2 = lgxy_s0_y_y->add_loop("lgxy_s0_x_x_2", 0, 20);
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + -1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxy_stencil_6 = lgxy_s0_x_x_2->add_op("op_hcompute_lgxy_stencil_6");
+  hcompute_lgxy_stencil_6->add_function("hcompute_lgxy_stencil_6");
+  hcompute_lgxy_stencil_6->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + 1)", "((lgxy_s0_x_x_2*3) + -1)");
+
+//store is: lgxy.stencil((lgxy_s0_x_x_2*3), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxy_stencil_7 = lgxy_s0_x_x_2->add_op("op_hcompute_lgxy_stencil_7");
+  hcompute_lgxy_stencil_7->add_function("hcompute_lgxy_stencil_7");
+  hcompute_lgxy_stencil_7->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + 1)", "(lgxy_s0_x_x_2*3)");
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + 1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgxy_stencil_8 = lgxy_s0_x_x_2->add_op("op_hcompute_lgxy_stencil_8");
+  hcompute_lgxy_stencil_8->add_function("hcompute_lgxy_stencil_8");
+  hcompute_lgxy_stencil_8->add_store("lgxy_stencil", "((lgxy_s0_y_y*3) + 1)", "((lgxy_s0_x_x_2*3) + 1)");
   auto lgxy_s1_y = prg.add_loop("lgxy_s1_y", -1, 59);
   auto lgxy_s1_x = lgxy_s1_y->add_loop("lgxy_s1_x", -1, 59);
   auto lgxy_s1_box_y = lgxy_s1_x->add_loop("lgxy_s1_box_y", -1, 2);
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_box_y + lgxy_s1_y)) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_box_y + lgxy_s1_y)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_box_y + lgxy_s1_y)))))
-  auto hcompute_lgxy_stencil_1 = lgxy_s1_box_y->add_op("op_hcompute_lgxy_stencil_1");
-  hcompute_lgxy_stencil_1->add_function("hcompute_lgxy_stencil_1");
-  hcompute_lgxy_stencil_1->add_load("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
-  hcompute_lgxy_stencil_1->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "(lgxy_s1_x + -1)");
-  hcompute_lgxy_stencil_1->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "lgxy_s1_x");
-  hcompute_lgxy_stencil_1->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "(lgxy_s1_x + 1)");
-  hcompute_lgxy_stencil_1->add_store("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
+  auto hcompute_lgxy_stencil_9 = lgxy_s1_box_y->add_op("op_hcompute_lgxy_stencil_9");
+  hcompute_lgxy_stencil_9->add_function("hcompute_lgxy_stencil_9");
+  hcompute_lgxy_stencil_9->add_load("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
+  hcompute_lgxy_stencil_9->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "(lgxy_s1_x + -1)");
+  hcompute_lgxy_stencil_9->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "lgxy_s1_x");
+  hcompute_lgxy_stencil_9->add_load("lxy_stencil", "(lgxy_s1_box_y + lgxy_s1_y)", "(lgxy_s1_x + 1)");
+  hcompute_lgxy_stencil_9->add_store("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
 
 //consuming lgxy.stencil
 ////producing lyy.stencil
@@ -4621,26 +4827,68 @@ prog harris_sch4_1pp3c() {
 
 //consuming lyy.stencil
 ////producing lgyy.stencil
-  auto lgyy_s0_y = prg.add_loop("lgyy_s0_y", -1, 59);
-  auto lgyy_s0_x = lgyy_s0_y->add_loop("lgyy_s0_x", -1, 59);
+  auto lgyy_s0_y_y = prg.add_loop("lgyy_s0_y_y", 0, 20);
+  auto lgyy_s0_x_x = lgyy_s0_y_y->add_loop("lgyy_s0_x_x", 0, 20);
 
-//store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
-  auto hcompute_lgyy_stencil = lgyy_s0_x->add_op("op_hcompute_lgyy_stencil");
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + -1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgyy_stencil = lgyy_s0_x_x->add_op("op_hcompute_lgyy_stencil");
   hcompute_lgyy_stencil->add_function("hcompute_lgyy_stencil");
   prg.buffer_port_widths["lgyy_stencil"] = 16;
-  hcompute_lgyy_stencil->add_store("lgyy_stencil", "lgyy_s0_y", "lgyy_s0_x");
+  hcompute_lgyy_stencil->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + -1)", "((lgyy_s0_x_x*3) + -1)");
+
+//store is: lgyy.stencil((lgyy_s0_x_x*3), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgyy_stencil_1 = lgyy_s0_x_x->add_op("op_hcompute_lgyy_stencil_1");
+  hcompute_lgyy_stencil_1->add_function("hcompute_lgyy_stencil_1");
+  hcompute_lgyy_stencil_1->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + -1)", "(lgyy_s0_x_x*3)");
+
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + 1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+  auto hcompute_lgyy_stencil_2 = lgyy_s0_x_x->add_op("op_hcompute_lgyy_stencil_2");
+  hcompute_lgyy_stencil_2->add_function("hcompute_lgyy_stencil_2");
+  hcompute_lgyy_stencil_2->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + -1)", "((lgyy_s0_x_x*3) + 1)");
+  auto lgyy_s0_x_x_1 = lgyy_s0_y_y->add_loop("lgyy_s0_x_x_1", 0, 20);
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + -1), (lgyy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgyy_stencil_3 = lgyy_s0_x_x_1->add_op("op_hcompute_lgyy_stencil_3");
+  hcompute_lgyy_stencil_3->add_function("hcompute_lgyy_stencil_3");
+  hcompute_lgyy_stencil_3->add_store("lgyy_stencil", "(lgyy_s0_y_y*3)", "((lgyy_s0_x_x_1*3) + -1)");
+
+//store is: lgyy.stencil((lgyy_s0_x_x_1*3), (lgyy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgyy_stencil_4 = lgyy_s0_x_x_1->add_op("op_hcompute_lgyy_stencil_4");
+  hcompute_lgyy_stencil_4->add_function("hcompute_lgyy_stencil_4");
+  hcompute_lgyy_stencil_4->add_store("lgyy_stencil", "(lgyy_s0_y_y*3)", "(lgyy_s0_x_x_1*3)");
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + 1), (lgyy_s0_y_y*3)) = (int16)0
+  auto hcompute_lgyy_stencil_5 = lgyy_s0_x_x_1->add_op("op_hcompute_lgyy_stencil_5");
+  hcompute_lgyy_stencil_5->add_function("hcompute_lgyy_stencil_5");
+  hcompute_lgyy_stencil_5->add_store("lgyy_stencil", "(lgyy_s0_y_y*3)", "((lgyy_s0_x_x_1*3) + 1)");
+  auto lgyy_s0_x_x_2 = lgyy_s0_y_y->add_loop("lgyy_s0_x_x_2", 0, 20);
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + -1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgyy_stencil_6 = lgyy_s0_x_x_2->add_op("op_hcompute_lgyy_stencil_6");
+  hcompute_lgyy_stencil_6->add_function("hcompute_lgyy_stencil_6");
+  hcompute_lgyy_stencil_6->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + 1)", "((lgyy_s0_x_x_2*3) + -1)");
+
+//store is: lgyy.stencil((lgyy_s0_x_x_2*3), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgyy_stencil_7 = lgyy_s0_x_x_2->add_op("op_hcompute_lgyy_stencil_7");
+  hcompute_lgyy_stencil_7->add_function("hcompute_lgyy_stencil_7");
+  hcompute_lgyy_stencil_7->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + 1)", "(lgyy_s0_x_x_2*3)");
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + 1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+  auto hcompute_lgyy_stencil_8 = lgyy_s0_x_x_2->add_op("op_hcompute_lgyy_stencil_8");
+  hcompute_lgyy_stencil_8->add_function("hcompute_lgyy_stencil_8");
+  hcompute_lgyy_stencil_8->add_store("lgyy_stencil", "((lgyy_s0_y_y*3) + 1)", "((lgyy_s0_x_x_2*3) + 1)");
   auto lgyy_s1_y = prg.add_loop("lgyy_s1_y", -1, 59);
   auto lgyy_s1_x = lgyy_s1_y->add_loop("lgyy_s1_x", -1, 59);
   auto lgyy_s1_box_y = lgyy_s1_x->add_loop("lgyy_s1_box_y", -1, 2);
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_box_y + lgyy_s1_y)) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_box_y + lgyy_s1_y)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_box_y + lgyy_s1_y)))))
-  auto hcompute_lgyy_stencil_1 = lgyy_s1_box_y->add_op("op_hcompute_lgyy_stencil_1");
-  hcompute_lgyy_stencil_1->add_function("hcompute_lgyy_stencil_1");
-  hcompute_lgyy_stencil_1->add_load("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
-  hcompute_lgyy_stencil_1->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "(lgyy_s1_x + -1)");
-  hcompute_lgyy_stencil_1->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "lgyy_s1_x");
-  hcompute_lgyy_stencil_1->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "(lgyy_s1_x + 1)");
-  hcompute_lgyy_stencil_1->add_store("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
+  auto hcompute_lgyy_stencil_9 = lgyy_s1_box_y->add_op("op_hcompute_lgyy_stencil_9");
+  hcompute_lgyy_stencil_9->add_function("hcompute_lgyy_stencil_9");
+  hcompute_lgyy_stencil_9->add_load("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
+  hcompute_lgyy_stencil_9->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "(lgyy_s1_x + -1)");
+  hcompute_lgyy_stencil_9->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "lgyy_s1_x");
+  hcompute_lgyy_stencil_9->add_load("lyy_stencil", "(lgyy_s1_box_y + lgyy_s1_y)", "(lgyy_s1_x + 1)");
+  hcompute_lgyy_stencil_9->add_store("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
 
 //consuming lgyy.stencil
 ////producing cim.stencil

--- a/example_progs.cpp
+++ b/example_progs.cpp
@@ -5239,19 +5239,31 @@ prog harris_sch6_2ppc() {
   hcompute_grad_x_unclamp_stencil_1->add_function("hcompute_grad_x_unclamp_stencil_1");
   hcompute_grad_x_unclamp_stencil_1->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s0_y", "((grad_x_unclamp_s0_x_x*2) + -1)");
   auto grad_x_unclamp_s1_y = prg.add_loop("grad_x_unclamp_s1_y", -2, 60);
-  auto grad_x_unclamp_s1_x = grad_x_unclamp_s1_y->add_loop("grad_x_unclamp_s1_x", -2, 60);
+  auto grad_x_unclamp_s1_x_x = grad_x_unclamp_s1_y->add_loop("grad_x_unclamp_s1_x_x", 0, 31);
 
-//store is: grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + 1)))
-  auto hcompute_grad_x_unclamp_stencil_2 = grad_x_unclamp_s1_x->add_op("op_hcompute_grad_x_unclamp_stencil_2");
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + 1)))
+  auto hcompute_grad_x_unclamp_stencil_2 = grad_x_unclamp_s1_x_x->add_op("op_hcompute_grad_x_unclamp_stencil_2");
   hcompute_grad_x_unclamp_stencil_2->add_function("hcompute_grad_x_unclamp_stencil_2");
-  hcompute_grad_x_unclamp_stencil_2->add_load("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "grad_x_unclamp_s1_x");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "(grad_x_unclamp_s1_x + 1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "(grad_x_unclamp_s1_x + 1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "(grad_x_unclamp_s1_x + 1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "(grad_x_unclamp_s1_x + -1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "(grad_x_unclamp_s1_x + -1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "(grad_x_unclamp_s1_x + -1)");
-  hcompute_grad_x_unclamp_stencil_2->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "grad_x_unclamp_s1_x");
+  hcompute_grad_x_unclamp_stencil_2->add_load("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_x_unclamp_stencil_2->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -2)");
+
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1)))
+  auto hcompute_grad_x_unclamp_stencil_3 = grad_x_unclamp_s1_x_x->add_op("op_hcompute_grad_x_unclamp_stencil_3");
+  hcompute_grad_x_unclamp_stencil_3->add_function("hcompute_grad_x_unclamp_stencil_3");
+  hcompute_grad_x_unclamp_stencil_3->add_load("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "(grad_x_unclamp_s1_x_x*2)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "(grad_x_unclamp_s1_x_x*2)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "(grad_x_unclamp_s1_x_x*2)");
+  hcompute_grad_x_unclamp_stencil_3->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
 
 //consuming grad_x_unclamp.stencil
 ////producing lxx.stencil
@@ -5287,22 +5299,37 @@ prog harris_sch6_2ppc() {
   hcompute_lgxx_stencil_1->add_function("hcompute_lgxx_stencil_1");
   hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "lgxx_s0_y", "(lgxx_s0_x_x*2)");
   auto lgxx_s1_y = prg.add_loop("lgxx_s1_y", -1, 59);
-  auto lgxx_s1_x = lgxx_s1_y->add_loop("lgxx_s1_x", -1, 59);
+  auto lgxx_s1_x_x = lgxx_s1_y->add_loop("lgxx_s1_x_x", 0, 30);
 
-//store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + -1)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + -1), lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + 1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + 1)) + lxx.stencil(lgxx_s1_x, (lgxx_s1_y + 1)))))))))))
-  auto hcompute_lgxx_stencil_2 = lgxx_s1_x->add_op("op_hcompute_lgxx_stencil_2");
+//store is: lgxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) = (lxx.stencil(((lgxx_s1_x_x*2) + -2), (lgxx_s1_y + -1)) + (lgxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + -2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -2), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + 1)) + lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + 1)))))))))))
+  auto hcompute_lgxx_stencil_2 = lgxx_s1_x_x->add_op("op_hcompute_lgxx_stencil_2");
   hcompute_lgxx_stencil_2->add_function("hcompute_lgxx_stencil_2");
-  hcompute_lgxx_stencil_2->add_load("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "(lgxx_s1_x + -1)");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "lgxx_s1_x");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "(lgxx_s1_x + 1)");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "lgxx_s1_y", "(lgxx_s1_x + -1)");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "lgxx_s1_y", "(lgxx_s1_x + 1)");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "(lgxx_s1_x + -1)");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "(lgxx_s1_x + 1)");
-  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "lgxx_s1_x");
-  hcompute_lgxx_stencil_2->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
+  hcompute_lgxx_stencil_2->add_load("lgxx_stencil", "lgxx_s1_y", "((lgxx_s1_x_x*2) + -1)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "((lgxx_s1_x_x*2) + -2)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "((lgxx_s1_x_x*2) + -1)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "(lgxx_s1_x_x*2)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "lgxx_s1_y", "((lgxx_s1_x_x*2) + -2)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "lgxx_s1_y", "((lgxx_s1_x_x*2) + -1)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "lgxx_s1_y", "(lgxx_s1_x_x*2)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "((lgxx_s1_x_x*2) + -2)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "(lgxx_s1_x_x*2)");
+  hcompute_lgxx_stencil_2->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "((lgxx_s1_x_x*2) + -1)");
+  hcompute_lgxx_stencil_2->add_store("lgxx_stencil", "lgxx_s1_y", "((lgxx_s1_x_x*2) + -1)");
+
+//store is: lgxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) = (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + -1)) + (lgxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + 1)) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), (lgxx_s1_y + 1)) + lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + 1)))))))))))
+  auto hcompute_lgxx_stencil_3 = lgxx_s1_x_x->add_op("op_hcompute_lgxx_stencil_3");
+  hcompute_lgxx_stencil_3->add_function("hcompute_lgxx_stencil_3");
+  hcompute_lgxx_stencil_3->add_load("lgxx_stencil", "lgxx_s1_y", "(lgxx_s1_x_x*2)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "((lgxx_s1_x_x*2) + -1)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "(lgxx_s1_x_x*2)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "(lgxx_s1_y + -1)", "((lgxx_s1_x_x*2) + 1)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "lgxx_s1_y", "((lgxx_s1_x_x*2) + -1)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "lgxx_s1_y", "(lgxx_s1_x_x*2)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "lgxx_s1_y", "((lgxx_s1_x_x*2) + 1)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "((lgxx_s1_x_x*2) + -1)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "((lgxx_s1_x_x*2) + 1)");
+  hcompute_lgxx_stencil_3->add_load("lxx_stencil", "(lgxx_s1_y + 1)", "(lgxx_s1_x_x*2)");
+  hcompute_lgxx_stencil_3->add_store("lgxx_stencil", "lgxx_s1_y", "(lgxx_s1_x_x*2)");
 
 //consuming lgxx.stencil
 ////producing grad_y_unclamp.stencil
@@ -5320,19 +5347,31 @@ prog harris_sch6_2ppc() {
   hcompute_grad_y_unclamp_stencil_1->add_function("hcompute_grad_y_unclamp_stencil_1");
   hcompute_grad_y_unclamp_stencil_1->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s0_y", "((grad_y_unclamp_s0_x_x*2) + -1)");
   auto grad_y_unclamp_s1_y = prg.add_loop("grad_y_unclamp_s1_y", -2, 60);
-  auto grad_y_unclamp_s1_x = grad_y_unclamp_s1_y->add_loop("grad_y_unclamp_s1_x", -2, 60);
+  auto grad_y_unclamp_s1_x_x = grad_y_unclamp_s1_y->add_loop("grad_y_unclamp_s1_x_x", 0, 31);
 
-//store is: grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) = ((((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + -1)) + (grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + 1))) - (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + 1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + 1)))
-  auto hcompute_grad_y_unclamp_stencil_2 = grad_y_unclamp_s1_x->add_op("op_hcompute_grad_y_unclamp_stencil_2");
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1)))
+  auto hcompute_grad_y_unclamp_stencil_2 = grad_y_unclamp_s1_x_x->add_op("op_hcompute_grad_y_unclamp_stencil_2");
   hcompute_grad_y_unclamp_stencil_2->add_function("hcompute_grad_y_unclamp_stencil_2");
-  hcompute_grad_y_unclamp_stencil_2->add_load("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "grad_y_unclamp_s1_x");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "(grad_y_unclamp_s1_x + -1)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "grad_y_unclamp_s1_x");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "(grad_y_unclamp_s1_x + 1)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "(grad_y_unclamp_s1_x + -1)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "(grad_y_unclamp_s1_x + 1)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "grad_y_unclamp_s1_x");
-  hcompute_grad_y_unclamp_stencil_2->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "grad_y_unclamp_s1_x");
+  hcompute_grad_y_unclamp_stencil_2->add_load("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_y_unclamp_stencil_2->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -2)");
+
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + -1)))
+  auto hcompute_grad_y_unclamp_stencil_3 = grad_y_unclamp_s1_x_x->add_op("op_hcompute_grad_y_unclamp_stencil_3");
+  hcompute_grad_y_unclamp_stencil_3->add_function("hcompute_grad_y_unclamp_stencil_3");
+  hcompute_grad_y_unclamp_stencil_3->add_load("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "(grad_y_unclamp_s1_x_x*2)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "(grad_y_unclamp_s1_x_x*2)");
+  hcompute_grad_y_unclamp_stencil_3->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -1)");
 
 //consuming grad_y_unclamp.stencil
 ////producing lxy.stencil
@@ -5370,22 +5409,37 @@ prog harris_sch6_2ppc() {
   hcompute_lgxy_stencil_1->add_function("hcompute_lgxy_stencil_1");
   hcompute_lgxy_stencil_1->add_store("lgxy_stencil", "lgxy_s0_y", "(lgxy_s0_x_x*2)");
   auto lgxy_s1_y = prg.add_loop("lgxy_s1_y", -1, 59);
-  auto lgxy_s1_x = lgxy_s1_y->add_loop("lgxy_s1_x", -1, 59);
+  auto lgxy_s1_x_x = lgxy_s1_y->add_loop("lgxy_s1_x_x", 0, 30);
 
-//store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + -1)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + -1), lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + 1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + 1)) + lxy.stencil(lgxy_s1_x, (lgxy_s1_y + 1)))))))))))
-  auto hcompute_lgxy_stencil_2 = lgxy_s1_x->add_op("op_hcompute_lgxy_stencil_2");
+//store is: lgxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) = (lxy.stencil(((lgxy_s1_x_x*2) + -2), (lgxy_s1_y + -1)) + (lgxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + -2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -2), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + 1)) + lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + 1)))))))))))
+  auto hcompute_lgxy_stencil_2 = lgxy_s1_x_x->add_op("op_hcompute_lgxy_stencil_2");
   hcompute_lgxy_stencil_2->add_function("hcompute_lgxy_stencil_2");
-  hcompute_lgxy_stencil_2->add_load("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "(lgxy_s1_x + -1)");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "lgxy_s1_x");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "(lgxy_s1_x + 1)");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "lgxy_s1_y", "(lgxy_s1_x + -1)");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "lgxy_s1_y", "(lgxy_s1_x + 1)");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "(lgxy_s1_x + -1)");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "(lgxy_s1_x + 1)");
-  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "lgxy_s1_x");
-  hcompute_lgxy_stencil_2->add_store("lgxy_stencil", "lgxy_s1_y", "lgxy_s1_x");
+  hcompute_lgxy_stencil_2->add_load("lgxy_stencil", "lgxy_s1_y", "((lgxy_s1_x_x*2) + -1)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "((lgxy_s1_x_x*2) + -2)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "((lgxy_s1_x_x*2) + -1)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "(lgxy_s1_x_x*2)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "lgxy_s1_y", "((lgxy_s1_x_x*2) + -2)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "lgxy_s1_y", "((lgxy_s1_x_x*2) + -1)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "lgxy_s1_y", "(lgxy_s1_x_x*2)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "((lgxy_s1_x_x*2) + -2)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "(lgxy_s1_x_x*2)");
+  hcompute_lgxy_stencil_2->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "((lgxy_s1_x_x*2) + -1)");
+  hcompute_lgxy_stencil_2->add_store("lgxy_stencil", "lgxy_s1_y", "((lgxy_s1_x_x*2) + -1)");
+
+//store is: lgxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) = (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + -1)) + (lgxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + 1)) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), (lgxy_s1_y + 1)) + lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + 1)))))))))))
+  auto hcompute_lgxy_stencil_3 = lgxy_s1_x_x->add_op("op_hcompute_lgxy_stencil_3");
+  hcompute_lgxy_stencil_3->add_function("hcompute_lgxy_stencil_3");
+  hcompute_lgxy_stencil_3->add_load("lgxy_stencil", "lgxy_s1_y", "(lgxy_s1_x_x*2)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "((lgxy_s1_x_x*2) + -1)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "(lgxy_s1_x_x*2)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "(lgxy_s1_y + -1)", "((lgxy_s1_x_x*2) + 1)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "lgxy_s1_y", "((lgxy_s1_x_x*2) + -1)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "lgxy_s1_y", "(lgxy_s1_x_x*2)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "lgxy_s1_y", "((lgxy_s1_x_x*2) + 1)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "((lgxy_s1_x_x*2) + -1)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "((lgxy_s1_x_x*2) + 1)");
+  hcompute_lgxy_stencil_3->add_load("lxy_stencil", "(lgxy_s1_y + 1)", "(lgxy_s1_x_x*2)");
+  hcompute_lgxy_stencil_3->add_store("lgxy_stencil", "lgxy_s1_y", "(lgxy_s1_x_x*2)");
 
 //consuming lgxy.stencil
 ////producing lyy.stencil
@@ -5421,22 +5475,37 @@ prog harris_sch6_2ppc() {
   hcompute_lgyy_stencil_1->add_function("hcompute_lgyy_stencil_1");
   hcompute_lgyy_stencil_1->add_store("lgyy_stencil", "lgyy_s0_y", "(lgyy_s0_x_x*2)");
   auto lgyy_s1_y = prg.add_loop("lgyy_s1_y", -1, 59);
-  auto lgyy_s1_x = lgyy_s1_y->add_loop("lgyy_s1_x", -1, 59);
+  auto lgyy_s1_x_x = lgyy_s1_y->add_loop("lgyy_s1_x_x", 0, 30);
 
-//store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + -1)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + -1), lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + 1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + 1)) + lyy.stencil(lgyy_s1_x, (lgyy_s1_y + 1)))))))))))
-  auto hcompute_lgyy_stencil_2 = lgyy_s1_x->add_op("op_hcompute_lgyy_stencil_2");
+//store is: lgyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) = (lyy.stencil(((lgyy_s1_x_x*2) + -2), (lgyy_s1_y + -1)) + (lgyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + -2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -2), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + 1)) + lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + 1)))))))))))
+  auto hcompute_lgyy_stencil_2 = lgyy_s1_x_x->add_op("op_hcompute_lgyy_stencil_2");
   hcompute_lgyy_stencil_2->add_function("hcompute_lgyy_stencil_2");
-  hcompute_lgyy_stencil_2->add_load("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "(lgyy_s1_x + -1)");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "lgyy_s1_x");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "(lgyy_s1_x + 1)");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "lgyy_s1_y", "(lgyy_s1_x + -1)");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "lgyy_s1_y", "(lgyy_s1_x + 1)");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "(lgyy_s1_x + -1)");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "(lgyy_s1_x + 1)");
-  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "lgyy_s1_x");
-  hcompute_lgyy_stencil_2->add_store("lgyy_stencil", "lgyy_s1_y", "lgyy_s1_x");
+  hcompute_lgyy_stencil_2->add_load("lgyy_stencil", "lgyy_s1_y", "((lgyy_s1_x_x*2) + -1)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "((lgyy_s1_x_x*2) + -2)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "((lgyy_s1_x_x*2) + -1)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "(lgyy_s1_x_x*2)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "lgyy_s1_y", "((lgyy_s1_x_x*2) + -2)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "lgyy_s1_y", "((lgyy_s1_x_x*2) + -1)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "lgyy_s1_y", "(lgyy_s1_x_x*2)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "((lgyy_s1_x_x*2) + -2)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "(lgyy_s1_x_x*2)");
+  hcompute_lgyy_stencil_2->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "((lgyy_s1_x_x*2) + -1)");
+  hcompute_lgyy_stencil_2->add_store("lgyy_stencil", "lgyy_s1_y", "((lgyy_s1_x_x*2) + -1)");
+
+//store is: lgyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) = (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + -1)) + (lgyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + 1)) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), (lgyy_s1_y + 1)) + lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + 1)))))))))))
+  auto hcompute_lgyy_stencil_3 = lgyy_s1_x_x->add_op("op_hcompute_lgyy_stencil_3");
+  hcompute_lgyy_stencil_3->add_function("hcompute_lgyy_stencil_3");
+  hcompute_lgyy_stencil_3->add_load("lgyy_stencil", "lgyy_s1_y", "(lgyy_s1_x_x*2)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "((lgyy_s1_x_x*2) + -1)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "(lgyy_s1_x_x*2)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "(lgyy_s1_y + -1)", "((lgyy_s1_x_x*2) + 1)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "lgyy_s1_y", "((lgyy_s1_x_x*2) + -1)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "lgyy_s1_y", "(lgyy_s1_x_x*2)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "lgyy_s1_y", "((lgyy_s1_x_x*2) + 1)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "((lgyy_s1_x_x*2) + -1)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "((lgyy_s1_x_x*2) + 1)");
+  hcompute_lgyy_stencil_3->add_load("lyy_stencil", "(lgyy_s1_y + 1)", "(lgyy_s1_x_x*2)");
+  hcompute_lgyy_stencil_3->add_store("lgyy_stencil", "lgyy_s1_y", "(lgyy_s1_x_x*2)");
 
 //consuming lgyy.stencil
 ////producing cim.stencil

--- a/harris_sch3_1pp9c_compute.h
+++ b/harris_sch3_1pp9c_compute.h
@@ -24,10 +24,15 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stenci
 
   int32_t _kernel_xa0[9];
   // produce kernel_xa0
-  int32_t _267 = _grad_x_unclamp_s1_r_y * 3;
-  int32_t _268 = _267 + 4;
-  int32_t _269 = _grad_x_unclamp_s1_r_x + _268;
-  _kernel_xa0[_269] = 0;
+  _kernel_xa0[0] = 0;
+  _kernel_xa0[1] = 0;
+  _kernel_xa0[2] = 0;
+  _kernel_xa0[3] = 0;
+  _kernel_xa0[4] = 0;
+  _kernel_xa0[5] = 0;
+  _kernel_xa0[6] = 0;
+  _kernel_xa0[7] = 0;
+  _kernel_xa0[8] = 0;
   _kernel_xa0[0] = -1;
   _kernel_xa0[3] = -2;
   _kernel_xa0[6] = -1;
@@ -35,57 +40,105 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stenci
   _kernel_xa0[5] = 2;
   _kernel_xa0[8] = 1;
 
-  int32_t _270 = _grad_x_unclamp_s1_r_y * 3;
-  int32_t _271 = _270 + 4;
-  int32_t _272 = _grad_x_unclamp_s1_r_x + _271;
-  int32_t _273 = ((const int32_t *)_kernel_xa0)[_272];
-  int16_t _274 = (int16_t)(_273);
-  int16_t _275 = _padded16_global_wrapper_stencil_1 * _274;
-  int16_t _276 = _grad_x_unclamp_stencil_1 + _275;
-  return _276;
+  int32_t _264 = _grad_x_unclamp_s1_r_y * 3;
+  int32_t _265 = _264 + 4;
+  int32_t _266 = _grad_x_unclamp_s1_r_x + _265;
+  int32_t _267 = ((const int32_t *)_kernel_xa0)[_266];
+  int16_t _268 = (int16_t)(_267);
+  int16_t _269 = _padded16_global_wrapper_stencil_1 * _268;
+  int16_t _270 = _grad_x_unclamp_stencil_1 + _269;
+  return _270;
 }
 
 //store is: grad_x.stencil(grad_x_s0_x, grad_x_s0_y) = max(min(grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y), (int16)255), (int16)-255)
 hw_uint<16> hcompute_grad_x_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _295 = (int16_t)(255);
-  int16_t _296 = min(_grad_x_unclamp_stencil_2, _295);
-  int16_t _297 = (int16_t)(-255);
-  int16_t _298 = max(_296, _297);
-  return _298;
+  int16_t _289 = (int16_t)(255);
+  int16_t _290 = min(_grad_x_unclamp_stencil_2, _289);
+  int16_t _291 = (int16_t)(-255);
+  int16_t _292 = max(_290, _291);
+  return _292;
 }
 
 //store is: lxx.stencil(lxx_s0_x, lxx_s0_y) = ((grad_x.stencil(lxx_s0_x, lxx_s0_y)*grad_x.stencil(lxx_s0_x, lxx_s0_y))/(int16)128)
 hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_stencil) {
   int16_t _grad_x_stencil_1 = (int16_t) grad_x_stencil.extract<0, 15>();
 
-  int16_t _308 = _grad_x_stencil_1 * _grad_x_stencil_1;
-  int16_t _309 = (int16_t)(7);
-  int16_t _310 = _308 >> _309;
-  return _310;
+  int16_t _302 = _grad_x_stencil_1 * _grad_x_stencil_1;
+  int16_t _303 = (int16_t)(7);
+  int16_t _304 = _302 >> _303;
+  return _304;
 }
 
-//store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + -1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _318 = (int16_t)(0);
-  return _318;
+  int16_t _312 = (int16_t)(0);
+  return _312;
+}
+
+//store is: lgxx.stencil((lgxx_s0_x_x*3), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_1() {
+  int16_t _319 = (int16_t)(0);
+  return _319;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + 1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_2() {
+  int16_t _325 = (int16_t)(0);
+  return _325;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + -1), (lgxx_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_3() {
+  int16_t _332 = (int16_t)(0);
+  return _332;
+}
+
+//store is: lgxx.stencil((lgxx_s0_x_x_1*3), (lgxx_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_4() {
+  int16_t _338 = (int16_t)(0);
+  return _338;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + 1), (lgxx_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_5() {
+  int16_t _343 = (int16_t)(0);
+  return _343;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + -1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_6() {
+  int16_t _349 = (int16_t)(0);
+  return _349;
+}
+
+//store is: lgxx.stencil((lgxx_s0_x_x_2*3), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_7() {
+  int16_t _356 = (int16_t)(0);
+  return _356;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + 1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_8() {
+  int16_t _362 = (int16_t)(0);
+  return _362;
 }
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + lxx.stencil((lgxx_s1_box_x + lgxx_s1_x), (lgxx_s1_box_y + lgxx_s1_y)))
-hw_uint<16> hcompute_lgxx_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<16>& lxx_stencil) {
+hw_uint<16> hcompute_lgxx_stencil_9(hw_uint<16>& lgxx_stencil, hw_uint<16>& lxx_stencil) {
   int16_t _lgxx_stencil_1 = (int16_t) lgxx_stencil.extract<0, 15>();
 
   int16_t _lxx_stencil_1 = (int16_t) lxx_stencil.extract<0, 15>();
 
-  int16_t _321 = _lgxx_stencil_1 + _lxx_stencil_1;
-  return _321;
+  int16_t _369 = _lgxx_stencil_1 + _lxx_stencil_1;
+  return _369;
 }
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil() {
-  int16_t _328 = (int16_t)(0);
-  return _328;
+  int16_t _376 = (int16_t)(0);
+  return _376;
 }
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + grad_y_unclamp_s1_r_x), (grad_y_s0_y + grad_y_unclamp_s1_r_y))*int16(kernel_ya1[(grad_y_unclamp_s1_r_x + ((grad_y_unclamp_s1_r_y*3) + 4))])))
@@ -96,36 +149,41 @@ hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stenci
 
   int32_t _kernel_ya1[9];
   // produce kernel_ya1
-  int32_t _334 = _grad_y_unclamp_s1_r_y * 3;
-  int32_t _335 = _334 + 4;
-  int32_t _336 = _grad_y_unclamp_s1_r_x + _335;
-  _kernel_ya1[_336] = 0;
-  _kernel_ya1[6] = -1;
-  _kernel_ya1[7] = -2;
-  _kernel_ya1[8] = -1;
-  _kernel_ya1[0] = 1;
-  _kernel_ya1[1] = 2;
-  _kernel_ya1[2] = 1;
+  _kernel_ya1[0] = 0;
+  _kernel_ya1[1] = 0;
+  _kernel_ya1[2] = 0;
+  _kernel_ya1[3] = 0;
+  _kernel_ya1[4] = 0;
+  _kernel_ya1[5] = 0;
+  _kernel_ya1[6] = 0;
+  _kernel_ya1[7] = 0;
+  _kernel_ya1[8] = 0;
+  _kernel_ya1[6] = 1;
+  _kernel_ya1[7] = 2;
+  _kernel_ya1[8] = 1;
+  _kernel_ya1[0] = -1;
+  _kernel_ya1[1] = -2;
+  _kernel_ya1[2] = -1;
 
-  int32_t _337 = _grad_y_unclamp_s1_r_y * 3;
-  int32_t _338 = _337 + 4;
-  int32_t _339 = _grad_y_unclamp_s1_r_x + _338;
-  int32_t _340 = ((const int32_t *)_kernel_ya1)[_339];
-  int16_t _341 = (int16_t)(_340);
-  int16_t _342 = _padded16_global_wrapper_stencil_2 * _341;
-  int16_t _343 = _grad_y_unclamp_stencil_1 + _342;
-  return _343;
+  int32_t _379 = _grad_y_unclamp_s1_r_y * 3;
+  int32_t _380 = _379 + 4;
+  int32_t _381 = _grad_y_unclamp_s1_r_x + _380;
+  int32_t _382 = ((const int32_t *)_kernel_ya1)[_381];
+  int16_t _383 = (int16_t)(_382);
+  int16_t _384 = _padded16_global_wrapper_stencil_2 * _383;
+  int16_t _385 = _grad_y_unclamp_stencil_1 + _384;
+  return _385;
 }
 
 //store is: grad_y.stencil(grad_y_s0_x, grad_y_s0_y) = max(min(grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y), (int16)255), (int16)-255)
 hw_uint<16> hcompute_grad_y_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _362 = (int16_t)(255);
-  int16_t _363 = min(_grad_y_unclamp_stencil_2, _362);
-  int16_t _364 = (int16_t)(-255);
-  int16_t _365 = max(_363, _364);
-  return _365;
+  int16_t _404 = (int16_t)(255);
+  int16_t _405 = min(_grad_y_unclamp_stencil_2, _404);
+  int16_t _406 = (int16_t)(-255);
+  int16_t _407 = max(_405, _406);
+  return _407;
 }
 
 //store is: lxy.stencil(lxy_s0_x, lxy_s0_y) = ((grad_x.stencil(lxy_s0_x, lxy_s0_y)*grad_y.stencil(lxy_s0_x, lxy_s0_y))/(int16)128)
@@ -134,52 +192,148 @@ hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_stencil, hw_uint<16>& grad_
 
   int16_t _grad_y_stencil_1 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _375 = _grad_x_stencil_2 * _grad_y_stencil_1;
-  int16_t _376 = (int16_t)(7);
-  int16_t _377 = _375 >> _376;
-  return _377;
+  int16_t _417 = _grad_x_stencil_2 * _grad_y_stencil_1;
+  int16_t _418 = (int16_t)(7);
+  int16_t _419 = _417 >> _418;
+  return _419;
 }
 
-//store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + -1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _386 = (int16_t)(0);
-  return _386;
+  int16_t _428 = (int16_t)(0);
+  return _428;
+}
+
+//store is: lgxy.stencil((lgxy_s0_x_x*3), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_1() {
+  int16_t _435 = (int16_t)(0);
+  return _435;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + 1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_2() {
+  int16_t _441 = (int16_t)(0);
+  return _441;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + -1), (lgxy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_3() {
+  int16_t _448 = (int16_t)(0);
+  return _448;
+}
+
+//store is: lgxy.stencil((lgxy_s0_x_x_1*3), (lgxy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_4() {
+  int16_t _454 = (int16_t)(0);
+  return _454;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + 1), (lgxy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_5() {
+  int16_t _459 = (int16_t)(0);
+  return _459;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + -1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_6() {
+  int16_t _465 = (int16_t)(0);
+  return _465;
+}
+
+//store is: lgxy.stencil((lgxy_s0_x_x_2*3), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_7() {
+  int16_t _472 = (int16_t)(0);
+  return _472;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + 1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_8() {
+  int16_t _478 = (int16_t)(0);
+  return _478;
 }
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + lxy.stencil((lgxy_s1_box_x + lgxy_s1_x), (lgxy_s1_box_y + lgxy_s1_y)))
-hw_uint<16> hcompute_lgxy_stencil_1(hw_uint<16>& lgxy_stencil, hw_uint<16>& lxy_stencil) {
+hw_uint<16> hcompute_lgxy_stencil_9(hw_uint<16>& lgxy_stencil, hw_uint<16>& lxy_stencil) {
   int16_t _lgxy_stencil_1 = (int16_t) lgxy_stencil.extract<0, 15>();
 
   int16_t _lxy_stencil_1 = (int16_t) lxy_stencil.extract<0, 15>();
 
-  int16_t _389 = _lgxy_stencil_1 + _lxy_stencil_1;
-  return _389;
+  int16_t _485 = _lgxy_stencil_1 + _lxy_stencil_1;
+  return _485;
 }
 
 //store is: lyy.stencil(lyy_s0_x, lyy_s0_y) = ((grad_y.stencil(lyy_s0_x, lyy_s0_y)*grad_y.stencil(lyy_s0_x, lyy_s0_y))/(int16)128)
 hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_stencil) {
   int16_t _grad_y_stencil_2 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _396 = _grad_y_stencil_2 * _grad_y_stencil_2;
-  int16_t _397 = (int16_t)(7);
-  int16_t _398 = _396 >> _397;
-  return _398;
+  int16_t _492 = _grad_y_stencil_2 * _grad_y_stencil_2;
+  int16_t _493 = (int16_t)(7);
+  int16_t _494 = _492 >> _493;
+  return _494;
 }
 
-//store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + -1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _406 = (int16_t)(0);
-  return _406;
+  int16_t _502 = (int16_t)(0);
+  return _502;
+}
+
+//store is: lgyy.stencil((lgyy_s0_x_x*3), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_1() {
+  int16_t _509 = (int16_t)(0);
+  return _509;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + 1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_2() {
+  int16_t _515 = (int16_t)(0);
+  return _515;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + -1), (lgyy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_3() {
+  int16_t _522 = (int16_t)(0);
+  return _522;
+}
+
+//store is: lgyy.stencil((lgyy_s0_x_x_1*3), (lgyy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_4() {
+  int16_t _528 = (int16_t)(0);
+  return _528;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + 1), (lgyy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_5() {
+  int16_t _533 = (int16_t)(0);
+  return _533;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + -1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_6() {
+  int16_t _539 = (int16_t)(0);
+  return _539;
+}
+
+//store is: lgyy.stencil((lgyy_s0_x_x_2*3), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_7() {
+  int16_t _546 = (int16_t)(0);
+  return _546;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + 1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_8() {
+  int16_t _552 = (int16_t)(0);
+  return _552;
 }
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + lyy.stencil((lgyy_s1_box_x + lgyy_s1_x), (lgyy_s1_box_y + lgyy_s1_y)))
-hw_uint<16> hcompute_lgyy_stencil_1(hw_uint<16>& lgyy_stencil, hw_uint<16>& lyy_stencil) {
+hw_uint<16> hcompute_lgyy_stencil_9(hw_uint<16>& lgyy_stencil, hw_uint<16>& lyy_stencil) {
   int16_t _lgyy_stencil_1 = (int16_t) lgyy_stencil.extract<0, 15>();
 
   int16_t _lyy_stencil_1 = (int16_t) lyy_stencil.extract<0, 15>();
 
-  int16_t _409 = _lgyy_stencil_1 + _lyy_stencil_1;
-  return _409;
+  int16_t _559 = _lgyy_stencil_1 + _lyy_stencil_1;
+  return _559;
 }
 
 //store is: cim.stencil(cim_s0_x, cim_s0_y) = ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)) - ((lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64))) - ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64))*((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)))/(int16)16))
@@ -190,19 +344,19 @@ hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_st
 
   int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _416 = (int16_t)(6);
-  int16_t _417 = _lgxx_stencil_2 >> _416;
-  int16_t _418 = _lgyy_stencil_2 >> _416;
-  int16_t _419 = _417 * _418;
-  int16_t _420 = _lgxy_stencil_2 >> _416;
-  int16_t _421 = _420 * _420;
-  int16_t _422 = _419 - _421;
-  int16_t _423 = _417 + _418;
-  int16_t _424 = _423 * _423;
-  int16_t _425 = (int16_t)(4);
-  int16_t _426 = _424 >> _425;
-  int16_t _427 = _422 - _426;
-  return _427;
+  int16_t _566 = (int16_t)(6);
+  int16_t _567 = _lgxx_stencil_2 >> _566;
+  int16_t _568 = _lgyy_stencil_2 >> _566;
+  int16_t _569 = _567 * _568;
+  int16_t _570 = _lgxy_stencil_2 >> _566;
+  int16_t _571 = _570 * _570;
+  int16_t _572 = _569 - _571;
+  int16_t _573 = _567 + _568;
+  int16_t _574 = _573 * _573;
+  int16_t _575 = (int16_t)(4);
+  int16_t _576 = _574 >> _575;
+  int16_t _577 = _572 - _576;
+  return _577;
 }
 
 //store is: cim_output.stencil(cim_output_s0_x, cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y)) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && ((int16)1 <= cim.stencil(cim_output_s0_x, cim_output_s0_y))), 255, 0))
@@ -217,27 +371,27 @@ hw_uint<16> hcompute_cim_output_stencil(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_8 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_9 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _455 = _cim_stencil_1 < _cim_stencil_2;
-  bool _456 = _cim_stencil_3 < _cim_stencil_2;
-  bool _457 = _455 && _456;
-  bool _458 = _cim_stencil_4 < _cim_stencil_2;
-  bool _459 = _457 && _458;
-  bool _460 = _cim_stencil_5 < _cim_stencil_2;
-  bool _461 = _459 && _460;
-  bool _462 = _cim_stencil_6 < _cim_stencil_2;
-  bool _463 = _461 && _462;
-  bool _464 = _cim_stencil_7 < _cim_stencil_2;
-  bool _465 = _463 && _464;
-  bool _466 = _cim_stencil_8 < _cim_stencil_2;
-  bool _467 = _465 && _466;
-  bool _468 = _cim_stencil_9 < _cim_stencil_2;
-  bool _469 = _467 && _468;
-  int16_t _470 = (int16_t)(1);
-  bool _471 = _470 <= _cim_stencil_2;
-  bool _472 = _469 && _471;
-  int32_t _473 = (int32_t)(_472 ? 255 : 0);
-  int16_t _474 = (int16_t)(_473);
-  return _474;
+  bool _605 = _cim_stencil_1 < _cim_stencil_2;
+  bool _606 = _cim_stencil_3 < _cim_stencil_2;
+  bool _607 = _605 && _606;
+  bool _608 = _cim_stencil_4 < _cim_stencil_2;
+  bool _609 = _607 && _608;
+  bool _610 = _cim_stencil_5 < _cim_stencil_2;
+  bool _611 = _609 && _610;
+  bool _612 = _cim_stencil_6 < _cim_stencil_2;
+  bool _613 = _611 && _612;
+  bool _614 = _cim_stencil_7 < _cim_stencil_2;
+  bool _615 = _613 && _614;
+  bool _616 = _cim_stencil_8 < _cim_stencil_2;
+  bool _617 = _615 && _616;
+  bool _618 = _cim_stencil_9 < _cim_stencil_2;
+  bool _619 = _617 && _618;
+  int16_t _620 = (int16_t)(1);
+  bool _621 = _620 <= _cim_stencil_2;
+  bool _622 = _619 && _621;
+  int32_t _623 = (int32_t)(_622 ? 255 : 0);
+  int16_t _624 = (int16_t)(_623);
+  return _624;
 }
 
 //store is: hw_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi) = cim_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi)

--- a/harris_sch4_1pp3c_compute.h
+++ b/harris_sch4_1pp3c_compute.h
@@ -12,8 +12,8 @@ hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stenc
 
 //store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_x_unclamp_stencil() {
-  int16_t _264 = (int16_t)(0);
-  return _264;
+  int16_t _261 = (int16_t)(0);
+  return _261;
 }
 
 //store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + grad_x_unclamp_s1_r_y))*int16(kernel_xa0[((grad_x_unclamp_s1_r_y*3) + 3)])) + ((padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + grad_x_unclamp_s1_r_y))*int16(kernel_xa0[((grad_x_unclamp_s1_r_y*3) + 4)])) + (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + grad_x_unclamp_s1_r_y))*int16(kernel_xa0[((grad_x_unclamp_s1_r_y*3) + 5)])))))
@@ -26,16 +26,15 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stenci
 
   int32_t _kernel_xa0[9];
   // produce kernel_xa0
-  for (int _kernel_x_s0_y = -1; _kernel_x_s0_y < -1 + 3; _kernel_x_s0_y++)
-  {
-   for (int _kernel_x_s0_x = -1; _kernel_x_s0_x < -1 + 3; _kernel_x_s0_x++)
-   {
-    int32_t _267 = _kernel_x_s0_y * 3;
-    int32_t _268 = _267 + 4;
-    int32_t _269 = _kernel_x_s0_x + _268;
-    _kernel_xa0[_269] = 0;
-   } // for _kernel_x_s0_x
-  } // for _kernel_x_s0_y
+  _kernel_xa0[0] = 0;
+  _kernel_xa0[1] = 0;
+  _kernel_xa0[2] = 0;
+  _kernel_xa0[3] = 0;
+  _kernel_xa0[4] = 0;
+  _kernel_xa0[5] = 0;
+  _kernel_xa0[6] = 0;
+  _kernel_xa0[7] = 0;
+  _kernel_xa0[8] = 0;
   _kernel_xa0[0] = -1;
   _kernel_xa0[3] = -2;
   _kernel_xa0[6] = -1;
@@ -43,70 +42,118 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stenci
   _kernel_xa0[5] = 2;
   _kernel_xa0[8] = 1;
 
-  int32_t _276 = _grad_x_unclamp_s1_r_y * 3;
-  int32_t _277 = _276 + 3;
-  int32_t _278 = ((const int32_t *)_kernel_xa0)[_277];
-  int16_t _279 = (int16_t)(_278);
-  int16_t _280 = _padded16_global_wrapper_stencil_1 * _279;
-  int32_t _281 = _276 + 4;
-  int32_t _282 = ((const int32_t *)_kernel_xa0)[_281];
-  int16_t _283 = (int16_t)(_282);
-  int16_t _284 = _padded16_global_wrapper_stencil_2 * _283;
-  int32_t _285 = _276 + 5;
-  int32_t _286 = ((const int32_t *)_kernel_xa0)[_285];
-  int16_t _287 = (int16_t)(_286);
-  int16_t _288 = _padded16_global_wrapper_stencil_3 * _287;
-  int16_t _289 = _grad_x_unclamp_stencil_1 + _288;
-  int16_t _290 = _284 + _289;
-  int16_t _291 = _280 + _290;
-  return _291;
+  int32_t _264 = _grad_x_unclamp_s1_r_y * 3;
+  int32_t _265 = _264 + 3;
+  int32_t _266 = ((const int32_t *)_kernel_xa0)[_265];
+  int16_t _267 = (int16_t)(_266);
+  int16_t _268 = _padded16_global_wrapper_stencil_1 * _267;
+  int32_t _269 = _264 + 4;
+  int32_t _270 = ((const int32_t *)_kernel_xa0)[_269];
+  int16_t _271 = (int16_t)(_270);
+  int16_t _272 = _padded16_global_wrapper_stencil_2 * _271;
+  int32_t _273 = _264 + 5;
+  int32_t _274 = ((const int32_t *)_kernel_xa0)[_273];
+  int16_t _275 = (int16_t)(_274);
+  int16_t _276 = _padded16_global_wrapper_stencil_3 * _275;
+  int16_t _277 = _grad_x_unclamp_stencil_1 + _276;
+  int16_t _278 = _272 + _277;
+  int16_t _279 = _268 + _278;
+  return _279;
 }
 
 //store is: grad_x.stencil(grad_x_s0_x, grad_x_s0_y) = max(min(grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y), (int16)255), (int16)-255)
 hw_uint<16> hcompute_grad_x_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _331 = (int16_t)(255);
-  int16_t _332 = min(_grad_x_unclamp_stencil_2, _331);
-  int16_t _333 = (int16_t)(-255);
-  int16_t _334 = max(_332, _333);
-  return _334;
+  int16_t _319 = (int16_t)(255);
+  int16_t _320 = min(_grad_x_unclamp_stencil_2, _319);
+  int16_t _321 = (int16_t)(-255);
+  int16_t _322 = max(_320, _321);
+  return _322;
 }
 
 //store is: lxx.stencil(lxx_s0_x, lxx_s0_y) = ((grad_x.stencil(lxx_s0_x, lxx_s0_y)*grad_x.stencil(lxx_s0_x, lxx_s0_y))/(int16)128)
 hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_stencil) {
   int16_t _grad_x_stencil_1 = (int16_t) grad_x_stencil.extract<0, 15>();
 
-  int16_t _344 = _grad_x_stencil_1 * _grad_x_stencil_1;
-  int16_t _345 = (int16_t)(7);
-  int16_t _346 = _344 >> _345;
-  return _346;
+  int16_t _332 = _grad_x_stencil_1 * _grad_x_stencil_1;
+  int16_t _333 = (int16_t)(7);
+  int16_t _334 = _332 >> _333;
+  return _334;
 }
 
-//store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + -1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _354 = (int16_t)(0);
-  return _354;
+  int16_t _342 = (int16_t)(0);
+  return _342;
+}
+
+//store is: lgxx.stencil((lgxx_s0_x_x*3), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_1() {
+  int16_t _349 = (int16_t)(0);
+  return _349;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x*3) + 1), ((lgxx_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_2() {
+  int16_t _355 = (int16_t)(0);
+  return _355;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + -1), (lgxx_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_3() {
+  int16_t _362 = (int16_t)(0);
+  return _362;
+}
+
+//store is: lgxx.stencil((lgxx_s0_x_x_1*3), (lgxx_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_4() {
+  int16_t _368 = (int16_t)(0);
+  return _368;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_1*3) + 1), (lgxx_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_5() {
+  int16_t _373 = (int16_t)(0);
+  return _373;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + -1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_6() {
+  int16_t _379 = (int16_t)(0);
+  return _379;
+}
+
+//store is: lgxx.stencil((lgxx_s0_x_x_2*3), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_7() {
+  int16_t _386 = (int16_t)(0);
+  return _386;
+}
+
+//store is: lgxx.stencil(((lgxx_s0_x_x_2*3) + 1), ((lgxx_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxx_stencil_8() {
+  int16_t _392 = (int16_t)(0);
+  return _392;
 }
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_box_y + lgxx_s1_y)) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_box_y + lgxx_s1_y)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_box_y + lgxx_s1_y)))))
-hw_uint<16> hcompute_lgxx_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<48>& lxx_stencil) {
+hw_uint<16> hcompute_lgxx_stencil_9(hw_uint<16>& lgxx_stencil, hw_uint<48>& lxx_stencil) {
   int16_t _lgxx_stencil_1 = (int16_t) lgxx_stencil.extract<0, 15>();
 
   int16_t _lxx_stencil_1 = (int16_t) lxx_stencil.extract<0, 15>();
   int16_t _lxx_stencil_2 = (int16_t) lxx_stencil.extract<16, 31>();
   int16_t _lxx_stencil_3 = (int16_t) lxx_stencil.extract<32, 47>();
 
-  int16_t _357 = _lgxx_stencil_1 + _lxx_stencil_3;
-  int16_t _358 = _lxx_stencil_2 + _357;
-  int16_t _359 = _lxx_stencil_1 + _358;
-  return _359;
+  int16_t _399 = _lgxx_stencil_1 + _lxx_stencil_3;
+  int16_t _400 = _lxx_stencil_2 + _399;
+  int16_t _401 = _lxx_stencil_1 + _400;
+  return _401;
 }
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil() {
-  int16_t _376 = (int16_t)(0);
-  return _376;
+  int16_t _415 = (int16_t)(0);
+  return _415;
 }
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + grad_y_unclamp_s1_r_y))*int16(kernel_ya1[((grad_y_unclamp_s1_r_y*3) + 3)])) + ((padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + grad_y_unclamp_s1_r_y))*int16(kernel_ya1[((grad_y_unclamp_s1_r_y*3) + 4)])) + (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + grad_y_unclamp_s1_r_y))*int16(kernel_ya1[((grad_y_unclamp_s1_r_y*3) + 5)])))))
@@ -119,51 +166,50 @@ hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stenci
 
   int32_t _kernel_ya1[9];
   // produce kernel_ya1
-  for (int _kernel_y_s0_y = -1; _kernel_y_s0_y < -1 + 3; _kernel_y_s0_y++)
-  {
-   for (int _kernel_y_s0_x = -1; _kernel_y_s0_x < -1 + 3; _kernel_y_s0_x++)
-   {
-    int32_t _379 = _kernel_y_s0_y * 3;
-    int32_t _380 = _379 + 4;
-    int32_t _381 = _kernel_y_s0_x + _380;
-    _kernel_ya1[_381] = 0;
-   } // for _kernel_y_s0_x
-  } // for _kernel_y_s0_y
-  _kernel_ya1[6] = -1;
-  _kernel_ya1[7] = -2;
-  _kernel_ya1[8] = -1;
-  _kernel_ya1[0] = 1;
-  _kernel_ya1[1] = 2;
-  _kernel_ya1[2] = 1;
+  _kernel_ya1[0] = 0;
+  _kernel_ya1[1] = 0;
+  _kernel_ya1[2] = 0;
+  _kernel_ya1[3] = 0;
+  _kernel_ya1[4] = 0;
+  _kernel_ya1[5] = 0;
+  _kernel_ya1[6] = 0;
+  _kernel_ya1[7] = 0;
+  _kernel_ya1[8] = 0;
+  _kernel_ya1[6] = 1;
+  _kernel_ya1[7] = 2;
+  _kernel_ya1[8] = 1;
+  _kernel_ya1[0] = -1;
+  _kernel_ya1[1] = -2;
+  _kernel_ya1[2] = -1;
 
-  int32_t _388 = _grad_y_unclamp_s1_r_y * 3;
-  int32_t _389 = _388 + 3;
-  int32_t _390 = ((const int32_t *)_kernel_ya1)[_389];
-  int16_t _391 = (int16_t)(_390);
-  int16_t _392 = _padded16_global_wrapper_stencil_4 * _391;
-  int32_t _393 = _388 + 4;
-  int32_t _394 = ((const int32_t *)_kernel_ya1)[_393];
-  int16_t _395 = (int16_t)(_394);
-  int16_t _396 = _padded16_global_wrapper_stencil_5 * _395;
-  int32_t _397 = _388 + 5;
-  int32_t _398 = ((const int32_t *)_kernel_ya1)[_397];
-  int16_t _399 = (int16_t)(_398);
-  int16_t _400 = _padded16_global_wrapper_stencil_6 * _399;
-  int16_t _401 = _grad_y_unclamp_stencil_1 + _400;
-  int16_t _402 = _396 + _401;
-  int16_t _403 = _392 + _402;
-  return _403;
+  int32_t _418 = _grad_y_unclamp_s1_r_y * 3;
+  int32_t _419 = _418 + 3;
+  int32_t _420 = ((const int32_t *)_kernel_ya1)[_419];
+  int16_t _421 = (int16_t)(_420);
+  int16_t _422 = _padded16_global_wrapper_stencil_4 * _421;
+  int32_t _423 = _418 + 4;
+  int32_t _424 = ((const int32_t *)_kernel_ya1)[_423];
+  int16_t _425 = (int16_t)(_424);
+  int16_t _426 = _padded16_global_wrapper_stencil_5 * _425;
+  int32_t _427 = _418 + 5;
+  int32_t _428 = ((const int32_t *)_kernel_ya1)[_427];
+  int16_t _429 = (int16_t)(_428);
+  int16_t _430 = _padded16_global_wrapper_stencil_6 * _429;
+  int16_t _431 = _grad_y_unclamp_stencil_1 + _430;
+  int16_t _432 = _426 + _431;
+  int16_t _433 = _422 + _432;
+  return _433;
 }
 
 //store is: grad_y.stencil(grad_y_s0_x, grad_y_s0_y) = max(min(grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y), (int16)255), (int16)-255)
 hw_uint<16> hcompute_grad_y_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _443 = (int16_t)(255);
-  int16_t _444 = min(_grad_y_unclamp_stencil_2, _443);
-  int16_t _445 = (int16_t)(-255);
-  int16_t _446 = max(_444, _445);
-  return _446;
+  int16_t _473 = (int16_t)(255);
+  int16_t _474 = min(_grad_y_unclamp_stencil_2, _473);
+  int16_t _475 = (int16_t)(-255);
+  int16_t _476 = max(_474, _475);
+  return _476;
 }
 
 //store is: lxy.stencil(lxy_s0_x, lxy_s0_y) = ((grad_x.stencil(lxy_s0_x, lxy_s0_y)*grad_y.stencil(lxy_s0_x, lxy_s0_y))/(int16)128)
@@ -172,60 +218,156 @@ hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_stencil, hw_uint<16>& grad_
 
   int16_t _grad_y_stencil_1 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _456 = _grad_x_stencil_2 * _grad_y_stencil_1;
-  int16_t _457 = (int16_t)(7);
-  int16_t _458 = _456 >> _457;
-  return _458;
+  int16_t _486 = _grad_x_stencil_2 * _grad_y_stencil_1;
+  int16_t _487 = (int16_t)(7);
+  int16_t _488 = _486 >> _487;
+  return _488;
 }
 
-//store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + -1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _467 = (int16_t)(0);
-  return _467;
+  int16_t _497 = (int16_t)(0);
+  return _497;
+}
+
+//store is: lgxy.stencil((lgxy_s0_x_x*3), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_1() {
+  int16_t _504 = (int16_t)(0);
+  return _504;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x*3) + 1), ((lgxy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_2() {
+  int16_t _510 = (int16_t)(0);
+  return _510;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + -1), (lgxy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_3() {
+  int16_t _517 = (int16_t)(0);
+  return _517;
+}
+
+//store is: lgxy.stencil((lgxy_s0_x_x_1*3), (lgxy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_4() {
+  int16_t _523 = (int16_t)(0);
+  return _523;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_1*3) + 1), (lgxy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_5() {
+  int16_t _528 = (int16_t)(0);
+  return _528;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + -1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_6() {
+  int16_t _534 = (int16_t)(0);
+  return _534;
+}
+
+//store is: lgxy.stencil((lgxy_s0_x_x_2*3), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_7() {
+  int16_t _541 = (int16_t)(0);
+  return _541;
+}
+
+//store is: lgxy.stencil(((lgxy_s0_x_x_2*3) + 1), ((lgxy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgxy_stencil_8() {
+  int16_t _547 = (int16_t)(0);
+  return _547;
 }
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_box_y + lgxy_s1_y)) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_box_y + lgxy_s1_y)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_box_y + lgxy_s1_y)))))
-hw_uint<16> hcompute_lgxy_stencil_1(hw_uint<16>& lgxy_stencil, hw_uint<48>& lxy_stencil) {
+hw_uint<16> hcompute_lgxy_stencil_9(hw_uint<16>& lgxy_stencil, hw_uint<48>& lxy_stencil) {
   int16_t _lgxy_stencil_1 = (int16_t) lgxy_stencil.extract<0, 15>();
 
   int16_t _lxy_stencil_1 = (int16_t) lxy_stencil.extract<0, 15>();
   int16_t _lxy_stencil_2 = (int16_t) lxy_stencil.extract<16, 31>();
   int16_t _lxy_stencil_3 = (int16_t) lxy_stencil.extract<32, 47>();
 
-  int16_t _470 = _lgxy_stencil_1 + _lxy_stencil_3;
-  int16_t _471 = _lxy_stencil_2 + _470;
-  int16_t _472 = _lxy_stencil_1 + _471;
-  return _472;
+  int16_t _554 = _lgxy_stencil_1 + _lxy_stencil_3;
+  int16_t _555 = _lxy_stencil_2 + _554;
+  int16_t _556 = _lxy_stencil_1 + _555;
+  return _556;
 }
 
 //store is: lyy.stencil(lyy_s0_x, lyy_s0_y) = ((grad_y.stencil(lyy_s0_x, lyy_s0_y)*grad_y.stencil(lyy_s0_x, lyy_s0_y))/(int16)128)
 hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_stencil) {
   int16_t _grad_y_stencil_2 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _486 = _grad_y_stencil_2 * _grad_y_stencil_2;
-  int16_t _487 = (int16_t)(7);
-  int16_t _488 = _486 >> _487;
-  return _488;
+  int16_t _570 = _grad_y_stencil_2 * _grad_y_stencil_2;
+  int16_t _571 = (int16_t)(7);
+  int16_t _572 = _570 >> _571;
+  return _572;
 }
 
-//store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + -1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _496 = (int16_t)(0);
-  return _496;
+  int16_t _580 = (int16_t)(0);
+  return _580;
+}
+
+//store is: lgyy.stencil((lgyy_s0_x_x*3), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_1() {
+  int16_t _587 = (int16_t)(0);
+  return _587;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x*3) + 1), ((lgyy_s0_y_y*3) + -1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_2() {
+  int16_t _593 = (int16_t)(0);
+  return _593;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + -1), (lgyy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_3() {
+  int16_t _600 = (int16_t)(0);
+  return _600;
+}
+
+//store is: lgyy.stencil((lgyy_s0_x_x_1*3), (lgyy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_4() {
+  int16_t _606 = (int16_t)(0);
+  return _606;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_1*3) + 1), (lgyy_s0_y_y*3)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_5() {
+  int16_t _611 = (int16_t)(0);
+  return _611;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + -1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_6() {
+  int16_t _617 = (int16_t)(0);
+  return _617;
+}
+
+//store is: lgyy.stencil((lgyy_s0_x_x_2*3), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_7() {
+  int16_t _624 = (int16_t)(0);
+  return _624;
+}
+
+//store is: lgyy.stencil(((lgyy_s0_x_x_2*3) + 1), ((lgyy_s0_y_y*3) + 1)) = (int16)0
+hw_uint<16> hcompute_lgyy_stencil_8() {
+  int16_t _630 = (int16_t)(0);
+  return _630;
 }
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_box_y + lgyy_s1_y)) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_box_y + lgyy_s1_y)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_box_y + lgyy_s1_y)))))
-hw_uint<16> hcompute_lgyy_stencil_1(hw_uint<16>& lgyy_stencil, hw_uint<48>& lyy_stencil) {
+hw_uint<16> hcompute_lgyy_stencil_9(hw_uint<16>& lgyy_stencil, hw_uint<48>& lyy_stencil) {
   int16_t _lgyy_stencil_1 = (int16_t) lgyy_stencil.extract<0, 15>();
 
   int16_t _lyy_stencil_1 = (int16_t) lyy_stencil.extract<0, 15>();
   int16_t _lyy_stencil_2 = (int16_t) lyy_stencil.extract<16, 31>();
   int16_t _lyy_stencil_3 = (int16_t) lyy_stencil.extract<32, 47>();
 
-  int16_t _499 = _lgyy_stencil_1 + _lyy_stencil_3;
-  int16_t _500 = _lyy_stencil_2 + _499;
-  int16_t _501 = _lyy_stencil_1 + _500;
-  return _501;
+  int16_t _637 = _lgyy_stencil_1 + _lyy_stencil_3;
+  int16_t _638 = _lyy_stencil_2 + _637;
+  int16_t _639 = _lyy_stencil_1 + _638;
+  return _639;
 }
 
 //store is: cim.stencil(cim_s0_x, cim_s0_y) = ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)) - ((lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64))) - ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64))*((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)))/(int16)16))
@@ -236,19 +378,19 @@ hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_st
 
   int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _515 = (int16_t)(6);
-  int16_t _516 = _lgxx_stencil_2 >> _515;
-  int16_t _517 = _lgyy_stencil_2 >> _515;
-  int16_t _518 = _516 * _517;
-  int16_t _519 = _lgxy_stencil_2 >> _515;
-  int16_t _520 = _519 * _519;
-  int16_t _521 = _518 - _520;
-  int16_t _522 = _516 + _517;
-  int16_t _523 = _522 * _522;
-  int16_t _524 = (int16_t)(4);
-  int16_t _525 = _523 >> _524;
-  int16_t _526 = _521 - _525;
-  return _526;
+  int16_t _653 = (int16_t)(6);
+  int16_t _654 = _lgxx_stencil_2 >> _653;
+  int16_t _655 = _lgyy_stencil_2 >> _653;
+  int16_t _656 = _654 * _655;
+  int16_t _657 = _lgxy_stencil_2 >> _653;
+  int16_t _658 = _657 * _657;
+  int16_t _659 = _656 - _658;
+  int16_t _660 = _654 + _655;
+  int16_t _661 = _660 * _660;
+  int16_t _662 = (int16_t)(4);
+  int16_t _663 = _661 >> _662;
+  int16_t _664 = _659 - _663;
+  return _664;
 }
 
 //store is: cim_output.stencil(cim_output_s0_x, cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y)) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && ((int16)1 <= cim.stencil(cim_output_s0_x, cim_output_s0_y))), 255, 0))
@@ -263,27 +405,27 @@ hw_uint<16> hcompute_cim_output_stencil(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_8 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_9 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _554 = _cim_stencil_1 < _cim_stencil_2;
-  bool _555 = _cim_stencil_3 < _cim_stencil_2;
-  bool _556 = _554 && _555;
-  bool _557 = _cim_stencil_4 < _cim_stencil_2;
-  bool _558 = _556 && _557;
-  bool _559 = _cim_stencil_5 < _cim_stencil_2;
-  bool _560 = _558 && _559;
-  bool _561 = _cim_stencil_6 < _cim_stencil_2;
-  bool _562 = _560 && _561;
-  bool _563 = _cim_stencil_7 < _cim_stencil_2;
-  bool _564 = _562 && _563;
-  bool _565 = _cim_stencil_8 < _cim_stencil_2;
-  bool _566 = _564 && _565;
-  bool _567 = _cim_stencil_9 < _cim_stencil_2;
-  bool _568 = _566 && _567;
-  int16_t _569 = (int16_t)(1);
-  bool _570 = _569 <= _cim_stencil_2;
-  bool _571 = _568 && _570;
-  int32_t _572 = (int32_t)(_571 ? 255 : 0);
-  int16_t _573 = (int16_t)(_572);
-  return _573;
+  bool _692 = _cim_stencil_1 < _cim_stencil_2;
+  bool _693 = _cim_stencil_3 < _cim_stencil_2;
+  bool _694 = _692 && _693;
+  bool _695 = _cim_stencil_4 < _cim_stencil_2;
+  bool _696 = _694 && _695;
+  bool _697 = _cim_stencil_5 < _cim_stencil_2;
+  bool _698 = _696 && _697;
+  bool _699 = _cim_stencil_6 < _cim_stencil_2;
+  bool _700 = _698 && _699;
+  bool _701 = _cim_stencil_7 < _cim_stencil_2;
+  bool _702 = _700 && _701;
+  bool _703 = _cim_stencil_8 < _cim_stencil_2;
+  bool _704 = _702 && _703;
+  bool _705 = _cim_stencil_9 < _cim_stencil_2;
+  bool _706 = _704 && _705;
+  int16_t _707 = (int16_t)(1);
+  bool _708 = _707 <= _cim_stencil_2;
+  bool _709 = _706 && _708;
+  int32_t _710 = (int32_t)(_709 ? 255 : 0);
+  int16_t _711 = (int16_t)(_710);
+  return _711;
 }
 
 //store is: hw_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi) = cim_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi)

--- a/harris_sch6_2ppc_compute.h
+++ b/harris_sch6_2ppc_compute.h
@@ -29,7 +29,7 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1() {
   return _271;
 }
 
-//store is: grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(grad_x_unclamp_s1_x, grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + 1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_unclamp_s1_x + -1), (grad_x_unclamp_s1_y + 1)))
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + 1)))
 hw_uint<16> hcompute_grad_x_unclamp_stencil_2(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_1 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
@@ -52,47 +52,70 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_2(hw_uint<16>& grad_x_unclamp_stenci
   return _284;
 }
 
-//store is: lxx.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255))/(int16)128)
-hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1)))
+hw_uint<16> hcompute_grad_x_unclamp_stencil_3(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _314 = (int16_t)(255);
-  int16_t _315 = min(_grad_x_unclamp_stencil_2, _314);
-  int16_t _316 = (int16_t)(-255);
-  int16_t _317 = max(_315, _316);
-  int16_t _318 = _317 * _317;
-  int16_t _319 = (int16_t)(7);
-  int16_t _320 = _318 >> _319;
-  return _320;
+  int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
+  int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
+  int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
+  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
+
+  int16_t _316 = (int16_t)(2);
+  int16_t _317 = _padded16_global_wrapper_stencil_9 * _316;
+  int16_t _318 = _padded16_global_wrapper_stencil_8 + _317;
+  int16_t _319 = _padded16_global_wrapper_stencil_7 + _318;
+  int16_t _320 = _grad_x_unclamp_stencil_2 + _319;
+  int16_t _321 = _320 - _padded16_global_wrapper_stencil_10;
+  int16_t _322 = _padded16_global_wrapper_stencil_11 * _316;
+  int16_t _323 = _321 - _322;
+  int16_t _324 = _323 - _padded16_global_wrapper_stencil_12;
+  return _324;
+}
+
+//store is: lxx.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
+  int16_t _grad_x_unclamp_stencil_3 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
+
+  int16_t _355 = (int16_t)(255);
+  int16_t _356 = min(_grad_x_unclamp_stencil_3, _355);
+  int16_t _357 = (int16_t)(-255);
+  int16_t _358 = max(_356, _357);
+  int16_t _359 = _358 * _358;
+  int16_t _360 = (int16_t)(7);
+  int16_t _361 = _359 >> _360;
+  return _361;
 }
 
 //store is: lxx.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)255), (int16)-255)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)255), (int16)-255))/(int16)128)
 hw_uint<16> hcompute_lxx_stencil_1(hw_uint<16>& grad_x_unclamp_stencil) {
-  int16_t _grad_x_unclamp_stencil_3 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
+  int16_t _grad_x_unclamp_stencil_4 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _338 = (int16_t)(255);
-  int16_t _339 = min(_grad_x_unclamp_stencil_3, _338);
-  int16_t _340 = (int16_t)(-255);
-  int16_t _341 = max(_339, _340);
-  int16_t _342 = _341 * _341;
-  int16_t _343 = (int16_t)(7);
-  int16_t _344 = _342 >> _343;
-  return _344;
+  int16_t _379 = (int16_t)(255);
+  int16_t _380 = min(_grad_x_unclamp_stencil_4, _379);
+  int16_t _381 = (int16_t)(-255);
+  int16_t _382 = max(_380, _381);
+  int16_t _383 = _382 * _382;
+  int16_t _384 = (int16_t)(7);
+  int16_t _385 = _383 >> _384;
+  return _385;
 }
 
 //store is: lgxx.stencil(((lgxx_s0_x_x*2) + -1), lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _362 = (int16_t)(0);
-  return _362;
+  int16_t _403 = (int16_t)(0);
+  return _403;
 }
 
 //store is: lgxx.stencil((lgxx_s0_x_x*2), lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil_1() {
-  int16_t _367 = (int16_t)(0);
-  return _367;
+  int16_t _408 = (int16_t)(0);
+  return _408;
 }
 
-//store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + -1)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + -1), lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + 1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + 1)) + lxx.stencil(lgxx_s1_x, (lgxx_s1_y + 1)))))))))))
+//store is: lgxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) = (lxx.stencil(((lgxx_s1_x_x*2) + -2), (lgxx_s1_y + -1)) + (lgxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + -2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -2), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + 1)) + lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + 1)))))))))))
 hw_uint<16> hcompute_lgxx_stencil_2(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx_stencil) {
   int16_t _lgxx_stencil_1 = (int16_t) lgxx_stencil.extract<0, 15>();
 
@@ -106,102 +129,151 @@ hw_uint<16> hcompute_lgxx_stencil_2(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx
   int16_t _lxx_stencil_8 = (int16_t) lxx_stencil.extract<112, 127>();
   int16_t _lxx_stencil_9 = (int16_t) lxx_stencil.extract<128, 143>();
 
-  int16_t _371 = _lxx_stencil_8 + _lxx_stencil_9;
-  int16_t _372 = _lxx_stencil_7 + _371;
-  int16_t _373 = _lxx_stencil_6 + _372;
-  int16_t _374 = _lxx_stencil_5 + _373;
-  int16_t _375 = _lxx_stencil_4 + _374;
-  int16_t _376 = _lxx_stencil_3 + _375;
-  int16_t _377 = _lxx_stencil_2 + _376;
-  int16_t _378 = _lgxx_stencil_1 + _377;
-  int16_t _379 = _lxx_stencil_1 + _378;
-  return _379;
+  int16_t _412 = _lxx_stencil_8 + _lxx_stencil_9;
+  int16_t _413 = _lxx_stencil_7 + _412;
+  int16_t _414 = _lxx_stencil_6 + _413;
+  int16_t _415 = _lxx_stencil_5 + _414;
+  int16_t _416 = _lxx_stencil_4 + _415;
+  int16_t _417 = _lxx_stencil_3 + _416;
+  int16_t _418 = _lxx_stencil_2 + _417;
+  int16_t _419 = _lgxx_stencil_1 + _418;
+  int16_t _420 = _lxx_stencil_1 + _419;
+  return _420;
+}
+
+//store is: lgxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) = (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + -1)) + (lgxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + 1)) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), (lgxx_s1_y + 1)) + lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + 1)))))))))))
+hw_uint<16> hcompute_lgxx_stencil_3(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx_stencil) {
+  int16_t _lgxx_stencil_2 = (int16_t) lgxx_stencil.extract<0, 15>();
+
+  int16_t _lxx_stencil_10 = (int16_t) lxx_stencil.extract<0, 15>();
+  int16_t _lxx_stencil_11 = (int16_t) lxx_stencil.extract<16, 31>();
+  int16_t _lxx_stencil_12 = (int16_t) lxx_stencil.extract<32, 47>();
+  int16_t _lxx_stencil_13 = (int16_t) lxx_stencil.extract<48, 63>();
+  int16_t _lxx_stencil_14 = (int16_t) lxx_stencil.extract<64, 79>();
+  int16_t _lxx_stencil_15 = (int16_t) lxx_stencil.extract<80, 95>();
+  int16_t _lxx_stencil_16 = (int16_t) lxx_stencil.extract<96, 111>();
+  int16_t _lxx_stencil_17 = (int16_t) lxx_stencil.extract<112, 127>();
+  int16_t _lxx_stencil_18 = (int16_t) lxx_stencil.extract<128, 143>();
+
+  int16_t _454 = _lxx_stencil_17 + _lxx_stencil_18;
+  int16_t _455 = _lxx_stencil_16 + _454;
+  int16_t _456 = _lxx_stencil_15 + _455;
+  int16_t _457 = _lxx_stencil_14 + _456;
+  int16_t _458 = _lxx_stencil_13 + _457;
+  int16_t _459 = _lxx_stencil_12 + _458;
+  int16_t _460 = _lxx_stencil_11 + _459;
+  int16_t _461 = _lgxx_stencil_2 + _460;
+  int16_t _462 = _lxx_stencil_10 + _461;
+  return _462;
 }
 
 //store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -2), grad_y_unclamp_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil() {
-  int16_t _412 = (int16_t)(0);
-  return _412;
+  int16_t _496 = (int16_t)(0);
+  return _496;
 }
 
 //store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -1), grad_y_unclamp_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil_1() {
-  int16_t _417 = (int16_t)(0);
-  return _417;
+  int16_t _501 = (int16_t)(0);
+  return _501;
 }
 
-//store is: grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) = ((((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + -1)) + (grad_y_unclamp.stencil(grad_y_unclamp_s1_x, grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + -1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + -1), (grad_y_unclamp_s1_y + 1))) - (padded16_global_wrapper.stencil(grad_y_unclamp_s1_x, (grad_y_unclamp_s1_y + 1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x + 1), (grad_y_unclamp_s1_y + 1)))
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1)))
 hw_uint<16> hcompute_grad_y_unclamp_stencil_2(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_y_unclamp_stencil_1 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
-  int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
-  int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
+  int16_t _padded16_global_wrapper_stencil_13 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
+  int16_t _padded16_global_wrapper_stencil_14 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
+  int16_t _padded16_global_wrapper_stencil_15 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
+  int16_t _padded16_global_wrapper_stencil_16 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_17 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_18 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
 
-  int16_t _422 = (int16_t)(2);
-  int16_t _423 = _padded16_global_wrapper_stencil_9 * _422;
-  int16_t _424 = _padded16_global_wrapper_stencil_8 + _423;
-  int16_t _425 = _grad_y_unclamp_stencil_1 + _424;
-  int16_t _426 = _padded16_global_wrapper_stencil_7 + _425;
-  int16_t _427 = _426 - _padded16_global_wrapper_stencil_10;
-  int16_t _428 = _padded16_global_wrapper_stencil_11 * _422;
-  int16_t _429 = _427 - _428;
-  int16_t _430 = _429 - _padded16_global_wrapper_stencil_12;
-  return _430;
+  int16_t _506 = (int16_t)(2);
+  int16_t _507 = _padded16_global_wrapper_stencil_15 * _506;
+  int16_t _508 = _padded16_global_wrapper_stencil_14 + _507;
+  int16_t _509 = _padded16_global_wrapper_stencil_13 + _508;
+  int16_t _510 = _grad_y_unclamp_stencil_1 + _509;
+  int16_t _511 = _510 - _padded16_global_wrapper_stencil_16;
+  int16_t _512 = _padded16_global_wrapper_stencil_17 * _506;
+  int16_t _513 = _511 - _512;
+  int16_t _514 = _513 - _padded16_global_wrapper_stencil_18;
+  return _514;
+}
+
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + -1)))
+hw_uint<16> hcompute_grad_y_unclamp_stencil_3(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
+  int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
+
+  int16_t _padded16_global_wrapper_stencil_19 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
+  int16_t _padded16_global_wrapper_stencil_20 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
+  int16_t _padded16_global_wrapper_stencil_21 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
+  int16_t _padded16_global_wrapper_stencil_22 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_23 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_24 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
+
+  int16_t _546 = (int16_t)(2);
+  int16_t _547 = _padded16_global_wrapper_stencil_21 * _546;
+  int16_t _548 = _padded16_global_wrapper_stencil_20 + _547;
+  int16_t _549 = _padded16_global_wrapper_stencil_19 + _548;
+  int16_t _550 = _grad_y_unclamp_stencil_2 + _549;
+  int16_t _551 = _550 - _padded16_global_wrapper_stencil_22;
+  int16_t _552 = _padded16_global_wrapper_stencil_23 * _546;
+  int16_t _553 = _551 - _552;
+  int16_t _554 = _553 - _padded16_global_wrapper_stencil_24;
+  return _554;
 }
 
 //store is: lxy.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)255), (int16)-255))/(int16)128)
 hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<16>& grad_y_unclamp_stencil) {
-  int16_t _grad_x_unclamp_stencil_4 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
-
-  int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
-
-  int16_t _460 = (int16_t)(255);
-  int16_t _461 = min(_grad_x_unclamp_stencil_4, _460);
-  int16_t _462 = (int16_t)(-255);
-  int16_t _463 = max(_461, _462);
-  int16_t _464 = min(_grad_y_unclamp_stencil_2, _460);
-  int16_t _465 = max(_464, _462);
-  int16_t _466 = _463 * _465;
-  int16_t _467 = (int16_t)(7);
-  int16_t _468 = _466 >> _467;
-  return _468;
-}
-
-//store is: lxy.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255))/(int16)128)
-hw_uint<16> hcompute_lxy_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_5 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
   int16_t _grad_y_unclamp_stencil_3 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _491 = (int16_t)(255);
-  int16_t _492 = min(_grad_x_unclamp_stencil_5, _491);
-  int16_t _493 = (int16_t)(-255);
-  int16_t _494 = max(_492, _493);
-  int16_t _495 = min(_grad_y_unclamp_stencil_3, _491);
-  int16_t _496 = max(_495, _493);
-  int16_t _497 = _494 * _496;
-  int16_t _498 = (int16_t)(7);
-  int16_t _499 = _497 >> _498;
-  return _499;
+  int16_t _585 = (int16_t)(255);
+  int16_t _586 = min(_grad_x_unclamp_stencil_5, _585);
+  int16_t _587 = (int16_t)(-255);
+  int16_t _588 = max(_586, _587);
+  int16_t _589 = min(_grad_y_unclamp_stencil_3, _585);
+  int16_t _590 = max(_589, _587);
+  int16_t _591 = _588 * _590;
+  int16_t _592 = (int16_t)(7);
+  int16_t _593 = _591 >> _592;
+  return _593;
+}
+
+//store is: lxy.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)255), (int16)-255))/(int16)128)
+hw_uint<16> hcompute_lxy_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<16>& grad_y_unclamp_stencil) {
+  int16_t _grad_x_unclamp_stencil_6 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
+
+  int16_t _grad_y_unclamp_stencil_4 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
+
+  int16_t _616 = (int16_t)(255);
+  int16_t _617 = min(_grad_x_unclamp_stencil_6, _616);
+  int16_t _618 = (int16_t)(-255);
+  int16_t _619 = max(_617, _618);
+  int16_t _620 = min(_grad_y_unclamp_stencil_4, _616);
+  int16_t _621 = max(_620, _618);
+  int16_t _622 = _619 * _621;
+  int16_t _623 = (int16_t)(7);
+  int16_t _624 = _622 >> _623;
+  return _624;
 }
 
 //store is: lgxy.stencil(((lgxy_s0_x_x*2) + -1), lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _522 = (int16_t)(0);
-  return _522;
+  int16_t _647 = (int16_t)(0);
+  return _647;
 }
 
 //store is: lgxy.stencil((lgxy_s0_x_x*2), lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil_1() {
-  int16_t _527 = (int16_t)(0);
-  return _527;
+  int16_t _652 = (int16_t)(0);
+  return _652;
 }
 
-//store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + -1)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + -1), lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + 1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + 1)) + lxy.stencil(lgxy_s1_x, (lgxy_s1_y + 1)))))))))))
+//store is: lgxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) = (lxy.stencil(((lgxy_s1_x_x*2) + -2), (lgxy_s1_y + -1)) + (lgxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + -2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -2), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + 1)) + lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + 1)))))))))))
 hw_uint<16> hcompute_lgxy_stencil_2(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy_stencil) {
   int16_t _lgxy_stencil_1 = (int16_t) lgxy_stencil.extract<0, 15>();
 
@@ -215,59 +287,85 @@ hw_uint<16> hcompute_lgxy_stencil_2(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy
   int16_t _lxy_stencil_8 = (int16_t) lxy_stencil.extract<112, 127>();
   int16_t _lxy_stencil_9 = (int16_t) lxy_stencil.extract<128, 143>();
 
-  int16_t _531 = _lxy_stencil_8 + _lxy_stencil_9;
-  int16_t _532 = _lxy_stencil_7 + _531;
-  int16_t _533 = _lxy_stencil_6 + _532;
-  int16_t _534 = _lxy_stencil_5 + _533;
-  int16_t _535 = _lxy_stencil_4 + _534;
-  int16_t _536 = _lxy_stencil_3 + _535;
-  int16_t _537 = _lxy_stencil_2 + _536;
-  int16_t _538 = _lgxy_stencil_1 + _537;
-  int16_t _539 = _lxy_stencil_1 + _538;
-  return _539;
+  int16_t _656 = _lxy_stencil_8 + _lxy_stencil_9;
+  int16_t _657 = _lxy_stencil_7 + _656;
+  int16_t _658 = _lxy_stencil_6 + _657;
+  int16_t _659 = _lxy_stencil_5 + _658;
+  int16_t _660 = _lxy_stencil_4 + _659;
+  int16_t _661 = _lxy_stencil_3 + _660;
+  int16_t _662 = _lxy_stencil_2 + _661;
+  int16_t _663 = _lgxy_stencil_1 + _662;
+  int16_t _664 = _lxy_stencil_1 + _663;
+  return _664;
+}
+
+//store is: lgxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) = (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + -1)) + (lgxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + 1)) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), (lgxy_s1_y + 1)) + lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + 1)))))))))))
+hw_uint<16> hcompute_lgxy_stencil_3(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy_stencil) {
+  int16_t _lgxy_stencil_2 = (int16_t) lgxy_stencil.extract<0, 15>();
+
+  int16_t _lxy_stencil_10 = (int16_t) lxy_stencil.extract<0, 15>();
+  int16_t _lxy_stencil_11 = (int16_t) lxy_stencil.extract<16, 31>();
+  int16_t _lxy_stencil_12 = (int16_t) lxy_stencil.extract<32, 47>();
+  int16_t _lxy_stencil_13 = (int16_t) lxy_stencil.extract<48, 63>();
+  int16_t _lxy_stencil_14 = (int16_t) lxy_stencil.extract<64, 79>();
+  int16_t _lxy_stencil_15 = (int16_t) lxy_stencil.extract<80, 95>();
+  int16_t _lxy_stencil_16 = (int16_t) lxy_stencil.extract<96, 111>();
+  int16_t _lxy_stencil_17 = (int16_t) lxy_stencil.extract<112, 127>();
+  int16_t _lxy_stencil_18 = (int16_t) lxy_stencil.extract<128, 143>();
+
+  int16_t _698 = _lxy_stencil_17 + _lxy_stencil_18;
+  int16_t _699 = _lxy_stencil_16 + _698;
+  int16_t _700 = _lxy_stencil_15 + _699;
+  int16_t _701 = _lxy_stencil_14 + _700;
+  int16_t _702 = _lxy_stencil_13 + _701;
+  int16_t _703 = _lxy_stencil_12 + _702;
+  int16_t _704 = _lxy_stencil_11 + _703;
+  int16_t _705 = _lgxy_stencil_2 + _704;
+  int16_t _706 = _lxy_stencil_10 + _705;
+  return _706;
 }
 
 //store is: lyy.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)255), (int16)-255))/(int16)128)
 hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
-  int16_t _grad_y_unclamp_stencil_4 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
+  int16_t _grad_y_unclamp_stencil_5 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _572 = (int16_t)(255);
-  int16_t _573 = min(_grad_y_unclamp_stencil_4, _572);
-  int16_t _574 = (int16_t)(-255);
-  int16_t _575 = max(_573, _574);
-  int16_t _576 = _575 * _575;
-  int16_t _577 = (int16_t)(7);
-  int16_t _578 = _576 >> _577;
-  return _578;
+  int16_t _740 = (int16_t)(255);
+  int16_t _741 = min(_grad_y_unclamp_stencil_5, _740);
+  int16_t _742 = (int16_t)(-255);
+  int16_t _743 = max(_741, _742);
+  int16_t _744 = _743 * _743;
+  int16_t _745 = (int16_t)(7);
+  int16_t _746 = _744 >> _745;
+  return _746;
 }
 
 //store is: lyy.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)255), (int16)-255)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)255), (int16)-255))/(int16)128)
 hw_uint<16> hcompute_lyy_stencil_1(hw_uint<16>& grad_y_unclamp_stencil) {
-  int16_t _grad_y_unclamp_stencil_5 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
+  int16_t _grad_y_unclamp_stencil_6 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _596 = (int16_t)(255);
-  int16_t _597 = min(_grad_y_unclamp_stencil_5, _596);
-  int16_t _598 = (int16_t)(-255);
-  int16_t _599 = max(_597, _598);
-  int16_t _600 = _599 * _599;
-  int16_t _601 = (int16_t)(7);
-  int16_t _602 = _600 >> _601;
-  return _602;
+  int16_t _764 = (int16_t)(255);
+  int16_t _765 = min(_grad_y_unclamp_stencil_6, _764);
+  int16_t _766 = (int16_t)(-255);
+  int16_t _767 = max(_765, _766);
+  int16_t _768 = _767 * _767;
+  int16_t _769 = (int16_t)(7);
+  int16_t _770 = _768 >> _769;
+  return _770;
 }
 
 //store is: lgyy.stencil(((lgyy_s0_x_x*2) + -1), lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _620 = (int16_t)(0);
-  return _620;
+  int16_t _788 = (int16_t)(0);
+  return _788;
 }
 
 //store is: lgyy.stencil((lgyy_s0_x_x*2), lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil_1() {
-  int16_t _625 = (int16_t)(0);
-  return _625;
+  int16_t _793 = (int16_t)(0);
+  return _793;
 }
 
-//store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + -1)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + -1), lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + 1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + 1)) + lyy.stencil(lgyy_s1_x, (lgyy_s1_y + 1)))))))))))
+//store is: lgyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) = (lyy.stencil(((lgyy_s1_x_x*2) + -2), (lgyy_s1_y + -1)) + (lgyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + -2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -2), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + 1)) + lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + 1)))))))))))
 hw_uint<16> hcompute_lgyy_stencil_2(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy_stencil) {
   int16_t _lgyy_stencil_1 = (int16_t) lgyy_stencil.extract<0, 15>();
 
@@ -281,62 +379,88 @@ hw_uint<16> hcompute_lgyy_stencil_2(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy
   int16_t _lyy_stencil_8 = (int16_t) lyy_stencil.extract<112, 127>();
   int16_t _lyy_stencil_9 = (int16_t) lyy_stencil.extract<128, 143>();
 
-  int16_t _629 = _lyy_stencil_8 + _lyy_stencil_9;
-  int16_t _630 = _lyy_stencil_7 + _629;
-  int16_t _631 = _lyy_stencil_6 + _630;
-  int16_t _632 = _lyy_stencil_5 + _631;
-  int16_t _633 = _lyy_stencil_4 + _632;
-  int16_t _634 = _lyy_stencil_3 + _633;
-  int16_t _635 = _lyy_stencil_2 + _634;
-  int16_t _636 = _lgyy_stencil_1 + _635;
-  int16_t _637 = _lyy_stencil_1 + _636;
-  return _637;
+  int16_t _797 = _lyy_stencil_8 + _lyy_stencil_9;
+  int16_t _798 = _lyy_stencil_7 + _797;
+  int16_t _799 = _lyy_stencil_6 + _798;
+  int16_t _800 = _lyy_stencil_5 + _799;
+  int16_t _801 = _lyy_stencil_4 + _800;
+  int16_t _802 = _lyy_stencil_3 + _801;
+  int16_t _803 = _lyy_stencil_2 + _802;
+  int16_t _804 = _lgyy_stencil_1 + _803;
+  int16_t _805 = _lyy_stencil_1 + _804;
+  return _805;
+}
+
+//store is: lgyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) = (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + -1)) + (lgyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + 1)) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), (lgyy_s1_y + 1)) + lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + 1)))))))))))
+hw_uint<16> hcompute_lgyy_stencil_3(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy_stencil) {
+  int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
+
+  int16_t _lyy_stencil_10 = (int16_t) lyy_stencil.extract<0, 15>();
+  int16_t _lyy_stencil_11 = (int16_t) lyy_stencil.extract<16, 31>();
+  int16_t _lyy_stencil_12 = (int16_t) lyy_stencil.extract<32, 47>();
+  int16_t _lyy_stencil_13 = (int16_t) lyy_stencil.extract<48, 63>();
+  int16_t _lyy_stencil_14 = (int16_t) lyy_stencil.extract<64, 79>();
+  int16_t _lyy_stencil_15 = (int16_t) lyy_stencil.extract<80, 95>();
+  int16_t _lyy_stencil_16 = (int16_t) lyy_stencil.extract<96, 111>();
+  int16_t _lyy_stencil_17 = (int16_t) lyy_stencil.extract<112, 127>();
+  int16_t _lyy_stencil_18 = (int16_t) lyy_stencil.extract<128, 143>();
+
+  int16_t _839 = _lyy_stencil_17 + _lyy_stencil_18;
+  int16_t _840 = _lyy_stencil_16 + _839;
+  int16_t _841 = _lyy_stencil_15 + _840;
+  int16_t _842 = _lyy_stencil_14 + _841;
+  int16_t _843 = _lyy_stencil_13 + _842;
+  int16_t _844 = _lyy_stencil_12 + _843;
+  int16_t _845 = _lyy_stencil_11 + _844;
+  int16_t _846 = _lgyy_stencil_2 + _845;
+  int16_t _847 = _lyy_stencil_10 + _846;
+  return _847;
 }
 
 //store is: cim.stencil(((cim_s0_x_x*2) + -1), cim_s0_y) = ((((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)*(lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)) - ((lgxy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)*(lgxy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64))) - ((((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64) + (lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64))*((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64) + (lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)))/(int16)16))
 hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_stencil, hw_uint<16>& lgyy_stencil) {
-  int16_t _lgxx_stencil_2 = (int16_t) lgxx_stencil.extract<0, 15>();
-
-  int16_t _lgxy_stencil_2 = (int16_t) lgxy_stencil.extract<0, 15>();
-
-  int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
-
-  int16_t _670 = (int16_t)(6);
-  int16_t _671 = _lgxx_stencil_2 >> _670;
-  int16_t _672 = _lgyy_stencil_2 >> _670;
-  int16_t _673 = _671 * _672;
-  int16_t _674 = _lgxy_stencil_2 >> _670;
-  int16_t _675 = _674 * _674;
-  int16_t _676 = _673 - _675;
-  int16_t _677 = _671 + _672;
-  int16_t _678 = _677 * _677;
-  int16_t _679 = (int16_t)(4);
-  int16_t _680 = _678 >> _679;
-  int16_t _681 = _676 - _680;
-  return _681;
-}
-
-//store is: cim.stencil((cim_s0_x_x*2), cim_s0_y) = ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)) - ((lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))) - ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))*((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)))/(int16)16))
-hw_uint<16> hcompute_cim_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_stencil, hw_uint<16>& lgyy_stencil) {
   int16_t _lgxx_stencil_3 = (int16_t) lgxx_stencil.extract<0, 15>();
 
   int16_t _lgxy_stencil_3 = (int16_t) lgxy_stencil.extract<0, 15>();
 
   int16_t _lgyy_stencil_3 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _711 = (int16_t)(6);
-  int16_t _712 = _lgxx_stencil_3 >> _711;
-  int16_t _713 = _lgyy_stencil_3 >> _711;
-  int16_t _714 = _712 * _713;
-  int16_t _715 = _lgxy_stencil_3 >> _711;
-  int16_t _716 = _715 * _715;
-  int16_t _717 = _714 - _716;
-  int16_t _718 = _712 + _713;
-  int16_t _719 = _718 * _718;
-  int16_t _720 = (int16_t)(4);
-  int16_t _721 = _719 >> _720;
-  int16_t _722 = _717 - _721;
-  return _722;
+  int16_t _881 = (int16_t)(6);
+  int16_t _882 = _lgxx_stencil_3 >> _881;
+  int16_t _883 = _lgyy_stencil_3 >> _881;
+  int16_t _884 = _882 * _883;
+  int16_t _885 = _lgxy_stencil_3 >> _881;
+  int16_t _886 = _885 * _885;
+  int16_t _887 = _884 - _886;
+  int16_t _888 = _882 + _883;
+  int16_t _889 = _888 * _888;
+  int16_t _890 = (int16_t)(4);
+  int16_t _891 = _889 >> _890;
+  int16_t _892 = _887 - _891;
+  return _892;
+}
+
+//store is: cim.stencil((cim_s0_x_x*2), cim_s0_y) = ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)) - ((lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))) - ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))*((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)))/(int16)16))
+hw_uint<16> hcompute_cim_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_stencil, hw_uint<16>& lgyy_stencil) {
+  int16_t _lgxx_stencil_4 = (int16_t) lgxx_stencil.extract<0, 15>();
+
+  int16_t _lgxy_stencil_4 = (int16_t) lgxy_stencil.extract<0, 15>();
+
+  int16_t _lgyy_stencil_4 = (int16_t) lgyy_stencil.extract<0, 15>();
+
+  int16_t _922 = (int16_t)(6);
+  int16_t _923 = _lgxx_stencil_4 >> _922;
+  int16_t _924 = _lgyy_stencil_4 >> _922;
+  int16_t _925 = _923 * _924;
+  int16_t _926 = _lgxy_stencil_4 >> _922;
+  int16_t _927 = _926 * _926;
+  int16_t _928 = _925 - _927;
+  int16_t _929 = _923 + _924;
+  int16_t _930 = _929 * _929;
+  int16_t _931 = (int16_t)(4);
+  int16_t _932 = _930 >> _931;
+  int16_t _933 = _928 - _932;
+  return _933;
 }
 
 //store is: cim_output.stencil((cim_output_s0_x_x*2), cim_output_s0_y) = int16(select((((((((((cim.stencil(((cim_output_s0_x_x*2) + -1), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y)) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + -1), cim_output_s0_y) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + -1), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && ((int16)1 <= cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))), 255, 0))
@@ -351,27 +475,27 @@ hw_uint<16> hcompute_cim_output_stencil(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_8 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_9 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _751 = _cim_stencil_1 < _cim_stencil_2;
-  bool _752 = _cim_stencil_3 < _cim_stencil_2;
-  bool _753 = _751 && _752;
-  bool _754 = _cim_stencil_4 < _cim_stencil_2;
-  bool _755 = _753 && _754;
-  bool _756 = _cim_stencil_5 < _cim_stencil_2;
-  bool _757 = _755 && _756;
-  bool _758 = _cim_stencil_6 < _cim_stencil_2;
-  bool _759 = _757 && _758;
-  bool _760 = _cim_stencil_7 < _cim_stencil_2;
-  bool _761 = _759 && _760;
-  bool _762 = _cim_stencil_8 < _cim_stencil_2;
-  bool _763 = _761 && _762;
-  bool _764 = _cim_stencil_9 < _cim_stencil_2;
-  bool _765 = _763 && _764;
-  int16_t _766 = (int16_t)(1);
-  bool _767 = _766 <= _cim_stencil_2;
-  bool _768 = _765 && _767;
-  int32_t _769 = (int32_t)(_768 ? 255 : 0);
-  int16_t _770 = (int16_t)(_769);
-  return _770;
+  bool _962 = _cim_stencil_1 < _cim_stencil_2;
+  bool _963 = _cim_stencil_3 < _cim_stencil_2;
+  bool _964 = _962 && _963;
+  bool _965 = _cim_stencil_4 < _cim_stencil_2;
+  bool _966 = _964 && _965;
+  bool _967 = _cim_stencil_5 < _cim_stencil_2;
+  bool _968 = _966 && _967;
+  bool _969 = _cim_stencil_6 < _cim_stencil_2;
+  bool _970 = _968 && _969;
+  bool _971 = _cim_stencil_7 < _cim_stencil_2;
+  bool _972 = _970 && _971;
+  bool _973 = _cim_stencil_8 < _cim_stencil_2;
+  bool _974 = _972 && _973;
+  bool _975 = _cim_stencil_9 < _cim_stencil_2;
+  bool _976 = _974 && _975;
+  int16_t _977 = (int16_t)(1);
+  bool _978 = _977 <= _cim_stencil_2;
+  bool _979 = _976 && _978;
+  int32_t _980 = (int32_t)(_979 ? 255 : 0);
+  int16_t _981 = (int16_t)(_980);
+  return _981;
 }
 
 //store is: cim_output.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y)) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), cim_output_s0_y) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && ((int16)1 <= cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))), 255, 0))
@@ -386,27 +510,27 @@ hw_uint<16> hcompute_cim_output_stencil_1(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_17 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_18 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _825 = _cim_stencil_10 < _cim_stencil_11;
-  bool _826 = _cim_stencil_12 < _cim_stencil_11;
-  bool _827 = _825 && _826;
-  bool _828 = _cim_stencil_13 < _cim_stencil_11;
-  bool _829 = _827 && _828;
-  bool _830 = _cim_stencil_14 < _cim_stencil_11;
-  bool _831 = _829 && _830;
-  bool _832 = _cim_stencil_15 < _cim_stencil_11;
-  bool _833 = _831 && _832;
-  bool _834 = _cim_stencil_16 < _cim_stencil_11;
-  bool _835 = _833 && _834;
-  bool _836 = _cim_stencil_17 < _cim_stencil_11;
-  bool _837 = _835 && _836;
-  bool _838 = _cim_stencil_18 < _cim_stencil_11;
-  bool _839 = _837 && _838;
-  int16_t _840 = (int16_t)(1);
-  bool _841 = _840 <= _cim_stencil_11;
-  bool _842 = _839 && _841;
-  int32_t _843 = (int32_t)(_842 ? 255 : 0);
-  int16_t _844 = (int16_t)(_843);
-  return _844;
+  bool _1036 = _cim_stencil_10 < _cim_stencil_11;
+  bool _1037 = _cim_stencil_12 < _cim_stencil_11;
+  bool _1038 = _1036 && _1037;
+  bool _1039 = _cim_stencil_13 < _cim_stencil_11;
+  bool _1040 = _1038 && _1039;
+  bool _1041 = _cim_stencil_14 < _cim_stencil_11;
+  bool _1042 = _1040 && _1041;
+  bool _1043 = _cim_stencil_15 < _cim_stencil_11;
+  bool _1044 = _1042 && _1043;
+  bool _1045 = _cim_stencil_16 < _cim_stencil_11;
+  bool _1046 = _1044 && _1045;
+  bool _1047 = _cim_stencil_17 < _cim_stencil_11;
+  bool _1048 = _1046 && _1047;
+  bool _1049 = _cim_stencil_18 < _cim_stencil_11;
+  bool _1050 = _1048 && _1049;
+  int16_t _1051 = (int16_t)(1);
+  bool _1052 = _1051 <= _cim_stencil_11;
+  bool _1053 = _1050 && _1052;
+  int32_t _1054 = (int32_t)(_1053 ? 255 : 0);
+  int16_t _1055 = (int16_t)(_1054);
+  return _1055;
 }
 
 //store is: hw_output.stencil((hw_output_s0_x_xi_xi*2), hw_output_s0_y_yi) = cim_output.stencil((hw_output_s0_x_xi_xi*2), hw_output_s0_y_yi)

--- a/options.h
+++ b/options.h
@@ -46,10 +46,12 @@ struct RTLOptions {
   bool use_external_controllers;
   bool pack_controllers_in_memtiles;
   bool use_prebuilt_memory;
+  bool use_pipelined_compute_units;
   int max_inpt, max_outpt;
   TargetTile target_tile;
 
   RTLOptions() : use_external_controllers(true), pack_controllers_in_memtiles(false),
+  use_pipelined_compute_units(false),
     max_inpt(1), max_outpt(1),
     target_tile(TARGET_TILE_DUAL_SRAM_WITH_ADDRGEN), use_prebuilt_memory(false) {}
   //RTLOptions() : use_external_controllers(true), pack_controllers_in_memtiles(false), use_prebuilt_memory(false), target_tile(TARGET_TILE_DUAL_SRAM_WITH_ADDRGEN) {}

--- a/prog.cpp
+++ b/prog.cpp
@@ -6649,12 +6649,21 @@ bool all_ops_scheduled(schedule_info& sched, prog& prg) {
   return true;
 }
 
+int schedule_info::compute_latency(const std::string& op_name) {
+  assert(contains_key(op_name, op_compute_unit_names));
+  string cu_name = map_find(op_name, op_compute_unit_names);
+  assert(contains_key(cu_name, compute_unit_latencies));
+  return map_find(cu_name, compute_unit_latencies);
+}
+
 int schedule_info::compute_latency(op* op) {
   if (op->func == "") {
     return 0;
   }
-  assert(contains_key(op->func, compute_unit_latencies));
-  return map_find(op->func, compute_unit_latencies);
+  assert(contains_key(op->name, op_compute_unit_names));
+  string cu_name = map_find(op->name, op_compute_unit_names);
+  assert(contains_key(cu_name, compute_unit_latencies));
+  return map_find(cu_name, compute_unit_latencies);
 
 
   //assert(contains_key(op->func + "_pipelined", compute_unit_latencies));

--- a/prog.cpp
+++ b/prog.cpp
@@ -6655,7 +6655,11 @@ int schedule_info::compute_latency(op* op) {
   }
   assert(contains_key(op->func, compute_unit_latencies));
   return map_find(op->func, compute_unit_latencies);
+
+
   //assert(contains_key(op->func + "_pipelined", compute_unit_latencies));
-  //return map_find(op->func + "_pipelined", compute_unit_latencies);
+  //int l = map_find(op->func + "_pipelined", compute_unit_latencies);
+  //assert(l >= 0);
+  //return l;
 }
 

--- a/prog.cpp
+++ b/prog.cpp
@@ -5714,24 +5714,28 @@ int schedule_info::instance_latency(op* op) {
     return maxoffset;
   }
 
-  assert(contains_key(op, instance_latencies));
-  return map_find(op, instance_latencies);
+  return op_latency(op, *this);
+  //assert(contains_key(op, instance_latencies));
+  //return map_find(op, instance_latencies);
 }
 
 bool is_op_scheduled(op* op, schedule_info& sched, prog& prg) {
-  bool has_latency = contains_key(op, sched.instance_latencies);
+  //bool has_latency = contains_key(op, sched.instance_latencies);
   bool has_offset = contains_key(op, sched.op_offset_within_parent);
   bool has_ii = contains_key(op->name, sched.loop_iis);
 
   if (op == prg.root) {
-    return has_latency && has_ii;
+    //return has_latency && has_ii;
+    return has_ii;
   }
 
   if (op->is_loop()) {
-    return has_latency && has_ii && has_offset;
+    //return has_latency && has_ii && has_offset;
+    return has_ii && has_offset;
   }
 
-  return has_latency && has_offset;
+  //return has_latency && has_offset;
+  return has_offset;
 }
 
 bool share_resource(const std::string& op0, const std::string& op1, schedule_info& sched) {
@@ -6672,3 +6676,13 @@ int schedule_info::compute_latency(op* op) {
   //return l;
 }
 
+int schedule_info::total_latency(op* op) {
+  if (!op->is_loop()) {
+    return instance_latency(op);
+    //assert(contains_key(op, instance_latencies));
+    //return map_find(op, instance_latencies);
+  }
+  return II(op)*(op->trip_count() - 1) + instance_latency(op);
+}
+
+int op_latency(op* op, schedule_info& hwinfo);

--- a/prog.cpp
+++ b/prog.cpp
@@ -5642,7 +5642,7 @@ vector<op*> ops_at_level(const int level, prog& prg) {
   vector<op*> ops = get_dft_nodes(prg);
   map<string, int> op_levels = get_op_levels(prg);
   for (auto op : ops) {
-    cout << tab(1) << op->name << " is at " << map_find(op->name, op_levels) << endl;
+    //cout << tab(1) << op->name << " is at " << map_find(op->name, op_levels) << endl;
     if (map_find(op->name, op_levels) == level) {
       at_level.push_back(op);
     }

--- a/prog.cpp
+++ b/prog.cpp
@@ -6739,7 +6739,8 @@ void adjust_outer_delays(schedule_info& sched, prog& prg) {
         found_smaller_delay = true;
         break;
       }
-      try_delay = max(try_delay * 2, try_delay + 1000);
+      try_delay = try_delay + 1000;
+      //try_delay = max(try_delay * 2, try_delay + 1000);
       //try_delay = min(try_delay * 2, try_delay + 1000);
       //try_delay *= 2;
     }

--- a/prog.cpp
+++ b/prog.cpp
@@ -6649,3 +6649,13 @@ bool all_ops_scheduled(schedule_info& sched, prog& prg) {
   return true;
 }
 
+int schedule_info::compute_latency(op* op) {
+  if (op->func == "") {
+    return 0;
+  }
+  assert(contains_key(op->func, compute_unit_latencies));
+  return map_find(op->func, compute_unit_latencies);
+  //assert(contains_key(op->func + "_pipelined", compute_unit_latencies));
+  //return map_find(op->func + "_pipelined", compute_unit_latencies);
+}
+

--- a/prog.h
+++ b/prog.h
@@ -1860,3 +1860,13 @@ vector<op*> unscheduled_nodes(schedule_info& sched, prog& prg);
 bool all_ops_scheduled(schedule_info& sched, prog& prg);
 
 int op_latency(op* op, schedule_info& hwinfo);
+
+void adjust_outer_delays(schedule_info& sched, prog& prg);
+
+void adjust_outer_pipeline_delays(schedule_info& sched, prog& prg);
+
+bool no_violated_cycle_accurate_dependencies(schedule_info& sched, prog& prg);
+
+bool schedule_bounds_fit_controller_bitwidth(const int bitwidth, schedule_info& sched, prog& prg);
+
+void adjust_inner_iis(schedule_info& sched, prog& prg);

--- a/prog.h
+++ b/prog.h
@@ -1717,6 +1717,7 @@ struct schedule_info {
   map<op*, int> instance_latencies;
   map<op*, int> op_offset_within_parent;
 
+  int compute_latency(const std::string& op_name);
   int compute_latency(op* op);
 
   int store_latency(const std::string& buf) {

--- a/prog.h
+++ b/prog.h
@@ -1703,7 +1703,7 @@ struct schedule_info {
   map<string, int> buffer_store_latencies;
   map<string, int> compute_unit_latencies;
   map<string, string> op_compute_unit_names;
-  map<string, int> op_compute_unit_latencies;
+  //map<string, int> op_compute_unit_latencies;
 
   // Resource constraints
   map<string, int> resource_quantities;

--- a/prog.h
+++ b/prog.h
@@ -1714,7 +1714,7 @@ struct schedule_info {
 
   // Schedule offsets
   map<string, int> loop_iis;
-  map<op*, int> instance_latencies;
+  //map<op*, int> instance_latencies;
   map<op*, int> op_offset_within_parent;
 
   int compute_latency(const std::string& op_name);
@@ -1747,13 +1747,7 @@ struct schedule_info {
     return last_delay;
   }
 
-  int total_latency(op* op) {
-    if (!op->is_loop()) {
-      assert(contains_key(op, instance_latencies));
-      return map_find(op, instance_latencies);
-    }
-    return II(op)*(op->trip_count() - 1) + instance_latency(op);
-  }
+  int total_latency(op* op);
 
   int instance_latency(op* op);
 
@@ -1865,3 +1859,4 @@ vector<op*> unscheduled_nodes(schedule_info& sched, prog& prg);
 
 bool all_ops_scheduled(schedule_info& sched, prog& prg);
 
+int op_latency(op* op, schedule_info& hwinfo);

--- a/prog.h
+++ b/prog.h
@@ -1716,13 +1716,7 @@ struct schedule_info {
   map<op*, int> instance_latencies;
   map<op*, int> op_offset_within_parent;
 
-  int compute_latency(op* op) {
-    if (op->func == "") {
-      return 0;
-    }
-    assert(contains_key(op->func, compute_unit_latencies));
-    return map_find(op->func, compute_unit_latencies);
-  }
+  int compute_latency(op* op);
 
   int store_latency(const std::string& buf) {
     assert(contains_key(buf, buffer_store_latencies));

--- a/prog.h
+++ b/prog.h
@@ -1702,6 +1702,7 @@ struct schedule_info {
   map<string, int> buffer_load_latencies;
   map<string, int> buffer_store_latencies;
   map<string, int> compute_unit_latencies;
+  map<string, string> op_compute_unit_names;
   map<string, int> op_compute_unit_latencies;
 
   // Resource constraints

--- a/ubuffer.cpp
+++ b/ubuffer.cpp
@@ -2057,10 +2057,12 @@ bool build_delay_map(UBuffer& buf, map<string, vector<pair<string, int> > >& del
       //}
       //assert(false);
       //int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
-      int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
+      //int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
       //int op_latency = hwinfo.compute_latency(write_op);
       //assert(op_latency == 0);
 
+      int op_latency = hwinfo.compute_latency(writer_name);
+      //map_find(writer_name, hwinfo.op_compute_unit_latencies);
       dd = dd - op_latency;
 
       delay_maps[inpt].push_back({outpt, dd});

--- a/ubuffer.cpp
+++ b/ubuffer.cpp
@@ -2146,11 +2146,12 @@ bool build_delay_map(UBuffer& buf, map<string, vector<pair<string, int> > >& del
           cout << "DD           : " << dd << endl;
           string writer_name = domain_name(pick(get_maps(writes)));
           cout << "writer op    : " << writer_name << endl;
-          for (auto e : hwinfo.op_compute_unit_latencies) {
-            cout << tab(1) << e.first << " -> " << e.second << endl;
-          }
+          //for (auto e : hwinfo.op_compute_unit_latencies) {
+            //cout << tab(1) << e.first << " -> " << e.second << endl;
+          //}
           //assert(false);
-          int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
+          //int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
+          int op_latency = hwinfo.compute_latency(writer_name);
           //assert(op_latency == 0);
 
           dd = dd - op_latency;

--- a/ubuffer.cpp
+++ b/ubuffer.cpp
@@ -2050,12 +2050,15 @@ bool build_delay_map(UBuffer& buf, map<string, vector<pair<string, int> > >& del
       int dd = to_int(lexminval(ddc));
       cout << "DD           : " << dd << endl;
       string writer_name = domain_name(pick(get_maps(writes)));
-      cout << "writer op    : " << writer_name << endl;
-      for (auto e : hwinfo.op_compute_unit_latencies) {
-        cout << tab(1) << e.first << " -> " << e.second << endl;
-      }
+      //auto write_op = prg.find_op(writer_name);
+      //cout << "writer op    : " << writer_name << endl;
+      //for (auto e : hwinfo.op_compute_unit_latencies) {
+        //cout << tab(1) << e.first << " -> " << e.second << endl;
+      //}
       //assert(false);
-      int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
+      //int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
+      int op_latency = map_find(writer_name + "_pipelined", hwinfo.op_compute_unit_latencies);
+      //int op_latency = hwinfo.compute_latency(write_op);
       //assert(op_latency == 0);
 
       dd = dd - op_latency;

--- a/ubuffer.cpp
+++ b/ubuffer.cpp
@@ -2057,7 +2057,7 @@ bool build_delay_map(UBuffer& buf, map<string, vector<pair<string, int> > >& del
       //}
       //assert(false);
       //int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
-      int op_latency = map_find(writer_name + "_pipelined", hwinfo.op_compute_unit_latencies);
+      int op_latency = map_find(writer_name, hwinfo.op_compute_unit_latencies);
       //int op_latency = hwinfo.compute_latency(write_op);
       //assert(op_latency == 0);
 

--- a/unoptimized_pointwise.cpp
+++ b/unoptimized_pointwise.cpp
@@ -127,24 +127,6 @@ inline void mult_stencil_op_hcompute_mult_stencil_write_bundle_write(hw_uint<16>
 
 
 // Operation logic
-inline void op_hcompute_hw_output_stencil(mult_stencil_cache& mult_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: mult_stencil
-	auto mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = mult_stencil_op_hcompute_hw_output_stencil_read_bundle_read(mult_stencil/* source_delay */, root, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x) {
   // Dynamic address computation
 
@@ -171,6 +153,24 @@ inline void op_hcompute_mult_stencil(hw_input_global_wrapper_stencil_cache& hw_i
 	auto compute_result = hcompute_mult_stencil(hw_input_global_wrapper_stencil_mult_s0_y_c__mult_s0_x_value);
 	// Produce: mult_stencil
 	mult_stencil_op_hcompute_mult_stencil_write_bundle_write(/* arg names */compute_result, mult_stencil, root, mult_s0_y, mult_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_output_stencil(mult_stencil_cache& mult_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: mult_stencil
+	auto mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = mult_stencil_op_hcompute_hw_output_stencil_read_bundle_read(mult_stencil/* source_delay */, root, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__

--- a/unoptimized_pointwise.cpp
+++ b/unoptimized_pointwise.cpp
@@ -127,6 +127,24 @@ inline void mult_stencil_op_hcompute_mult_stencil_write_bundle_write(hw_uint<16>
 
 
 // Operation logic
+inline void op_hcompute_hw_output_stencil(mult_stencil_cache& mult_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: mult_stencil
+	auto mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = mult_stencil_op_hcompute_hw_output_stencil_read_bundle_read(mult_stencil/* source_delay */, root, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x) {
   // Dynamic address computation
 
@@ -153,24 +171,6 @@ inline void op_hcompute_mult_stencil(hw_input_global_wrapper_stencil_cache& hw_i
 	auto compute_result = hcompute_mult_stencil(hw_input_global_wrapper_stencil_mult_s0_y_c__mult_s0_x_value);
 	// Produce: mult_stencil
 	mult_stencil_op_hcompute_mult_stencil_write_bundle_write(/* arg names */compute_result, mult_stencil, root, mult_s0_y, mult_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_output_stencil(mult_stencil_cache& mult_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: mult_stencil
-	auto mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = mult_stencil_op_hcompute_hw_output_stencil_read_bundle_read(mult_stencil/* source_delay */, root, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(mult_stencil_hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,30 +932,28 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
-	// Consume: conv_stencil
-	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+}
 
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
 
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -992,14 +990,54 @@ inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1054,44 +1092,6 @@ inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWSt
 
 }
 
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,14 +932,14 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -958,6 +958,20 @@ inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWSt
 	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
 	// Produce: hw_output_stencil
 	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -994,48 +1008,6 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
@@ -1060,14 +1032,12 @@ inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int roo
 
 }
 
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1104,6 +1074,36 @@ inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 // Driver function
 void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_input_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_kernel_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_output_stencil) {
 
@@ -1124,15 +1124,15 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,14 +932,12 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -958,30 +956,14 @@ inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int roo
 
 }
 
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
   // Dynamic address computation
 
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1018,6 +1000,24 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -1048,18 +1048,6 @@ inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -1084,6 +1072,18 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,6 +932,30 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
   // Dynamic address computation
 
@@ -956,74 +980,6 @@ inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root,
 	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1060,6 +1016,34 @@ inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -1090,14 +1074,30 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -946,50 +946,6 @@ inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& 
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -1020,6 +976,20 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
@@ -1032,18 +1002,30 @@ inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root,
 
 }
 
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1104,6 +1086,24 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 // Driver function
 void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_input_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_kernel_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_output_stencil) {
 
@@ -1124,15 +1124,15 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -12,16 +12,16 @@ using namespace std;
 #include "hw_classes.h"
 
 struct conv_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 27], [0, 27], [0, 3]}
-  hw_uint<16> RAM[3][28][28][4];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
-    return RAM[d0][d1][d2][d3];
+	// RAM Box: {[0, 2], [0, 27], [0, 27]}
+  hw_uint<16> RAM[3][28][28];
+  inline hw_uint<16> read(int d0, int d1, int d2) {
+    return RAM[d0][d1][d2];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
-    RAM[d0][d1][d2][d3] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
+    RAM[d0][d1][d2] = value;
   }
 
 };
@@ -33,62 +33,62 @@ struct conv_stencil_cache {
 
 
 
-inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0);
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
@@ -96,90 +96,90 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_sten
 // # of bundles = 10
 // op_hcompute_conv_stencil_1_write
 //	conv_stencil_op_hcompute_conv_stencil_1_61
-inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_1_61_res = op_hcompute_conv_stencil_1_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_2_write
 //	conv_stencil_op_hcompute_conv_stencil_2_60
-inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_2_60_res = op_hcompute_conv_stencil_2_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_3_read
 //	conv_stencil_op_hcompute_conv_stencil_3_43
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_3_43
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_3_43_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_3_write
 //	conv_stencil_op_hcompute_conv_stencil_3_42
-inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_42_res = op_hcompute_conv_stencil_3_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_4_read
 //	conv_stencil_op_hcompute_conv_stencil_4_25
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_4_25
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_4_25_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_4_write
 //	conv_stencil_op_hcompute_conv_stencil_4_24
-inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_24_res = op_hcompute_conv_stencil_4_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_5_read
 //	conv_stencil_op_hcompute_conv_stencil_5_7
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_5_7
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_5_7_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_5_write
 //	conv_stencil_op_hcompute_conv_stencil_5_6
-inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_6_res = op_hcompute_conv_stencil_5_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_write
 //	conv_stencil_op_hcompute_conv_stencil_62
-inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_62_res = op_hcompute_conv_stencil_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_hw_output_stencil_read
 //	conv_stencil_op_hcompute_hw_output_stencil_1
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_hw_output_stencil_1
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_hw_output_stencil_1_res);
 	return result;
 }
@@ -187,16 +187,16 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(c
 #include "hw_classes.h"
 
 struct hw_input_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 29], [0, 29], [0, 7], [0, 3]}
-  hw_uint<16> RAM[30][30][8][4];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
-    return RAM[d0][d1][d2][d3];
+	// RAM Box: {[0, 29], [0, 29], [0, 7]}
+  hw_uint<16> RAM[30][30][8];
+  inline hw_uint<16> read(int d0, int d1, int d2) {
+    return RAM[d0][d1][d2];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
-    RAM[d0][d1][d2][d3] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
+    RAM[d0][d1][d2] = value;
   }
 
 };
@@ -208,222 +208,222 @@ struct hw_input_global_wrapper_stencil_cache {
 
 
 
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
-  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0, gb_tile - 0);
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0);
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
@@ -438,7 +438,7 @@ inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45
@@ -450,21 +450,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res);
 	return result;
 }
@@ -478,7 +478,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27
@@ -490,21 +490,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res);
 	return result;
 }
@@ -518,7 +518,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9
@@ -530,45 +530,45 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res);
 	return result;
 }
 
 // op_hcompute_hw_input_global_wrapper_stencil_write
 //	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res = op_hcompute_hw_input_global_wrapper_stencil_write.extract<0, 15>();
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
 }
 
 #include "hw_classes.h"
 
 struct hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7], [0, 3]}
-  hw_uint<16> RAM[3][3][3][8][4];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3, int d4) {
-    return RAM[d0][d1][d2][d3][d4];
+	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7]}
+  hw_uint<16> RAM[3][3][3][8];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
+    return RAM[d0][d1][d2][d3];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3, int d4) {
-    RAM[d0][d1][d2][d3][d4] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
+    RAM[d0][d1][d2][d3] = value;
   }
 
 };
@@ -580,222 +580,222 @@ struct hw_kernel_global_wrapper_stencil_cache {
 
 
 
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
-  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0, gb_tile - 0);
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0);
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
@@ -810,7 +810,7 @@ inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_2
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53
@@ -822,21 +822,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res);
 	return result;
 }
@@ -850,7 +850,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35
@@ -862,21 +862,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res);
 	return result;
 }
@@ -890,7 +890,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17
@@ -902,202 +902,202 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res);
 	return result;
 }
 
 // op_hcompute_hw_kernel_global_wrapper_stencil_write
 //	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res = op_hcompute_hw_kernel_global_wrapper_stencil_write.extract<0, 15>();
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
 }
 
-// Total re-use buffer capacity: 625152 bits
+// Total re-use buffer capacity: 156288 bits
 
 
 // Operation logic
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
   // Dynamic address computation
 
 	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value);
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
 	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
   // Dynamic address computation
 
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
-	auto compute_result = hcompute_conv_stencil_1();
+	// Consume: conv_stencil
+	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_2();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value);
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value);
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,86 +1124,86 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-//   { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_1(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-1 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_5(((-2 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-4 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_2(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-2 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
-//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (29 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-1 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (2 - i9 >= 0) && (i11 >= 0) && (7 - i11 >= 0)))
-//   { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_4(((-1 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+//   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
+//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
+//   { op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_1(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-1 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
+//   { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_5(((-2 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 
   /*
-for (int c3 = 0; c3 <= 3; c3 += 1) {
-  for (int c5 = 0; c5 <= 29; c5 += 1)
-    for (int c7 = 0; c7 <= 29; c7 += 1)
-      for (int c9 = 0; c9 <= 7; c9 += 1)
-        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7, c9);
-  for (int c5 = 0; c5 <= 2; c5 += 1)
-    for (int c7 = 0; c7 <= 2; c7 += 1)
-      for (int c9 = 0; c9 <= 2; c9 += 1)
-        for (int c11 = 0; c11 <= 7; c11 += 1)
-          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9, c11);
-  for (int c5 = 0; c5 <= 27; c5 += 1)
-    for (int c7 = 0; c7 <= 27; c7 += 1) {
-      op_hcompute_conv_stencil(0, c3, c5, c7);
-      op_hcompute_conv_stencil_1(0, c3, c5, c7);
-      op_hcompute_conv_stencil_2(0, c3, c5, c7);
+{
+  for (int c3 = 0; c3 <= 29; c3 += 1)
+    for (int c5 = 0; c5 <= 29; c5 += 1)
+      for (int c7 = 0; c7 <= 7; c7 += 1)
+        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7);
+  for (int c3 = 0; c3 <= 2; c3 += 1)
+    for (int c5 = 0; c5 <= 2; c5 += 1)
+      for (int c7 = 0; c7 <= 2; c7 += 1)
+        for (int c9 = 0; c9 <= 7; c9 += 1)
+          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9);
+  for (int c3 = 0; c3 <= 27; c3 += 1)
+    for (int c5 = 0; c5 <= 27; c5 += 1) {
+      op_hcompute_conv_stencil(0, c3, c5);
+      op_hcompute_conv_stencil_1(0, c3, c5);
+      op_hcompute_conv_stencil_2(0, c3, c5);
     }
-  for (int c5 = 0; c5 <= 2; c5 += 1)
-    for (int c7 = 0; c7 <= 2; c7 += 1)
-      for (int c9 = 0; c9 <= 27; c9 += 1)
-        for (int c11 = 0; c11 <= 27; c11 += 1) {
-          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9, c11);
-          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9, c11);
-          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9, c11);
+  for (int c3 = 0; c3 <= 2; c3 += 1)
+    for (int c5 = 0; c5 <= 2; c5 += 1)
+      for (int c7 = 0; c7 <= 27; c7 += 1)
+        for (int c9 = 0; c9 <= 27; c9 += 1) {
+          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9);
+          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9);
+          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9);
         }
-  for (int c5 = 0; c5 <= 2; c5 += 1)
-    for (int c7 = 0; c7 <= 27; c7 += 1)
-      for (int c9 = 0; c9 <= 27; c9 += 1)
-        op_hcompute_hw_output_stencil(0, c3, c5, c7, c9);
+  for (int c3 = 0; c3 <= 2; c3 += 1)
+    for (int c5 = 0; c5 <= 27; c5 += 1)
+      for (int c7 = 0; c7 <= 27; c7 += 1)
+        op_hcompute_hw_output_stencil(0, c3, c5, c7);
 }
 
   */
-	for (int c3 = 0; c3 <= 3; c3 += 1) {
-	  for (int c5 = 0; c5 <= 29; c5 += 1)
-	    for (int c7 = 0; c7 <= 29; c7 += 1)
-	      for (int c9 = 0; c9 <= 7; c9 += 1)
-	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7, c9);
-	  for (int c5 = 0; c5 <= 2; c5 += 1)
-	    for (int c7 = 0; c7 <= 2; c7 += 1)
-	      for (int c9 = 0; c9 <= 2; c9 += 1)
-	        for (int c11 = 0; c11 <= 7; c11 += 1)
-	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9, c11);
-	  for (int c5 = 0; c5 <= 27; c5 += 1)
-	    for (int c7 = 0; c7 <= 27; c7 += 1) {
-	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5, c7);
-	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5, c7);
-	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5, c7);
+	{
+	  for (int c3 = 0; c3 <= 29; c3 += 1)
+	    for (int c5 = 0; c5 <= 29; c5 += 1)
+	      for (int c7 = 0; c7 <= 7; c7 += 1)
+	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7);
+	  for (int c3 = 0; c3 <= 2; c3 += 1)
+	    for (int c5 = 0; c5 <= 2; c5 += 1)
+	      for (int c7 = 0; c7 <= 2; c7 += 1)
+	        for (int c9 = 0; c9 <= 7; c9 += 1)
+	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9);
+	  for (int c3 = 0; c3 <= 27; c3 += 1)
+	    for (int c5 = 0; c5 <= 27; c5 += 1) {
+	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5);
+	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5);
+	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5);
 	    }
-	  for (int c5 = 0; c5 <= 2; c5 += 1)
-	    for (int c7 = 0; c7 <= 2; c7 += 1)
-	      for (int c9 = 0; c9 <= 27; c9 += 1)
-	        for (int c11 = 0; c11 <= 27; c11 += 1) {
-	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
-	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
-	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
+	  for (int c3 = 0; c3 <= 2; c3 += 1)
+	    for (int c5 = 0; c5 <= 2; c5 += 1)
+	      for (int c7 = 0; c7 <= 27; c7 += 1)
+	        for (int c9 = 0; c9 <= 27; c9 += 1) {
+	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
+	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
+	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
 	        }
-	  for (int c5 = 0; c5 <= 2; c5 += 1)
-	    for (int c7 = 0; c7 <= 27; c7 += 1)
-	      for (int c9 = 0; c9 <= 27; c9 += 1)
-	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7, c9);
+	  for (int c3 = 0; c3 <= 2; c3 += 1)
+	    for (int c5 = 0; c5 <= 27; c5 += 1)
+	      for (int c7 = 0; c7 <= 27; c7 += 1)
+	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7);
 	}
 	
 #ifndef __VIVADO_SYNTH__
@@ -1218,12 +1218,12 @@ void unoptimized_resnet_wrapper(HWStream<hw_uint<16> >& /* no bundle get_args nu
   }
 }
 #ifdef __VIVADO_SYNTH__
-  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 28800;
-  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 864;
-  // { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 9408;
+  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 7200;
+  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 216;
+  // { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 2352;
 
 
 extern "C" {

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,56 +932,14 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
   // Dynamic address computation
 
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1018,44 +976,30 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-}
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil();
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1092,12 +1036,68 @@ inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_2();
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,36 +932,6 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -992,42 +962,6 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
   // Dynamic address computation
 
@@ -1040,6 +974,48 @@ inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWSt
 	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
 	// Produce: hw_output_stencil
 	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1070,6 +1046,30 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,15 +1124,15 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -960,36 +960,6 @@ inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >&
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
@@ -1014,30 +984,42 @@ inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int roo
 
 }
 
-inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1074,6 +1056,36 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
   // Dynamic address computation
 
@@ -1086,18 +1098,6 @@ inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWSt
 	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
 	// Produce: hw_output_stencil
 	hw_output_stencil.write(compute_result);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -12,16 +12,16 @@ using namespace std;
 #include "hw_classes.h"
 
 struct conv_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 27], [0, 27]}
-  hw_uint<16> RAM[3][28][28];
-  inline hw_uint<16> read(int d0, int d1, int d2) {
-    return RAM[d0][d1][d2];
+	// RAM Box: {[0, 2], [0, 27], [0, 27], [0, 3]}
+  hw_uint<16> RAM[3][28][28][4];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
+    return RAM[d0][d1][d2][d3];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
-    RAM[d0][d1][d2] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
+    RAM[d0][d1][d2][d3] = value;
   }
 
 };
@@ -33,62 +33,62 @@ struct conv_stencil_cache {
 
 
 
-inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0);
+  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0);
+  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0);
+  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0);
+  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
@@ -96,90 +96,90 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_sten
 // # of bundles = 10
 // op_hcompute_conv_stencil_1_write
 //	conv_stencil_op_hcompute_conv_stencil_1_61
-inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_1_61_res = op_hcompute_conv_stencil_1_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_2_write
 //	conv_stencil_op_hcompute_conv_stencil_2_60
-inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_2_60_res = op_hcompute_conv_stencil_2_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_3_read
 //	conv_stencil_op_hcompute_conv_stencil_3_43
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_3_43
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_3_43_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_3_write
 //	conv_stencil_op_hcompute_conv_stencil_3_42
-inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_42_res = op_hcompute_conv_stencil_3_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_4_read
 //	conv_stencil_op_hcompute_conv_stencil_4_25
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_4_25
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_4_25_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_4_write
 //	conv_stencil_op_hcompute_conv_stencil_4_24
-inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_24_res = op_hcompute_conv_stencil_4_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_5_read
 //	conv_stencil_op_hcompute_conv_stencil_5_7
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_5_7
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_5_7_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_5_write
 //	conv_stencil_op_hcompute_conv_stencil_5_6
-inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_6_res = op_hcompute_conv_stencil_5_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_write
 //	conv_stencil_op_hcompute_conv_stencil_62
-inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_62_res = op_hcompute_conv_stencil_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_hw_output_stencil_read
 //	conv_stencil_op_hcompute_hw_output_stencil_1
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_hw_output_stencil_1
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_hw_output_stencil_1_res);
 	return result;
 }
@@ -187,16 +187,16 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(c
 #include "hw_classes.h"
 
 struct hw_input_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 29], [0, 29], [0, 7]}
-  hw_uint<16> RAM[30][30][8];
-  inline hw_uint<16> read(int d0, int d1, int d2) {
-    return RAM[d0][d1][d2];
+	// RAM Box: {[0, 29], [0, 29], [0, 7], [0, 3]}
+  hw_uint<16> RAM[30][30][8][4];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
+    return RAM[d0][d1][d2][d3];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
-    RAM[d0][d1][d2] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
+    RAM[d0][d1][d2][d3] = value;
   }
 
 };
@@ -208,222 +208,222 @@ struct hw_input_global_wrapper_stencil_cache {
 
 
 
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
-  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0);
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0, gb_tile - 0);
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
@@ -438,7 +438,7 @@ inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45
@@ -450,21 +450,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res);
 	return result;
 }
@@ -478,7 +478,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27
@@ -490,21 +490,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res);
 	return result;
 }
@@ -518,7 +518,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9
@@ -530,45 +530,45 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res);
 	return result;
 }
 
 // op_hcompute_hw_input_global_wrapper_stencil_write
 //	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res = op_hcompute_hw_input_global_wrapper_stencil_write.extract<0, 15>();
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
 }
 
 #include "hw_classes.h"
 
 struct hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7]}
-  hw_uint<16> RAM[3][3][3][8];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
-    return RAM[d0][d1][d2][d3];
+	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7], [0, 3]}
+  hw_uint<16> RAM[3][3][3][8][4];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3, int d4) {
+    return RAM[d0][d1][d2][d3][d4];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
-    RAM[d0][d1][d2][d3] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3, int d4) {
+    RAM[d0][d1][d2][d3][d4] = value;
   }
 
 };
@@ -580,222 +580,222 @@ struct hw_kernel_global_wrapper_stencil_cache {
 
 
 
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
-  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0);
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0, gb_tile - 0);
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
@@ -810,7 +810,7 @@ inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_2
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53
@@ -822,21 +822,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res);
 	return result;
 }
@@ -850,7 +850,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35
@@ -862,21 +862,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res);
 	return result;
 }
@@ -890,7 +890,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17
@@ -902,200 +902,200 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res);
 	return result;
 }
 
 // op_hcompute_hw_kernel_global_wrapper_stencil_write
 //	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res = op_hcompute_hw_kernel_global_wrapper_stencil_write.extract<0, 15>();
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
 }
 
-// Total re-use buffer capacity: 156288 bits
+// Total re-use buffer capacity: 625152 bits
 
 
 // Operation logic
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
 	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value);
 	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
   // Dynamic address computation
 
 	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value);
 	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_1();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_2();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value);
 	// Produce: hw_output_stencil
 	hw_output_stencil.write(compute_result);
 
@@ -1124,86 +1124,86 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-//   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
-//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
-//   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
-//   { op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_1(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-1 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
-//   { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_5(((-2 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+// schedule: { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+//   { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_1(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-1 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_5(((-2 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-4 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_2(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-2 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
+//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (29 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-1 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (2 - i9 >= 0) && (i11 >= 0) && (7 - i11 >= 0)))
+//   { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_4(((-1 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
 
   /*
-{
-  for (int c3 = 0; c3 <= 29; c3 += 1)
-    for (int c5 = 0; c5 <= 29; c5 += 1)
-      for (int c7 = 0; c7 <= 7; c7 += 1)
-        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7);
-  for (int c3 = 0; c3 <= 2; c3 += 1)
-    for (int c5 = 0; c5 <= 2; c5 += 1)
-      for (int c7 = 0; c7 <= 2; c7 += 1)
-        for (int c9 = 0; c9 <= 7; c9 += 1)
-          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9);
-  for (int c3 = 0; c3 <= 27; c3 += 1)
-    for (int c5 = 0; c5 <= 27; c5 += 1) {
-      op_hcompute_conv_stencil(0, c3, c5);
-      op_hcompute_conv_stencil_1(0, c3, c5);
-      op_hcompute_conv_stencil_2(0, c3, c5);
+for (int c3 = 0; c3 <= 3; c3 += 1) {
+  for (int c5 = 0; c5 <= 29; c5 += 1)
+    for (int c7 = 0; c7 <= 29; c7 += 1)
+      for (int c9 = 0; c9 <= 7; c9 += 1)
+        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7, c9);
+  for (int c5 = 0; c5 <= 2; c5 += 1)
+    for (int c7 = 0; c7 <= 2; c7 += 1)
+      for (int c9 = 0; c9 <= 2; c9 += 1)
+        for (int c11 = 0; c11 <= 7; c11 += 1)
+          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9, c11);
+  for (int c5 = 0; c5 <= 27; c5 += 1)
+    for (int c7 = 0; c7 <= 27; c7 += 1) {
+      op_hcompute_conv_stencil(0, c3, c5, c7);
+      op_hcompute_conv_stencil_1(0, c3, c5, c7);
+      op_hcompute_conv_stencil_2(0, c3, c5, c7);
     }
-  for (int c3 = 0; c3 <= 2; c3 += 1)
-    for (int c5 = 0; c5 <= 2; c5 += 1)
-      for (int c7 = 0; c7 <= 27; c7 += 1)
-        for (int c9 = 0; c9 <= 27; c9 += 1) {
-          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9);
-          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9);
-          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9);
+  for (int c5 = 0; c5 <= 2; c5 += 1)
+    for (int c7 = 0; c7 <= 2; c7 += 1)
+      for (int c9 = 0; c9 <= 27; c9 += 1)
+        for (int c11 = 0; c11 <= 27; c11 += 1) {
+          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9, c11);
+          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9, c11);
+          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9, c11);
         }
-  for (int c3 = 0; c3 <= 2; c3 += 1)
-    for (int c5 = 0; c5 <= 27; c5 += 1)
-      for (int c7 = 0; c7 <= 27; c7 += 1)
-        op_hcompute_hw_output_stencil(0, c3, c5, c7);
+  for (int c5 = 0; c5 <= 2; c5 += 1)
+    for (int c7 = 0; c7 <= 27; c7 += 1)
+      for (int c9 = 0; c9 <= 27; c9 += 1)
+        op_hcompute_hw_output_stencil(0, c3, c5, c7, c9);
 }
 
   */
-	{
-	  for (int c3 = 0; c3 <= 29; c3 += 1)
-	    for (int c5 = 0; c5 <= 29; c5 += 1)
-	      for (int c7 = 0; c7 <= 7; c7 += 1)
-	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7);
-	  for (int c3 = 0; c3 <= 2; c3 += 1)
-	    for (int c5 = 0; c5 <= 2; c5 += 1)
-	      for (int c7 = 0; c7 <= 2; c7 += 1)
-	        for (int c9 = 0; c9 <= 7; c9 += 1)
-	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9);
-	  for (int c3 = 0; c3 <= 27; c3 += 1)
-	    for (int c5 = 0; c5 <= 27; c5 += 1) {
-	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5);
-	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5);
-	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5);
+	for (int c3 = 0; c3 <= 3; c3 += 1) {
+	  for (int c5 = 0; c5 <= 29; c5 += 1)
+	    for (int c7 = 0; c7 <= 29; c7 += 1)
+	      for (int c9 = 0; c9 <= 7; c9 += 1)
+	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7, c9);
+	  for (int c5 = 0; c5 <= 2; c5 += 1)
+	    for (int c7 = 0; c7 <= 2; c7 += 1)
+	      for (int c9 = 0; c9 <= 2; c9 += 1)
+	        for (int c11 = 0; c11 <= 7; c11 += 1)
+	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9, c11);
+	  for (int c5 = 0; c5 <= 27; c5 += 1)
+	    for (int c7 = 0; c7 <= 27; c7 += 1) {
+	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5, c7);
+	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5, c7);
+	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5, c7);
 	    }
-	  for (int c3 = 0; c3 <= 2; c3 += 1)
-	    for (int c5 = 0; c5 <= 2; c5 += 1)
-	      for (int c7 = 0; c7 <= 27; c7 += 1)
-	        for (int c9 = 0; c9 <= 27; c9 += 1) {
-	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
-	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
-	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
+	  for (int c5 = 0; c5 <= 2; c5 += 1)
+	    for (int c7 = 0; c7 <= 2; c7 += 1)
+	      for (int c9 = 0; c9 <= 27; c9 += 1)
+	        for (int c11 = 0; c11 <= 27; c11 += 1) {
+	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
+	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
+	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
 	        }
-	  for (int c3 = 0; c3 <= 2; c3 += 1)
-	    for (int c5 = 0; c5 <= 27; c5 += 1)
-	      for (int c7 = 0; c7 <= 27; c7 += 1)
-	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7);
+	  for (int c5 = 0; c5 <= 2; c5 += 1)
+	    for (int c7 = 0; c7 <= 27; c7 += 1)
+	      for (int c9 = 0; c9 <= 27; c9 += 1)
+	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7, c9);
 	}
 	
 #ifndef __VIVADO_SYNTH__
@@ -1218,12 +1218,12 @@ void unoptimized_resnet_wrapper(HWStream<hw_uint<16> >& /* no bundle get_args nu
   }
 }
 #ifdef __VIVADO_SYNTH__
-  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 7200;
-  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 216;
-  // { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 2352;
+  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 28800;
+  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 864;
+  // { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 9408;
 
 
 extern "C" {

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,6 +932,36 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -956,6 +986,42 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1024,18 +1090,6 @@ inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >&
 
 }
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
@@ -1044,60 +1098,6 @@ inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& 
 	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
 	// Produce: hw_input_global_wrapper_stencil
 	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,24 +932,30 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-}
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_2();
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -968,76 +974,6 @@ inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWSt
 	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
 	// Produce: hw_output_stencil
 	hw_output_stencil.write(compute_result);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1074,30 +1010,94 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,30 +932,6 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
   // Dynamic address computation
 
@@ -964,54 +940,6 @@ inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >&
 	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
 	// Produce: hw_kernel_global_wrapper_stencil
 	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1048,6 +976,90 @@ inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -1072,18 +1084,6 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -962,24 +962,30 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-}
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_2();
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1010,32 +1016,6 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1074,30 +1054,50 @@ inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& 
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -946,18 +946,30 @@ inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& 
 
 }
 
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1020,6 +1032,24 @@ inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root,
 
 }
 
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
@@ -1038,36 +1068,6 @@ inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int roo
 	auto compute_result = hcompute_conv_stencil_2();
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,104 +932,6 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -1104,6 +1006,104 @@ inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& 
 
 }
 
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 // Driver function
 void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_input_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_kernel_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_output_stencil) {
 
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,36 +932,6 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
@@ -976,98 +946,12 @@ inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& 
 
 }
 
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_1();
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1104,6 +988,122 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 // Driver function
 void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_input_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_kernel_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_output_stencil) {
 
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -12,16 +12,16 @@ using namespace std;
 #include "hw_classes.h"
 
 struct conv_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 27], [0, 27], [0, 3]}
-  hw_uint<16> RAM[3][28][28][4];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
-    return RAM[d0][d1][d2][d3];
+	// RAM Box: {[0, 2], [0, 27], [0, 27]}
+  hw_uint<16> RAM[3][28][28];
+  inline hw_uint<16> read(int d0, int d1, int d2) {
+    return RAM[d0][d1][d2];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
-    RAM[d0][d1][d2][d3] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
+    RAM[d0][d1][d2] = value;
   }
 
 };
@@ -33,62 +33,62 @@ struct conv_stencil_cache {
 
 
 
-inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0);
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0, gb_tile - 0);
+  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
@@ -96,90 +96,90 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_sten
 // # of bundles = 10
 // op_hcompute_conv_stencil_1_write
 //	conv_stencil_op_hcompute_conv_stencil_1_61
-inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_1_61_res = op_hcompute_conv_stencil_1_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_2_write
 //	conv_stencil_op_hcompute_conv_stencil_2_60
-inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_2_60_res = op_hcompute_conv_stencil_2_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_3_read
 //	conv_stencil_op_hcompute_conv_stencil_3_43
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_3_43
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_3_43_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_3_write
 //	conv_stencil_op_hcompute_conv_stencil_3_42
-inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_42_res = op_hcompute_conv_stencil_3_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_4_read
 //	conv_stencil_op_hcompute_conv_stencil_4_25
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_4_25
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_4_25_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_4_write
 //	conv_stencil_op_hcompute_conv_stencil_4_24
-inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_24_res = op_hcompute_conv_stencil_4_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_5_read
 //	conv_stencil_op_hcompute_conv_stencil_5_7
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_5_7
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_5_7_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_5_write
 //	conv_stencil_op_hcompute_conv_stencil_5_6
-inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_6_res = op_hcompute_conv_stencil_5_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_write
 //	conv_stencil_op_hcompute_conv_stencil_62
-inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_62_res = op_hcompute_conv_stencil_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_hw_output_stencil_read
 //	conv_stencil_op_hcompute_hw_output_stencil_1
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_hw_output_stencil_1
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_hw_output_stencil_1_res);
 	return result;
 }
@@ -187,16 +187,16 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(c
 #include "hw_classes.h"
 
 struct hw_input_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 29], [0, 29], [0, 7], [0, 3]}
-  hw_uint<16> RAM[30][30][8][4];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
-    return RAM[d0][d1][d2][d3];
+	// RAM Box: {[0, 29], [0, 29], [0, 7]}
+  hw_uint<16> RAM[30][30][8];
+  inline hw_uint<16> read(int d0, int d1, int d2) {
+    return RAM[d0][d1][d2];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
-    RAM[d0][d1][d2][d3] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
+    RAM[d0][d1][d2] = value;
   }
 
 };
@@ -208,222 +208,222 @@ struct hw_input_global_wrapper_stencil_cache {
 
 
 
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
-  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0, gb_tile - 0);
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0);
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
@@ -438,7 +438,7 @@ inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45
@@ -450,21 +450,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res);
 	return result;
 }
@@ -478,7 +478,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27
@@ -490,21 +490,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res);
 	return result;
 }
@@ -518,7 +518,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9
@@ -530,45 +530,45 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res);
 	return result;
 }
 
 // op_hcompute_hw_input_global_wrapper_stencil_write
 //	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res = op_hcompute_hw_input_global_wrapper_stencil_write.extract<0, 15>();
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
 }
 
 #include "hw_classes.h"
 
 struct hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7], [0, 3]}
-  hw_uint<16> RAM[3][3][3][8][4];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3, int d4) {
-    return RAM[d0][d1][d2][d3][d4];
+	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7]}
+  hw_uint<16> RAM[3][3][3][8];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
+    return RAM[d0][d1][d2][d3];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3, int d4) {
-    RAM[d0][d1][d2][d3][d4] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
+    RAM[d0][d1][d2][d3] = value;
   }
 
 };
@@ -580,222 +580,222 @@ struct hw_kernel_global_wrapper_stencil_cache {
 
 
 
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
-  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0, gb_tile - 0);
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0);
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0, gb_tile - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
@@ -810,7 +810,7 @@ inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_2
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53
@@ -822,21 +822,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res);
 	return result;
 }
@@ -850,7 +850,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35
@@ -862,21 +862,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res);
 	return result;
 }
@@ -890,7 +890,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17
@@ -902,202 +902,202 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res);
 	return result;
 }
 
 // op_hcompute_hw_kernel_global_wrapper_stencil_write
 //	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res = op_hcompute_hw_kernel_global_wrapper_stencil_write.extract<0, 15>();
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
 }
 
-// Total re-use buffer capacity: 625152 bits
+// Total re-use buffer capacity: 156288 bits
 
 
 // Operation logic
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
   // Dynamic address computation
 
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_1();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_2();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value);
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value);
+	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
-	// Consume: conv_stencil
-	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,86 +1124,86 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-//   { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_1(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-1 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_5(((-2 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-4 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_2(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-2 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
-//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (29 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-1 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (2 - i9 >= 0) && (i11 >= 0) && (7 - i11 >= 0)))
-//   { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_4(((-1 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+//   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
+//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
+//   { op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_1(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-1 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
+//   { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_5(((-2 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 
   /*
-for (int c3 = 0; c3 <= 3; c3 += 1) {
-  for (int c5 = 0; c5 <= 29; c5 += 1)
-    for (int c7 = 0; c7 <= 29; c7 += 1)
-      for (int c9 = 0; c9 <= 7; c9 += 1)
-        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7, c9);
-  for (int c5 = 0; c5 <= 2; c5 += 1)
-    for (int c7 = 0; c7 <= 2; c7 += 1)
-      for (int c9 = 0; c9 <= 2; c9 += 1)
-        for (int c11 = 0; c11 <= 7; c11 += 1)
-          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9, c11);
-  for (int c5 = 0; c5 <= 27; c5 += 1)
-    for (int c7 = 0; c7 <= 27; c7 += 1) {
-      op_hcompute_conv_stencil(0, c3, c5, c7);
-      op_hcompute_conv_stencil_1(0, c3, c5, c7);
-      op_hcompute_conv_stencil_2(0, c3, c5, c7);
+{
+  for (int c3 = 0; c3 <= 29; c3 += 1)
+    for (int c5 = 0; c5 <= 29; c5 += 1)
+      for (int c7 = 0; c7 <= 7; c7 += 1)
+        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7);
+  for (int c3 = 0; c3 <= 2; c3 += 1)
+    for (int c5 = 0; c5 <= 2; c5 += 1)
+      for (int c7 = 0; c7 <= 2; c7 += 1)
+        for (int c9 = 0; c9 <= 7; c9 += 1)
+          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9);
+  for (int c3 = 0; c3 <= 27; c3 += 1)
+    for (int c5 = 0; c5 <= 27; c5 += 1) {
+      op_hcompute_conv_stencil(0, c3, c5);
+      op_hcompute_conv_stencil_1(0, c3, c5);
+      op_hcompute_conv_stencil_2(0, c3, c5);
     }
-  for (int c5 = 0; c5 <= 2; c5 += 1)
-    for (int c7 = 0; c7 <= 2; c7 += 1)
-      for (int c9 = 0; c9 <= 27; c9 += 1)
-        for (int c11 = 0; c11 <= 27; c11 += 1) {
-          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9, c11);
-          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9, c11);
-          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9, c11);
+  for (int c3 = 0; c3 <= 2; c3 += 1)
+    for (int c5 = 0; c5 <= 2; c5 += 1)
+      for (int c7 = 0; c7 <= 27; c7 += 1)
+        for (int c9 = 0; c9 <= 27; c9 += 1) {
+          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9);
+          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9);
+          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9);
         }
-  for (int c5 = 0; c5 <= 2; c5 += 1)
-    for (int c7 = 0; c7 <= 27; c7 += 1)
-      for (int c9 = 0; c9 <= 27; c9 += 1)
-        op_hcompute_hw_output_stencil(0, c3, c5, c7, c9);
+  for (int c3 = 0; c3 <= 2; c3 += 1)
+    for (int c5 = 0; c5 <= 27; c5 += 1)
+      for (int c7 = 0; c7 <= 27; c7 += 1)
+        op_hcompute_hw_output_stencil(0, c3, c5, c7);
 }
 
   */
-	for (int c3 = 0; c3 <= 3; c3 += 1) {
-	  for (int c5 = 0; c5 <= 29; c5 += 1)
-	    for (int c7 = 0; c7 <= 29; c7 += 1)
-	      for (int c9 = 0; c9 <= 7; c9 += 1)
-	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7, c9);
-	  for (int c5 = 0; c5 <= 2; c5 += 1)
-	    for (int c7 = 0; c7 <= 2; c7 += 1)
-	      for (int c9 = 0; c9 <= 2; c9 += 1)
-	        for (int c11 = 0; c11 <= 7; c11 += 1)
-	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9, c11);
-	  for (int c5 = 0; c5 <= 27; c5 += 1)
-	    for (int c7 = 0; c7 <= 27; c7 += 1) {
-	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5, c7);
-	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5, c7);
-	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5, c7);
+	{
+	  for (int c3 = 0; c3 <= 29; c3 += 1)
+	    for (int c5 = 0; c5 <= 29; c5 += 1)
+	      for (int c7 = 0; c7 <= 7; c7 += 1)
+	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7);
+	  for (int c3 = 0; c3 <= 2; c3 += 1)
+	    for (int c5 = 0; c5 <= 2; c5 += 1)
+	      for (int c7 = 0; c7 <= 2; c7 += 1)
+	        for (int c9 = 0; c9 <= 7; c9 += 1)
+	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9);
+	  for (int c3 = 0; c3 <= 27; c3 += 1)
+	    for (int c5 = 0; c5 <= 27; c5 += 1) {
+	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5);
+	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5);
+	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5);
 	    }
-	  for (int c5 = 0; c5 <= 2; c5 += 1)
-	    for (int c7 = 0; c7 <= 2; c7 += 1)
-	      for (int c9 = 0; c9 <= 27; c9 += 1)
-	        for (int c11 = 0; c11 <= 27; c11 += 1) {
-	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
-	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
-	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
+	  for (int c3 = 0; c3 <= 2; c3 += 1)
+	    for (int c5 = 0; c5 <= 2; c5 += 1)
+	      for (int c7 = 0; c7 <= 27; c7 += 1)
+	        for (int c9 = 0; c9 <= 27; c9 += 1) {
+	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
+	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
+	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
 	        }
-	  for (int c5 = 0; c5 <= 2; c5 += 1)
-	    for (int c7 = 0; c7 <= 27; c7 += 1)
-	      for (int c9 = 0; c9 <= 27; c9 += 1)
-	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7, c9);
+	  for (int c3 = 0; c3 <= 2; c3 += 1)
+	    for (int c5 = 0; c5 <= 27; c5 += 1)
+	      for (int c7 = 0; c7 <= 27; c7 += 1)
+	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7);
 	}
 	
 #ifndef __VIVADO_SYNTH__
@@ -1218,12 +1218,12 @@ void unoptimized_resnet_wrapper(HWStream<hw_uint<16> >& /* no bundle get_args nu
   }
 }
 #ifdef __VIVADO_SYNTH__
-  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 28800;
-  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 864;
-  // { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 9408;
+  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 7200;
+  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 216;
+  // { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 2352;
 
 
 extern "C" {

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,20 +932,6 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
-  // Dynamic address computation
-
-	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
-	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
 inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
   // Dynamic address computation
 
@@ -954,30 +940,6 @@ inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >&
 	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
 	// Produce: hw_kernel_global_wrapper_stencil
 	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -996,30 +958,30 @@ inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int roo
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
   // Dynamic address computation
 
 	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+}
 
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
 
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1056,6 +1018,48 @@ inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
@@ -1086,18 +1090,14 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
+	// Consume: hw_input_stencil
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	// Produce: hw_input_global_wrapper_stencil
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -980,30 +980,24 @@ inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWSt
 
 }
 
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	auto compute_result = hcompute_conv_stencil_1();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1016,6 +1010,20 @@ inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root,
 	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1052,38 +1060,30 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
-}
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
-  // Dynamic address computation
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
 
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -12,16 +12,16 @@ using namespace std;
 #include "hw_classes.h"
 
 struct conv_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 27], [0, 27]}
-  hw_uint<16> RAM[3][28][28];
-  inline hw_uint<16> read(int d0, int d1, int d2) {
-    return RAM[d0][d1][d2];
+	// RAM Box: {[0, 2], [0, 27], [0, 27], [0, 3]}
+  hw_uint<16> RAM[3][28][28][4];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
+    return RAM[d0][d1][d2][d3];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
-    RAM[d0][d1][d2] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
+    RAM[d0][d1][d2][d3] = value;
   }
 
 };
@@ -33,62 +33,62 @@ struct conv_stencil_cache {
 
 
 
-inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_1_61_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_1_61, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_1_61, 1 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_2_60_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_2_60, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_2_60, 2 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_3_42_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_3_42, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_3_42, 0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_4_24_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_4_24, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_4_24, 1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_5_6_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_5_6, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_5_6, 2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
 }
 
-inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
-  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0);
+inline void conv_stencil_op_hcompute_conv_stencil_62_write(hw_uint<16>& conv_stencil_op_hcompute_conv_stencil_62, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+  conv_stencil.conv_stencil_all_inputs_to_all_outputs.write(conv_stencil_op_hcompute_conv_stencil_62, 0 - 0, conv_s0_y - 0, conv_s0_x - 0, gb_tile - 0);
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0);
+  // conv_stencil_op_hcompute_conv_stencil_3_43 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[0, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(0 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0);
+  // conv_stencil_op_hcompute_conv_stencil_4_25 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[1, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(1 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0);
+  // conv_stencil_op_hcompute_conv_stencil_5_7 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> conv_stencil[2, conv_s1_y, conv_s1_x, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(2 - 0, conv_s1_y - 0, conv_s1_x - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
 
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0);
+  // conv_stencil_op_hcompute_hw_output_stencil_1 read pattern: { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> conv_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+  auto value_conv_stencil_op_hcompute_conv_stencil_1_61 = conv_stencil.conv_stencil_all_inputs_to_all_outputs.read(hw_output_s0_w - 0, hw_output_s0_y_yi - 0, hw_output_s0_x_xi - 0, gb_tile - 0);
   return value_conv_stencil_op_hcompute_conv_stencil_1_61;
   return 0;
 }
@@ -96,90 +96,90 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_sten
 // # of bundles = 10
 // op_hcompute_conv_stencil_1_write
 //	conv_stencil_op_hcompute_conv_stencil_1_61
-inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_1_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_1_61_res = op_hcompute_conv_stencil_1_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_1_61_write(conv_stencil_op_hcompute_conv_stencil_1_61_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_2_write
 //	conv_stencil_op_hcompute_conv_stencil_2_60
-inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_2_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_2_60_res = op_hcompute_conv_stencil_2_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_2_60_write(conv_stencil_op_hcompute_conv_stencil_2_60_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_3_read
 //	conv_stencil_op_hcompute_conv_stencil_3_43
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_3_43
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_43_res = conv_stencil_op_hcompute_conv_stencil_3_43_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_3_43_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_3_write
 //	conv_stencil_op_hcompute_conv_stencil_3_42
-inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_3_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_3_42_res = op_hcompute_conv_stencil_3_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_3_42_write(conv_stencil_op_hcompute_conv_stencil_3_42_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_4_read
 //	conv_stencil_op_hcompute_conv_stencil_4_25
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_4_25
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_25_res = conv_stencil_op_hcompute_conv_stencil_4_25_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_4_25_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_4_write
 //	conv_stencil_op_hcompute_conv_stencil_4_24
-inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_4_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_4_24_res = op_hcompute_conv_stencil_4_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_4_24_write(conv_stencil_op_hcompute_conv_stencil_4_24_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_5_read
 //	conv_stencil_op_hcompute_conv_stencil_5_7
-inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_conv_stencil_5_7
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_7_res = conv_stencil_op_hcompute_conv_stencil_5_7_select(conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_conv_stencil_5_7_res);
 	return result;
 }
 
 // op_hcompute_conv_stencil_5_write
 //	conv_stencil_op_hcompute_conv_stencil_5_6
-inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_5_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_5_6_res = op_hcompute_conv_stencil_5_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_5_6_write(conv_stencil_op_hcompute_conv_stencil_5_6_res, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 }
 
 // op_hcompute_conv_stencil_write
 //	conv_stencil_op_hcompute_conv_stencil_62
-inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x, int dynamic_address) {
+inline void conv_stencil_op_hcompute_conv_stencil_write_bundle_write(hw_uint<16>& op_hcompute_conv_stencil_write, conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x, int dynamic_address) {
 	hw_uint<16> conv_stencil_op_hcompute_conv_stencil_62_res = op_hcompute_conv_stencil_write.extract<0, 15>();
-	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, conv_s0_y, conv_s0_x, dynamic_address);
+	conv_stencil_op_hcompute_conv_stencil_62_write(conv_stencil_op_hcompute_conv_stencil_62_res, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, dynamic_address);
 }
 
 // op_hcompute_hw_output_stencil_read
 //	conv_stencil_op_hcompute_hw_output_stencil_1
-inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
+inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil_cache& conv_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi, int dynamic_address) {
   // # of ports in bundle: 1
     // conv_stencil_op_hcompute_hw_output_stencil_1
 
 	hw_uint<16> result;
-	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
+	hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_1_res = conv_stencil_op_hcompute_hw_output_stencil_1_select(conv_stencil, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, dynamic_address);
 	set_at<0, 16>(result, conv_stencil_op_hcompute_hw_output_stencil_1_res);
 	return result;
 }
@@ -187,16 +187,16 @@ inline hw_uint<16> conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(c
 #include "hw_classes.h"
 
 struct hw_input_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 29], [0, 29], [0, 7]}
-  hw_uint<16> RAM[30][30][8];
-  inline hw_uint<16> read(int d0, int d1, int d2) {
-    return RAM[d0][d1][d2];
+	// RAM Box: {[0, 29], [0, 29], [0, 7], [0, 3]}
+  hw_uint<16> RAM[30][30][8][4];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
+    return RAM[d0][d1][d2][d3];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2) {
-    RAM[d0][d1][d2] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
+    RAM[d0][d1][d2][d3] = value;
   }
 
 };
@@ -208,222 +208,222 @@ struct hw_input_global_wrapper_stencil_cache {
 
 
 
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
-  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0);
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_uint<16>& hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+  hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4, hw_input_global_wrapper_s0_y - 0, hw_input_global_wrapper_s0_x - 0, hw_input_global_wrapper_s0_z - 0, gb_tile - 0);
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 2 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 3 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 4 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 5 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 7 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 6 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 0 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
 
-inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0);
+  // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_input_global_wrapper_stencil[conv_s1_r_y + conv_s1_y, conv_s1_r_x + conv_s1_x, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4 = hw_input_global_wrapper_stencil.hw_input_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y + conv_s1_y - 0, conv_s1_r_x + conv_s1_x - 0, 1 - 0, gb_tile - 0);
   return value_hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4;
   return 0;
 }
@@ -438,7 +438,7 @@ inline hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45
@@ -450,21 +450,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_44_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_45_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_46_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_47_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_48_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_49_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_50_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_51_res);
 	return result;
 }
@@ -478,7 +478,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27
@@ -490,21 +490,21 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_26_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_27_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_28_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_29_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_30_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_31_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_32_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_33_res);
 	return result;
 }
@@ -518,7 +518,7 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_r
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14
 //	hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
-inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9
@@ -530,45 +530,45 @@ inline hw_uint<128> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_r
     // hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15
 
 	hw_uint<128> result;
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_8_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_9_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_10_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_11_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_12_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_13_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_14_res);
-	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_select(hw_input_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_15_res);
 	return result;
 }
 
 // op_hcompute_hw_input_global_wrapper_stencil_write
 //	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4
-inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_input_global_wrapper_stencil_write, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res = op_hcompute_hw_input_global_wrapper_stencil_write.extract<0, 15>();
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_write(hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_4_res, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, dynamic_address);
 }
 
 #include "hw_classes.h"
 
 struct hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs_cache {
-	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7]}
-  hw_uint<16> RAM[3][3][3][8];
-  inline hw_uint<16> read(int d0, int d1, int d2, int d3) {
-    return RAM[d0][d1][d2][d3];
+	// RAM Box: {[0, 2], [0, 2], [0, 2], [0, 7], [0, 3]}
+  hw_uint<16> RAM[3][3][3][8][4];
+  inline hw_uint<16> read(int d0, int d1, int d2, int d3, int d4) {
+    return RAM[d0][d1][d2][d3][d4];
   }
 
 
 
-	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3) {
-    RAM[d0][d1][d2][d3] = value;
+	inline void write(const hw_uint<16> value, int d0, int d1, int d2, int d3, int d4) {
+    RAM[d0][d1][d2][d3][d4] = value;
   }
 
 };
@@ -580,222 +580,222 @@ struct hw_kernel_global_wrapper_stencil_cache {
 
 
 
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
-  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0);
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_uint<16>& hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+  hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2, hw_kernel_global_wrapper_s0_y - 0, hw_kernel_global_wrapper_s0_x - 0, hw_kernel_global_wrapper_s0_w - 0, hw_kernel_global_wrapper_s0_z - 0, gb_tile - 0);
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 0 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 1 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 2 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 3 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 4 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 5 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 7 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59 read pattern: { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 0, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 0 - 0, 6 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 1 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 2 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 3 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 4 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 5 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 7 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 6 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41 read pattern: { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 1, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 1 - 0, 0 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 0, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 0 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 1, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 1 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 2, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 2 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 3, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 3 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 4, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 4 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 5, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 5 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 7, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 7 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
 
-inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
 #ifdef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
-  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0);
+  // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23 read pattern: { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> hw_kernel_global_wrapper_stencil[conv_s1_r_y, conv_s1_r_x, 2, 6, gb_tile] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+  auto value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2 = hw_kernel_global_wrapper_stencil.hw_kernel_global_wrapper_stencil_all_inputs_to_all_outputs.read(conv_s1_r_y - 0, conv_s1_r_x - 0, 2 - 0, 6 - 0, gb_tile - 0);
   return value_hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2;
   return 0;
 }
@@ -810,7 +810,7 @@ inline hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_2
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53
@@ -822,21 +822,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_52_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_53_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_54_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_55_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_56_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_57_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_58_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_59_res);
 	return result;
 }
@@ -850,7 +850,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35
@@ -862,21 +862,21 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_34_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_35_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_36_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_37_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_38_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_39_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_40_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_41_res);
 	return result;
 }
@@ -890,7 +890,7 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22
 //	hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
-inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
+inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x, int dynamic_address) {
   // # of ports in bundle: 8
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17
@@ -902,202 +902,202 @@ inline hw_uint<128> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_
     // hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23
 
 	hw_uint<128> result;
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<0, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_16_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<16, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_17_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<32, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_18_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<48, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_19_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<64, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_20_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<80, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_21_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<96, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_22_res);
-	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
+	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_select(hw_kernel_global_wrapper_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, dynamic_address);
 	set_at<112, 128>(result, hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_23_res);
 	return result;
 }
 
 // op_hcompute_hw_kernel_global_wrapper_stencil_write
 //	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2
-inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
+inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(hw_uint<16>& op_hcompute_hw_kernel_global_wrapper_stencil_write, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z, int dynamic_address) {
 	hw_uint<16> hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res = op_hcompute_hw_kernel_global_wrapper_stencil_write.extract<0, 15>();
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_write(hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_2_res, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, dynamic_address);
 }
 
-// Total re-use buffer capacity: 156288 bits
+// Total re-use buffer capacity: 625152 bits
 
 
 // Operation logic
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_value);
-	// Produce: hw_output_stencil
-	hw_output_stencil.write(compute_result);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
+inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_input_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, int root, int gb_tile, int hw_input_global_wrapper_s0_y, int hw_input_global_wrapper_s0_x, int hw_input_global_wrapper_s0_z) {
   // Dynamic address computation
 
 	// Consume: hw_input_stencil
-	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value = hw_input_stencil.read();
-	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_value);
+	auto hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value = hw_input_stencil.read();
+	auto compute_result = hcompute_hw_input_global_wrapper_stencil(hw_input_stencil_hw_input_global_wrapper_s0_y_c__hw_input_global_wrapper_s0_x_c__hw_input_global_wrapper_s0_z_c__gb_tile_value);
 	// Produce: hw_input_global_wrapper_stencil
-	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
+	hw_input_global_wrapper_stencil_op_hcompute_hw_input_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_input_global_wrapper_stencil, root, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+  // Dynamic address computation
+
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_c__gb_tile_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_1();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int gb_tile, int conv_s0_y, int conv_s0_x) {
   // Dynamic address computation
 
 	auto compute_result = hcompute_conv_stencil_2();
 	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
 
 }
 
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_c__gb_tile_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_c__gb_tile_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int gb_tile, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value = conv_stencil_op_hcompute_conv_stencil_5_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_5_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_5(conv_stencil_2_c__conv_s1_y_c__conv_s1_x_c__gb_tile_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_c__gb_tile_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__2_c__0_c__gb_tile_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_5_write_bundle_write(/* arg names */compute_result, conv_stencil, root, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_hw_output_stencil(conv_stencil_cache& conv_stencil, HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_output_stencil, int root, int gb_tile, int hw_output_s0_w, int hw_output_s0_y_yi, int hw_output_s0_x_xi) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value = conv_stencil_op_hcompute_hw_output_stencil_read_bundle_read(conv_stencil/* source_delay */, root, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_hw_output_stencil(conv_stencil_hw_output_s0_w_c__hw_output_s0_y_yi_c__hw_output_s0_x_xi_c__gb_tile_value);
+	// Produce: hw_output_stencil
+	hw_output_stencil.write(compute_result);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1124,86 +1124,86 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-//   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
-//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
-//   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-// Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
-//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
-//   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
-//   { op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
-// Condition for op_hcompute_conv_stencil_1(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-1 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
-//   { op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_5(((-2 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+// schedule: { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+//   { op_hcompute_conv_stencil_1[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_1(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-1 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_5[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_5(((-2 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
+//   { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 0, gb_tile, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+// Condition for op_hcompute_hw_output_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-4 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
+//   { op_hcompute_conv_stencil_2[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil_2(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (-2 + i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil[root = 0, gb_tile, conv_s0_y, conv_s0_x] -> [0, 0, 0, gb_tile, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
+// Condition for op_hcompute_conv_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (-2 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
+//   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_input_global_wrapper_stencil(((i12 == 0) && (i11 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (29 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
+//   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 0, gb_tile, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+// Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-1 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (2 - i9 >= 0) && (i11 >= 0) && (7 - i11 >= 0)))
+//   { op_hcompute_conv_stencil_4[root = 0, gb_tile, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 0, gb_tile, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= gb_tile <= 3 and 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_4(((-1 + i12 == 0) && (i10 == 0) && (i8 == 0) && (i6 == 0) && (-3 + i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (3 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0) && (i11 >= 0) && (27 - i11 >= 0)))
 
   /*
-{
-  for (int c3 = 0; c3 <= 29; c3 += 1)
-    for (int c5 = 0; c5 <= 29; c5 += 1)
-      for (int c7 = 0; c7 <= 7; c7 += 1)
-        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7);
-  for (int c3 = 0; c3 <= 2; c3 += 1)
-    for (int c5 = 0; c5 <= 2; c5 += 1)
-      for (int c7 = 0; c7 <= 2; c7 += 1)
-        for (int c9 = 0; c9 <= 7; c9 += 1)
-          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9);
-  for (int c3 = 0; c3 <= 27; c3 += 1)
-    for (int c5 = 0; c5 <= 27; c5 += 1) {
-      op_hcompute_conv_stencil(0, c3, c5);
-      op_hcompute_conv_stencil_1(0, c3, c5);
-      op_hcompute_conv_stencil_2(0, c3, c5);
+for (int c3 = 0; c3 <= 3; c3 += 1) {
+  for (int c5 = 0; c5 <= 29; c5 += 1)
+    for (int c7 = 0; c7 <= 29; c7 += 1)
+      for (int c9 = 0; c9 <= 7; c9 += 1)
+        op_hcompute_hw_input_global_wrapper_stencil(0, c3, c5, c7, c9);
+  for (int c5 = 0; c5 <= 2; c5 += 1)
+    for (int c7 = 0; c7 <= 2; c7 += 1)
+      for (int c9 = 0; c9 <= 2; c9 += 1)
+        for (int c11 = 0; c11 <= 7; c11 += 1)
+          op_hcompute_hw_kernel_global_wrapper_stencil(0, c3, c5, c7, c9, c11);
+  for (int c5 = 0; c5 <= 27; c5 += 1)
+    for (int c7 = 0; c7 <= 27; c7 += 1) {
+      op_hcompute_conv_stencil(0, c3, c5, c7);
+      op_hcompute_conv_stencil_1(0, c3, c5, c7);
+      op_hcompute_conv_stencil_2(0, c3, c5, c7);
     }
-  for (int c3 = 0; c3 <= 2; c3 += 1)
-    for (int c5 = 0; c5 <= 2; c5 += 1)
-      for (int c7 = 0; c7 <= 27; c7 += 1)
-        for (int c9 = 0; c9 <= 27; c9 += 1) {
-          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9);
-          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9);
-          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9);
+  for (int c5 = 0; c5 <= 2; c5 += 1)
+    for (int c7 = 0; c7 <= 2; c7 += 1)
+      for (int c9 = 0; c9 <= 27; c9 += 1)
+        for (int c11 = 0; c11 <= 27; c11 += 1) {
+          op_hcompute_conv_stencil_3(0, c3, c5, c7, c9, c11);
+          op_hcompute_conv_stencil_4(0, c3, c5, c7, c9, c11);
+          op_hcompute_conv_stencil_5(0, c3, c5, c7, c9, c11);
         }
-  for (int c3 = 0; c3 <= 2; c3 += 1)
-    for (int c5 = 0; c5 <= 27; c5 += 1)
-      for (int c7 = 0; c7 <= 27; c7 += 1)
-        op_hcompute_hw_output_stencil(0, c3, c5, c7);
+  for (int c5 = 0; c5 <= 2; c5 += 1)
+    for (int c7 = 0; c7 <= 27; c7 += 1)
+      for (int c9 = 0; c9 <= 27; c9 += 1)
+        op_hcompute_hw_output_stencil(0, c3, c5, c7, c9);
 }
 
   */
-	{
-	  for (int c3 = 0; c3 <= 29; c3 += 1)
-	    for (int c5 = 0; c5 <= 29; c5 += 1)
-	      for (int c7 = 0; c7 <= 7; c7 += 1)
-	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7);
-	  for (int c3 = 0; c3 <= 2; c3 += 1)
-	    for (int c5 = 0; c5 <= 2; c5 += 1)
-	      for (int c7 = 0; c7 <= 2; c7 += 1)
-	        for (int c9 = 0; c9 <= 7; c9 += 1)
-	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9);
-	  for (int c3 = 0; c3 <= 27; c3 += 1)
-	    for (int c5 = 0; c5 <= 27; c5 += 1) {
-	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5);
-	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5);
-	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5);
+	for (int c3 = 0; c3 <= 3; c3 += 1) {
+	  for (int c5 = 0; c5 <= 29; c5 += 1)
+	    for (int c7 = 0; c7 <= 29; c7 += 1)
+	      for (int c9 = 0; c9 <= 7; c9 += 1)
+	        op_hcompute_hw_input_global_wrapper_stencil(hw_input_stencil /* buf name */, hw_input_global_wrapper_stencil, 0, c3, c5, c7, c9);
+	  for (int c5 = 0; c5 <= 2; c5 += 1)
+	    for (int c7 = 0; c7 <= 2; c7 += 1)
+	      for (int c9 = 0; c9 <= 2; c9 += 1)
+	        for (int c11 = 0; c11 <= 7; c11 += 1)
+	          op_hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil /* buf name */, hw_kernel_global_wrapper_stencil, 0, c3, c5, c7, c9, c11);
+	  for (int c5 = 0; c5 <= 27; c5 += 1)
+	    for (int c7 = 0; c7 <= 27; c7 += 1) {
+	      op_hcompute_conv_stencil(conv_stencil, 0, c3, c5, c7);
+	      op_hcompute_conv_stencil_1(conv_stencil, 0, c3, c5, c7);
+	      op_hcompute_conv_stencil_2(conv_stencil, 0, c3, c5, c7);
 	    }
-	  for (int c3 = 0; c3 <= 2; c3 += 1)
-	    for (int c5 = 0; c5 <= 2; c5 += 1)
-	      for (int c7 = 0; c7 <= 27; c7 += 1)
-	        for (int c9 = 0; c9 <= 27; c9 += 1) {
-	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
-	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
-	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9);
+	  for (int c5 = 0; c5 <= 2; c5 += 1)
+	    for (int c7 = 0; c7 <= 2; c7 += 1)
+	      for (int c9 = 0; c9 <= 27; c9 += 1)
+	        for (int c11 = 0; c11 <= 27; c11 += 1) {
+	          op_hcompute_conv_stencil_3(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
+	          op_hcompute_conv_stencil_4(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
+	          op_hcompute_conv_stencil_5(conv_stencil /* buf name */, hw_input_global_wrapper_stencil /* buf name */, hw_kernel_global_wrapper_stencil /* buf name */, 0, c3, c5, c7, c9, c11);
 	        }
-	  for (int c3 = 0; c3 <= 2; c3 += 1)
-	    for (int c5 = 0; c5 <= 27; c5 += 1)
-	      for (int c7 = 0; c7 <= 27; c7 += 1)
-	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7);
+	  for (int c5 = 0; c5 <= 2; c5 += 1)
+	    for (int c7 = 0; c7 <= 27; c7 += 1)
+	      for (int c9 = 0; c9 <= 27; c9 += 1)
+	        op_hcompute_hw_output_stencil(conv_stencil /* buf name */, hw_output_stencil, 0, c3, c5, c7, c9);
 	}
 	
 #ifndef __VIVADO_SYNTH__
@@ -1218,12 +1218,12 @@ void unoptimized_resnet_wrapper(HWStream<hw_uint<16> >& /* no bundle get_args nu
   }
 }
 #ifdef __VIVADO_SYNTH__
-  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 7200;
-  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
-const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 216;
-  // { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
-const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 2352;
+  // { op_hcompute_hw_input_global_wrapper_stencil[root = 0, gb_tile, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> hw_input_stencil[hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_input_global_wrapper_stencil_read_pipe0_num_transfers = 28800;
+  // { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, gb_tile, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> hw_kernel_stencil[hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
+const int op_hcompute_hw_kernel_global_wrapper_stencil_read_pipe0_num_transfers = 864;
+  // { op_hcompute_hw_output_stencil[root = 0, gb_tile, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> hw_output_stencil[hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi, gb_tile] : 0 <= gb_tile <= 3 and 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
+const int op_hcompute_hw_output_stencil_write_pipe0_num_transfers = 9408;
 
 
 extern "C" {

--- a/unoptimized_resnet.cpp
+++ b/unoptimized_resnet.cpp
@@ -932,14 +932,54 @@ inline void hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrappe
 
 
 // Operation logic
-inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
+inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
   // Dynamic address computation
 
-	// Consume: hw_kernel_stencil
-	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
-	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
-	// Produce: hw_kernel_global_wrapper_stencil
-	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
+	// Consume: conv_stencil
+	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_1();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
+inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
+  // Dynamic address computation
+
+	auto compute_result = hcompute_conv_stencil_2();
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -976,60 +1016,14 @@ inline void op_hcompute_conv_stencil_5(conv_stencil_cache& conv_stencil, hw_inpu
 
 }
 
-inline void op_hcompute_conv_stencil_4(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+inline void op_hcompute_hw_kernel_global_wrapper_stencil(HWStream<hw_uint<16> >& /* buffer_args num ports = 1 */hw_kernel_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int hw_kernel_global_wrapper_s0_y, int hw_kernel_global_wrapper_s0_x, int hw_kernel_global_wrapper_s0_w, int hw_kernel_global_wrapper_s0_z) {
   // Dynamic address computation
 
-	// Consume: conv_stencil
-	auto conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_4_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_4_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_4(conv_stencil_1_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__1_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__1_c__1_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_4_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
-  // Dynamic address computation
-
-	// Consume: conv_stencil
-	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_input_global_wrapper_stencil
-	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	// Consume: hw_kernel_global_wrapper_stencil
-	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+	// Consume: hw_kernel_stencil
+	auto hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value = hw_kernel_stencil.read();
+	auto compute_result = hcompute_hw_kernel_global_wrapper_stencil(hw_kernel_stencil_hw_kernel_global_wrapper_s0_y_c__hw_kernel_global_wrapper_s0_x_c__hw_kernel_global_wrapper_s0_w_c__hw_kernel_global_wrapper_s0_z_value);
+	// Produce: hw_kernel_global_wrapper_stencil
+	hw_kernel_global_wrapper_stencil_op_hcompute_hw_kernel_global_wrapper_stencil_write_bundle_write(/* arg names */compute_result, hw_kernel_global_wrapper_stencil, root, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1042,30 +1036,6 @@ inline void op_hcompute_conv_stencil(conv_stencil_cache& conv_stencil, int root,
 	auto compute_result = hcompute_conv_stencil();
 	// Produce: conv_stencil
 	conv_stencil_op_hcompute_conv_stencil_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_1(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_1();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_1_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
-
-#ifndef __VIVADO_SYNTH__
-#endif //__VIVADO_SYNTH__
-
-}
-
-inline void op_hcompute_conv_stencil_2(conv_stencil_cache& conv_stencil, int root, int conv_s0_y, int conv_s0_x) {
-  // Dynamic address computation
-
-	auto compute_result = hcompute_conv_stencil_2();
-	// Produce: conv_stencil
-	conv_stencil_op_hcompute_conv_stencil_2_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s0_y, conv_s0_x, 0);
 
 #ifndef __VIVADO_SYNTH__
 #endif //__VIVADO_SYNTH__
@@ -1104,6 +1074,36 @@ inline void op_hcompute_hw_input_global_wrapper_stencil(HWStream<hw_uint<16> >& 
 
 }
 
+inline void op_hcompute_conv_stencil_3(conv_stencil_cache& conv_stencil, hw_input_global_wrapper_stencil_cache& hw_input_global_wrapper_stencil, hw_kernel_global_wrapper_stencil_cache& hw_kernel_global_wrapper_stencil, int root, int conv_s1_r_y, int conv_s1_r_x, int conv_s1_y, int conv_s1_x) {
+  // Dynamic address computation
+
+	// Consume: conv_stencil
+	auto conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value = conv_stencil_op_hcompute_conv_stencil_3_read_bundle_read(conv_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_input_global_wrapper_stencil
+	auto hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value = hw_input_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_input_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	// Consume: hw_kernel_global_wrapper_stencil
+	auto hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value = hw_kernel_global_wrapper_stencil_op_hcompute_conv_stencil_3_read_bundle_read(hw_kernel_global_wrapper_stencil/* source_delay */, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+	auto compute_result = hcompute_conv_stencil_3(conv_stencil_0_c__conv_s1_y_c__conv_s1_x_value, hw_input_global_wrapper_stencil__lp_conv_s1_r_y__p__conv_s1_y_rp__c___lp_conv_s1_r_x__p__conv_s1_x_rp__c__0_value, hw_kernel_global_wrapper_stencil_conv_s1_r_y_c__conv_s1_r_x_c__0_c__0_value);
+	// Produce: conv_stencil
+	conv_stencil_op_hcompute_conv_stencil_3_write_bundle_write(/* arg names */compute_result, conv_stencil, root, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x, 0);
+
+#ifndef __VIVADO_SYNTH__
+#endif //__VIVADO_SYNTH__
+
+}
+
 // Driver function
 void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_input_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_kernel_stencil, HWStream<hw_uint<16> >& /* no bundle get_args num ports = 1 */hw_output_stencil) {
 
@@ -1124,17 +1124,17 @@ void unoptimized_resnet(HWStream<hw_uint<16> >& /* no bundle get_args num ports 
 #pragma HLS inline recursive
 #endif // __VIVADO_SYNTH__
 
-// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// schedule: { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7; op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7; op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27; op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27; op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_1[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 1, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27; op_hcompute_conv_stencil_5[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 2] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 //   { op_hcompute_conv_stencil_2[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 2, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }
 // Condition for op_hcompute_conv_stencil_2(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i7 == 0) && (-2 + i6 == 0) && (i4 == 0) && (-2 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (27 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0)))
 //   { op_hcompute_hw_input_global_wrapper_stencil[root = 0, hw_input_global_wrapper_s0_y, hw_input_global_wrapper_s0_x, hw_input_global_wrapper_s0_z] -> [0, 0, 0, hw_input_global_wrapper_s0_y, 0, hw_input_global_wrapper_s0_x, 0, hw_input_global_wrapper_s0_z, 0, 0, 0] : 0 <= hw_input_global_wrapper_s0_y <= 29 and 0 <= hw_input_global_wrapper_s0_x <= 29 and 0 <= hw_input_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_input_global_wrapper_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (29 - i3 >= 0) && (i5 >= 0) && (29 - i5 >= 0) && (i7 >= 0) && (7 - i7 >= 0)))
 //   { op_hcompute_hw_kernel_global_wrapper_stencil[root = 0, hw_kernel_global_wrapper_s0_y, hw_kernel_global_wrapper_s0_x, hw_kernel_global_wrapper_s0_w, hw_kernel_global_wrapper_s0_z] -> [0, 0, 1, hw_kernel_global_wrapper_s0_y, 0, hw_kernel_global_wrapper_s0_x, 0, hw_kernel_global_wrapper_s0_w, 0, hw_kernel_global_wrapper_s0_z, 0] : 0 <= hw_kernel_global_wrapper_s0_y <= 2 and 0 <= hw_kernel_global_wrapper_s0_x <= 2 and 0 <= hw_kernel_global_wrapper_s0_w <= 2 and 0 <= hw_kernel_global_wrapper_s0_z <= 7 }
 // Condition for op_hcompute_hw_kernel_global_wrapper_stencil(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-1 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (2 - i7 >= 0) && (i9 >= 0) && (7 - i9 >= 0)))
-//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
-// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_hw_output_stencil[root = 0, hw_output_s0_w, hw_output_s0_y_yi, hw_output_s0_x_xi] -> [0, 0, 4, hw_output_s0_w, 0, hw_output_s0_y_yi, 0, hw_output_s0_x_xi, 0, 0, 0] : 0 <= hw_output_s0_w <= 2 and 0 <= hw_output_s0_y_yi <= 27 and 0 <= hw_output_s0_x_xi <= 27 }
 // Condition for op_hcompute_hw_output_stencil(((i10 == 0) && (i9 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-4 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (27 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0)))
+//   { op_hcompute_conv_stencil_3[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 0] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
+// Condition for op_hcompute_conv_stencil_3(((i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil_4[root = 0, conv_s1_r_y, conv_s1_r_x, conv_s1_y, conv_s1_x] -> [0, 0, 3, conv_s1_r_y, 0, conv_s1_r_x, 0, conv_s1_y, 0, conv_s1_x, 1] : 0 <= conv_s1_r_y <= 2 and 0 <= conv_s1_r_x <= 2 and 0 <= conv_s1_y <= 27 and 0 <= conv_s1_x <= 27 }
 // Condition for op_hcompute_conv_stencil_4(((-1 + i10 == 0) && (i8 == 0) && (i6 == 0) && (i4 == 0) && (-3 + i2 == 0) && (i1 == 0) && (i0 == 0) && (i3 >= 0) && (2 - i3 >= 0) && (i5 >= 0) && (2 - i5 >= 0) && (i7 >= 0) && (27 - i7 >= 0) && (i9 >= 0) && (27 - i9 >= 0)))
 //   { op_hcompute_conv_stencil[root = 0, conv_s0_y, conv_s0_x] -> [0, 0, 2, conv_s0_y, 0, conv_s0_x, 0, 0, 0, 0, 0] : 0 <= conv_s0_y <= 27 and 0 <= conv_s0_x <= 27 }

--- a/verilog_backend.cpp
+++ b/verilog_backend.cpp
@@ -497,6 +497,10 @@ void generate_fsm(
     isl_aff* aff,
     isl_set* dom) {
 
+  isl_point* pt = lexminpt(dom);
+  isl_val* min_time = eval(aff, pt);
+  assert(to_int(min_time) >= 0);
+
   out << "// " << str(aff) << endl;
   cout << to_int(const_coeff(aff)) << endl;
   int dims = num_in_dims(aff);
@@ -988,6 +992,7 @@ void generate_platonic_ubuffer(
 
   map<string,pair<string,int>> shift_registered_outputs = determine_shift_reg_map(prg, buf, hwinfo);
   vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs = determine_output_shift_reg_map(prg, buf,hwinfo);
+
   //map<string,pair<string,int>> shift_registered_outputs;
   //vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs;
 

--- a/verilog_backend.cpp
+++ b/verilog_backend.cpp
@@ -990,11 +990,11 @@ void generate_platonic_ubuffer(
     print_cyclic_banks_selector(out, bank_factors, buf);
   }
 
-  //map<string,pair<string,int>> shift_registered_outputs = determine_shift_reg_map(prg, buf, hwinfo);
-  //vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs = determine_output_shift_reg_map(prg, buf,hwinfo);
+  map<string,pair<string,int>> shift_registered_outputs = determine_shift_reg_map(prg, buf, hwinfo);
+  vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs = determine_output_shift_reg_map(prg, buf,hwinfo);
 
-  map<string,pair<string,int>> shift_registered_outputs;
-  vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs;
+  //map<string,pair<string,int>> shift_registered_outputs;
+  //vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs;
 
   print_shift_registers(out, shift_registered_outputs, options, prg, buf, hwinfo);
   print_shift_registers(out, shift_registered_outputs_to_outputs, options, prg, buf, hwinfo);

--- a/verilog_backend.cpp
+++ b/verilog_backend.cpp
@@ -990,11 +990,11 @@ void generate_platonic_ubuffer(
     print_cyclic_banks_selector(out, bank_factors, buf);
   }
 
-  map<string,pair<string,int>> shift_registered_outputs = determine_shift_reg_map(prg, buf, hwinfo);
-  vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs = determine_output_shift_reg_map(prg, buf,hwinfo);
+  //map<string,pair<string,int>> shift_registered_outputs = determine_shift_reg_map(prg, buf, hwinfo);
+  //vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs = determine_output_shift_reg_map(prg, buf,hwinfo);
 
-  //map<string,pair<string,int>> shift_registered_outputs;
-  //vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs;
+  map<string,pair<string,int>> shift_registered_outputs;
+  vector<pair<string,pair<string,int>>> shift_registered_outputs_to_outputs;
 
   print_shift_registers(out, shift_registered_outputs, options, prg, buf, hwinfo);
   print_shift_registers(out, shift_registered_outputs_to_outputs, options, prg, buf, hwinfo);

--- a/verilog_backend.h
+++ b/verilog_backend.h
@@ -5,6 +5,15 @@
 static int DATAPATH_WIDTH = 16;
 static int CONTROLPATH_WIDTH = 16;
 
+void generate_fsm(
+        ostream& out,
+    CodegenOptions& options,
+    const std::string& module_name,
+    const std::string& ctrl_vars,
+    const std::string& enable,
+    isl_aff* aff,
+    isl_set* dom);
+
 void generate_platonic_ubuffer(
     std::ostream& out,
     CodegenOptions& options,


### PR DESCRIPTION
- sch3 and sch4 no longer have null init values
- sch6 has all loops unrolled by 2, including the update loops