### PR TITLE
Update harris schs without kernel memory

### DIFF
--- a/coreir_compute/harris_sch5_1ppc_compute.json
+++ b/coreir_compute/harris_sch5_1ppc_compute.json
@@ -8,28 +8,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_759_760_761":{
+          "bitand_591_592_593":{
             "modref":"corebit.and"
           },
-          "bitand_761_762_763":{
+          "bitand_593_594_595":{
             "modref":"corebit.and"
           },
-          "bitand_763_764_765":{
+          "bitand_595_596_597":{
             "modref":"corebit.and"
           },
-          "bitand_765_766_767":{
+          "bitand_597_598_599":{
             "modref":"corebit.and"
           },
-          "bitand_767_768_769":{
+          "bitand_599_600_601":{
             "modref":"corebit.and"
           },
-          "bitand_769_770_771":{
+          "bitand_601_602_603":{
             "modref":"corebit.and"
           },
-          "bitand_771_772_773":{
+          "bitand_603_604_605":{
             "modref":"corebit.and"
           },
-          "bitand_773_775_776":{
+          "bitand_605_607_608":{
             "modref":"corebit.and"
           },
           "const_p0_0":{
@@ -37,7 +37,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__774":{
+          "const_p1__606":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -47,86 +47,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_7762550":{
+          "mux_6082550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_774_cim_stencil_2_775":{
+          "sle_606_cim_stencil_2_607":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_1_cim_stencil_2_759":{
+          "slt_cim_stencil_1_cim_stencil_2_591":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_3_cim_stencil_2_760":{
+          "slt_cim_stencil_3_cim_stencil_2_592":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_4_cim_stencil_2_762":{
+          "slt_cim_stencil_4_cim_stencil_2_594":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_5_cim_stencil_2_764":{
+          "slt_cim_stencil_5_cim_stencil_2_596":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_6_cim_stencil_2_766":{
+          "slt_cim_stencil_6_cim_stencil_2_598":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_7_cim_stencil_2_768":{
+          "slt_cim_stencil_7_cim_stencil_2_600":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_8_cim_stencil_2_770":{
+          "slt_cim_stencil_8_cim_stencil_2_602":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_9_cim_stencil_2_772":{
+          "slt_cim_stencil_9_cim_stencil_2_604":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_1_cim_stencil_2_759.out","bitand_759_760_761.in0"],
-          ["slt_cim_stencil_3_cim_stencil_2_760.out","bitand_759_760_761.in1"],
-          ["bitand_761_762_763.in0","bitand_759_760_761.out"],
-          ["slt_cim_stencil_4_cim_stencil_2_762.out","bitand_761_762_763.in1"],
-          ["bitand_763_764_765.in0","bitand_761_762_763.out"],
-          ["slt_cim_stencil_5_cim_stencil_2_764.out","bitand_763_764_765.in1"],
-          ["bitand_765_766_767.in0","bitand_763_764_765.out"],
-          ["slt_cim_stencil_6_cim_stencil_2_766.out","bitand_765_766_767.in1"],
-          ["bitand_767_768_769.in0","bitand_765_766_767.out"],
-          ["slt_cim_stencil_7_cim_stencil_2_768.out","bitand_767_768_769.in1"],
-          ["bitand_769_770_771.in0","bitand_767_768_769.out"],
-          ["slt_cim_stencil_8_cim_stencil_2_770.out","bitand_769_770_771.in1"],
-          ["bitand_771_772_773.in0","bitand_769_770_771.out"],
-          ["slt_cim_stencil_9_cim_stencil_2_772.out","bitand_771_772_773.in1"],
-          ["bitand_773_775_776.in0","bitand_771_772_773.out"],
-          ["sle_774_cim_stencil_2_775.out","bitand_773_775_776.in1"],
-          ["mux_7762550.sel","bitand_773_775_776.out"],
-          ["mux_7762550.in0","const_p0_0.out"],
-          ["sle_774_cim_stencil_2_775.in0","const_p1__774.out"],
-          ["mux_7762550.in1","const_p255_255.out"],
-          ["self.out_cim_output_stencil","mux_7762550.out"],
-          ["slt_cim_stencil_1_cim_stencil_2_759.in0","self.in0_cim_stencil.0"],
-          ["sle_774_cim_stencil_2_775.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_1_cim_stencil_2_759.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_760.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_4_cim_stencil_2_762.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_5_cim_stencil_2_764.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_6_cim_stencil_2_766.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_7_cim_stencil_2_768.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_8_cim_stencil_2_770.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_9_cim_stencil_2_772.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_760.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_4_cim_stencil_2_762.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_5_cim_stencil_2_764.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_6_cim_stencil_2_766.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_7_cim_stencil_2_768.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_8_cim_stencil_2_770.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_9_cim_stencil_2_772.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_1_cim_stencil_2_591.out","bitand_591_592_593.in0"],
+          ["slt_cim_stencil_3_cim_stencil_2_592.out","bitand_591_592_593.in1"],
+          ["bitand_593_594_595.in0","bitand_591_592_593.out"],
+          ["slt_cim_stencil_4_cim_stencil_2_594.out","bitand_593_594_595.in1"],
+          ["bitand_595_596_597.in0","bitand_593_594_595.out"],
+          ["slt_cim_stencil_5_cim_stencil_2_596.out","bitand_595_596_597.in1"],
+          ["bitand_597_598_599.in0","bitand_595_596_597.out"],
+          ["slt_cim_stencil_6_cim_stencil_2_598.out","bitand_597_598_599.in1"],
+          ["bitand_599_600_601.in0","bitand_597_598_599.out"],
+          ["slt_cim_stencil_7_cim_stencil_2_600.out","bitand_599_600_601.in1"],
+          ["bitand_601_602_603.in0","bitand_599_600_601.out"],
+          ["slt_cim_stencil_8_cim_stencil_2_602.out","bitand_601_602_603.in1"],
+          ["bitand_603_604_605.in0","bitand_601_602_603.out"],
+          ["slt_cim_stencil_9_cim_stencil_2_604.out","bitand_603_604_605.in1"],
+          ["bitand_605_607_608.in0","bitand_603_604_605.out"],
+          ["sle_606_cim_stencil_2_607.out","bitand_605_607_608.in1"],
+          ["mux_6082550.sel","bitand_605_607_608.out"],
+          ["mux_6082550.in0","const_p0_0.out"],
+          ["sle_606_cim_stencil_2_607.in0","const_p1__606.out"],
+          ["mux_6082550.in1","const_p255_255.out"],
+          ["self.out_cim_output_stencil","mux_6082550.out"],
+          ["slt_cim_stencil_1_cim_stencil_2_591.in0","self.in0_cim_stencil.0"],
+          ["sle_606_cim_stencil_2_607.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_1_cim_stencil_2_591.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_592.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_4_cim_stencil_2_594.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_5_cim_stencil_2_596.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_6_cim_stencil_2_598.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_7_cim_stencil_2_600.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_8_cim_stencil_2_602.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_9_cim_stencil_2_604.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_592.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_4_cim_stencil_2_594.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_5_cim_stencil_2_596.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_6_cim_stencil_2_598.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_7_cim_stencil_2_600.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_8_cim_stencil_2_602.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_9_cim_stencil_2_604.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_stencil":{
@@ -137,89 +137,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_713_714_719":{
+          "add_545_546_551":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_720_721_722":{
+          "ashr_552_553_554":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_2_712_713":{
+          "ashr_lgxx_stencil_2_544_545":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_2_712_716":{
+          "ashr_lgxy_stencil_2_544_548":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_2_712_714":{
+          "ashr_lgyy_stencil_2_544_546":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__721":{
+          "const_p4__553":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__712":{
+          "const_p6__544":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__712$1":{
+          "const_p6__544$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__712$2":{
+          "const_p6__544$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_713_714_715":{
+          "mul_545_546_547":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_716_716_717":{
+          "mul_548_548_549":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_719_719_720":{
+          "mul_551_551_552":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_715_717_718":{
+          "sub_547_549_550":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_718_722_723":{
+          "sub_550_554_555":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_2_712_713.out","add_713_714_719.in0"],
-          ["ashr_lgyy_stencil_2_712_714.out","add_713_714_719.in1"],
-          ["mul_719_719_720.in0","add_713_714_719.out"],
-          ["mul_719_719_720.in1","add_713_714_719.out"],
-          ["mul_719_719_720.out","ashr_720_721_722.in0"],
-          ["const_p4__721.out","ashr_720_721_722.in1"],
-          ["sub_718_722_723.in1","ashr_720_721_722.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_712_713.in0"],
-          ["const_p6__712.out","ashr_lgxx_stencil_2_712_713.in1"],
-          ["mul_713_714_715.in0","ashr_lgxx_stencil_2_712_713.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_712_716.in0"],
-          ["const_p6__712$2.out","ashr_lgxy_stencil_2_712_716.in1"],
-          ["mul_716_716_717.in0","ashr_lgxy_stencil_2_712_716.out"],
-          ["mul_716_716_717.in1","ashr_lgxy_stencil_2_712_716.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_712_714.in0"],
-          ["const_p6__712$1.out","ashr_lgyy_stencil_2_712_714.in1"],
-          ["mul_713_714_715.in1","ashr_lgyy_stencil_2_712_714.out"],
-          ["sub_715_717_718.in0","mul_713_714_715.out"],
-          ["sub_715_717_718.in1","mul_716_716_717.out"],
-          ["sub_718_722_723.out","self.out_cim_stencil"],
-          ["sub_718_722_723.in0","sub_715_717_718.out"]
+          ["ashr_lgxx_stencil_2_544_545.out","add_545_546_551.in0"],
+          ["ashr_lgyy_stencil_2_544_546.out","add_545_546_551.in1"],
+          ["mul_551_551_552.in0","add_545_546_551.out"],
+          ["mul_551_551_552.in1","add_545_546_551.out"],
+          ["mul_551_551_552.out","ashr_552_553_554.in0"],
+          ["const_p4__553.out","ashr_552_553_554.in1"],
+          ["sub_550_554_555.in1","ashr_552_553_554.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_544_545.in0"],
+          ["const_p6__544.out","ashr_lgxx_stencil_2_544_545.in1"],
+          ["mul_545_546_547.in0","ashr_lgxx_stencil_2_544_545.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_544_548.in0"],
+          ["const_p6__544$2.out","ashr_lgxy_stencil_2_544_548.in1"],
+          ["mul_548_548_549.in0","ashr_lgxy_stencil_2_544_548.out"],
+          ["mul_548_548_549.in1","ashr_lgxy_stencil_2_544_548.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_544_546.in0"],
+          ["const_p6__544$1.out","ashr_lgyy_stencil_2_544_546.in1"],
+          ["mul_545_546_547.in1","ashr_lgyy_stencil_2_544_546.out"],
+          ["sub_547_549_550.in0","mul_545_546_547.out"],
+          ["sub_547_549_550.in1","mul_548_548_549.out"],
+          ["sub_550_554_555.out","self.out_cim_stencil"],
+          ["sub_550_554_555.in0","sub_547_549_550.out"]
         ]
       },
       "hcompute_grad_x_stencil":{
@@ -228,31 +228,31 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n180__392":{
+          "const_n180__308":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__390":{
+          "const_p180__306":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "smax_391_392_393":{
+          "smax_307_308_309":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_2_390_391":{
+          "smin_grad_x_unclamp_stencil_2_306_307":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_391_392_393.in1","const_n180__392.out"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.in1","const_p180__390.out"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smax_391_392_393.out","self.out_grad_x_stencil"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.out","smax_391_392_393.in0"]
+          ["smax_307_308_309.in1","const_n180__308.out"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.in1","const_p180__306.out"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smax_307_308_309.out","self.out_grad_x_stencil"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.out","smax_307_308_309.in0"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil":{
@@ -260,135 +260,84 @@
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__307":{
+          "const_p0__262":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_x_unclamp_stencil","const_p0__307.out"]
+          ["self.out_grad_x_unclamp_stencil","const_p0__262.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil_1":{
         "type":["Record",[
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_x_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_327_343_344":{
+          "add_grad_x_unclamp_stencil_1_276_277":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_328_341_342":{
+          "add_padded16_global_wrapper_stencil_1_275_276":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_329_340_341":{
+          "add_padded16_global_wrapper_stencil_2_274_275":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_330_339_340":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__273":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_331_338_339":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__273$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_332_337_338":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_333_336_337":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_334_335_336":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_x_unclamp_stencil_1_342_343":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327":{
+          "mul_padded16_global_wrapper_stencil_3_273_274":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328":{
+          "mul_padded16_global_wrapper_stencil_5_273_279":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329":{
-            "genref":"coreir.mul",
+          "sub_277_padded16_global_wrapper_stencil_4_278":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330":{
-            "genref":"coreir.mul",
+          "sub_278_279_280":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335":{
-            "genref":"coreir.mul",
+          "sub_280_padded16_global_wrapper_stencil_6_281":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.out","add_327_343_344.in0"],
-          ["add_grad_x_unclamp_stencil_1_342_343.out","add_327_343_344.in1"],
-          ["self.out_grad_x_unclamp_stencil","add_327_343_344.out"],
-          ["mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.out","add_328_341_342.in0"],
-          ["add_329_340_341.out","add_328_341_342.in1"],
-          ["add_grad_x_unclamp_stencil_1_342_343.in1","add_328_341_342.out"],
-          ["mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.out","add_329_340_341.in0"],
-          ["add_330_339_340.out","add_329_340_341.in1"],
-          ["mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.out","add_330_339_340.in0"],
-          ["add_331_338_339.out","add_330_339_340.in1"],
-          ["mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.out","add_331_338_339.in0"],
-          ["add_332_337_338.out","add_331_338_339.in1"],
-          ["mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.out","add_332_337_338.in0"],
-          ["add_333_336_337.out","add_332_337_338.in1"],
-          ["mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.out","add_333_336_337.in0"],
-          ["add_334_335_336.out","add_333_336_337.in1"],
-          ["mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.out","add_334_335_336.in0"],
-          ["mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.out","add_334_335_336.in1"],
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_342_343.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.in0"],
-          ["self.in1_kernel_x_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.in0"],
-          ["self.in1_kernel_x_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.in0"],
-          ["self.in1_kernel_x_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.in0"],
-          ["self.in1_kernel_x_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.in0"],
-          ["self.in1_kernel_x_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.in0"],
-          ["self.in1_kernel_x_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.in0"],
-          ["self.in1_kernel_x_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.in0"],
-          ["self.in1_kernel_x_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.in0"],
-          ["self.in1_kernel_x_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.in1"]
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_276_277.in0"],
+          ["add_padded16_global_wrapper_stencil_1_275_276.out","add_grad_x_unclamp_stencil_1_276_277.in1"],
+          ["sub_277_padded16_global_wrapper_stencil_4_278.in0","add_grad_x_unclamp_stencil_1_276_277.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_1_275_276.in0"],
+          ["add_padded16_global_wrapper_stencil_2_274_275.out","add_padded16_global_wrapper_stencil_1_275_276.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_2_274_275.in0"],
+          ["mul_padded16_global_wrapper_stencil_3_273_274.out","add_padded16_global_wrapper_stencil_2_274_275.in1"],
+          ["mul_padded16_global_wrapper_stencil_5_273_279.in1","const_p2__273$1.out"],
+          ["mul_padded16_global_wrapper_stencil_3_273_274.in1","const_p2__273.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_273_274.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_273_279.in0"],
+          ["sub_278_279_280.in1","mul_padded16_global_wrapper_stencil_5_273_279.out"],
+          ["sub_277_padded16_global_wrapper_stencil_4_278.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.out","self.out_grad_x_unclamp_stencil"],
+          ["sub_278_279_280.in0","sub_277_padded16_global_wrapper_stencil_4_278.out"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.in0","sub_278_279_280.out"]
         ]
       },
       "hcompute_grad_y_stencil":{
@@ -397,31 +346,31 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n180__584":{
+          "const_n180__416":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__582":{
+          "const_p180__414":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "smax_583_584_585":{
+          "smax_415_416_417":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_2_582_583":{
+          "smin_grad_y_unclamp_stencil_2_414_415":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_583_584_585.in1","const_n180__584.out"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.in1","const_p180__582.out"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smax_583_584_585.out","self.out_grad_y_stencil"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.out","smax_583_584_585.in0"]
+          ["smax_415_416_417.in1","const_n180__416.out"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.in1","const_p180__414.out"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smax_415_416_417.out","self.out_grad_y_stencil"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.out","smax_415_416_417.in0"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil":{
@@ -429,135 +378,84 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__499":{
+          "const_p0__370":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__499.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__370.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_1":{
         "type":["Record",[
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_y_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_519_535_536":{
+          "add_grad_y_unclamp_stencil_1_384_385":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_520_533_534":{
+          "add_padded16_global_wrapper_stencil_7_383_384":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_521_532_533":{
+          "add_padded16_global_wrapper_stencil_8_382_383":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_522_531_532":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__381":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_523_530_531":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__381$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_524_529_530":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_525_528_529":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_526_527_528":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_y_unclamp_stencil_1_534_535":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519":{
+          "mul_padded16_global_wrapper_stencil_11_381_387":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520":{
+          "mul_padded16_global_wrapper_stencil_9_381_382":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521":{
-            "genref":"coreir.mul",
+          "sub_385_padded16_global_wrapper_stencil_10_386":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522":{
-            "genref":"coreir.mul",
+          "sub_386_387_388":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527":{
-            "genref":"coreir.mul",
+          "sub_388_padded16_global_wrapper_stencil_12_389":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.out","add_519_535_536.in0"],
-          ["add_grad_y_unclamp_stencil_1_534_535.out","add_519_535_536.in1"],
-          ["self.out_grad_y_unclamp_stencil","add_519_535_536.out"],
-          ["mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.out","add_520_533_534.in0"],
-          ["add_521_532_533.out","add_520_533_534.in1"],
-          ["add_grad_y_unclamp_stencil_1_534_535.in1","add_520_533_534.out"],
-          ["mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.out","add_521_532_533.in0"],
-          ["add_522_531_532.out","add_521_532_533.in1"],
-          ["mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.out","add_522_531_532.in0"],
-          ["add_523_530_531.out","add_522_531_532.in1"],
-          ["mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.out","add_523_530_531.in0"],
-          ["add_524_529_530.out","add_523_530_531.in1"],
-          ["mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.out","add_524_529_530.in0"],
-          ["add_525_528_529.out","add_524_529_530.in1"],
-          ["mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.out","add_525_528_529.in0"],
-          ["add_526_527_528.out","add_525_528_529.in1"],
-          ["mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.out","add_526_527_528.in0"],
-          ["mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.out","add_526_527_528.in1"],
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_534_535.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.in0"],
-          ["self.in1_kernel_y_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.in0"],
-          ["self.in1_kernel_y_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.in0"],
-          ["self.in1_kernel_y_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.in0"],
-          ["self.in1_kernel_y_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.in0"],
-          ["self.in1_kernel_y_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.in0"],
-          ["self.in1_kernel_y_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.in0"],
-          ["self.in1_kernel_y_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.in0"],
-          ["self.in1_kernel_y_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.in0"],
-          ["self.in1_kernel_y_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.in1"]
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_384_385.in0"],
+          ["add_padded16_global_wrapper_stencil_7_383_384.out","add_grad_y_unclamp_stencil_1_384_385.in1"],
+          ["sub_385_padded16_global_wrapper_stencil_10_386.in0","add_grad_y_unclamp_stencil_1_384_385.out"],
+          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_383_384.in0"],
+          ["add_padded16_global_wrapper_stencil_8_382_383.out","add_padded16_global_wrapper_stencil_7_383_384.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_382_383.in0"],
+          ["mul_padded16_global_wrapper_stencil_9_381_382.out","add_padded16_global_wrapper_stencil_8_382_383.in1"],
+          ["mul_padded16_global_wrapper_stencil_11_381_387.in1","const_p2__381$1.out"],
+          ["mul_padded16_global_wrapper_stencil_9_381_382.in1","const_p2__381.out"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_381_387.in0"],
+          ["sub_386_387_388.in1","mul_padded16_global_wrapper_stencil_11_381_387.out"],
+          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_381_382.in0"],
+          ["sub_385_padded16_global_wrapper_stencil_10_386.in1","self.in1_padded16_global_wrapper_stencil.0"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.in1","self.in1_padded16_global_wrapper_stencil.2"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_386_387_388.in0","sub_385_padded16_global_wrapper_stencil_10_386.out"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.in0","sub_386_387_388.out"]
         ]
       },
       "hcompute_hw_output_stencil":{
@@ -569,469 +467,19 @@
           ["self.out_hw_output_stencil","self.in0_cim_output_stencil.0"]
         ]
       },
-      "hcompute_kernel_x_stencil":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__261":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__261.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__264":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__264.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__291":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n2__291.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__294":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__294.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__297":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__297.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__300":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p2__300.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__303":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__303.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__267":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__267.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__270":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__270.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__273":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__273.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__276":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__276.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__279":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__279.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__282":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__282.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__285":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__285.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__288":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__288.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__454":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__454.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__457":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__457.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__484":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p2__484.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__487":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__487.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__490":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__490.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__493":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n2__493.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__496":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__496.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__460":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__460.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__463":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__463.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__466":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__466.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__469":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__469.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__472":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__472.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__475":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__475.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__478":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__478.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__481":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__481.out"]
-        ]
-      },
       "hcompute_lgxx_stencil":{
         "type":["Record",[
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__410":{
+          "const_p0__326":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__410.out"]
+          ["self.out_lgxx_stencil","const_p0__326.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
@@ -1041,63 +489,63 @@
           ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_427_428":{
+          "add_lgxx_stencil_1_343_344":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_1_428_429":{
+          "add_lxx_stencil_1_344_345":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_2_426_427":{
+          "add_lxx_stencil_2_342_343":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_3_425_426":{
+          "add_lxx_stencil_3_341_342":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_4_424_425":{
+          "add_lxx_stencil_4_340_341":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_5_423_424":{
+          "add_lxx_stencil_5_339_340":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_6_422_423":{
+          "add_lxx_stencil_6_338_339":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_7_421_422":{
+          "add_lxx_stencil_7_337_338":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_8_lxx_stencil_9_421":{
+          "add_lxx_stencil_8_lxx_stencil_9_337":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_427_428.in0"],
-          ["add_lxx_stencil_2_426_427.out","add_lgxx_stencil_1_427_428.in1"],
-          ["add_lxx_stencil_1_428_429.in1","add_lgxx_stencil_1_427_428.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_428_429.in0"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_1_428_429.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_426_427.in0"],
-          ["add_lxx_stencil_3_425_426.out","add_lxx_stencil_2_426_427.in1"],
-          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_425_426.in0"],
-          ["add_lxx_stencil_4_424_425.out","add_lxx_stencil_3_425_426.in1"],
-          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_424_425.in0"],
-          ["add_lxx_stencil_5_423_424.out","add_lxx_stencil_4_424_425.in1"],
-          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_423_424.in0"],
-          ["add_lxx_stencil_6_422_423.out","add_lxx_stencil_5_423_424.in1"],
-          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_422_423.in0"],
-          ["add_lxx_stencil_7_421_422.out","add_lxx_stencil_6_422_423.in1"],
-          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_421_422.in0"],
-          ["add_lxx_stencil_8_lxx_stencil_9_421.out","add_lxx_stencil_7_421_422.in1"],
-          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_421.in0"],
-          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_421.in1"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_343_344.in0"],
+          ["add_lxx_stencil_2_342_343.out","add_lgxx_stencil_1_343_344.in1"],
+          ["add_lxx_stencil_1_344_345.in1","add_lgxx_stencil_1_343_344.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_344_345.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_1_344_345.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_342_343.in0"],
+          ["add_lxx_stencil_3_341_342.out","add_lxx_stencil_2_342_343.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_341_342.in0"],
+          ["add_lxx_stencil_4_340_341.out","add_lxx_stencil_3_341_342.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_340_341.in0"],
+          ["add_lxx_stencil_5_339_340.out","add_lxx_stencil_4_340_341.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_339_340.in0"],
+          ["add_lxx_stencil_6_338_339.out","add_lxx_stencil_5_339_340.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_338_339.in0"],
+          ["add_lxx_stencil_7_337_338.out","add_lxx_stencil_6_338_339.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_337_338.in0"],
+          ["add_lxx_stencil_8_lxx_stencil_9_337.out","add_lxx_stencil_7_337_338.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_337.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_337.in1"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -1105,14 +553,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__603":{
+          "const_p0__435":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__603.out"]
+          ["self.out_lgxy_stencil","const_p0__435.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
@@ -1122,63 +570,63 @@
           ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_620_621":{
+          "add_lgxy_stencil_1_452_453":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_1_621_622":{
+          "add_lxy_stencil_1_453_454":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_2_619_620":{
+          "add_lxy_stencil_2_451_452":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_3_618_619":{
+          "add_lxy_stencil_3_450_451":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_4_617_618":{
+          "add_lxy_stencil_4_449_450":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_5_616_617":{
+          "add_lxy_stencil_5_448_449":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_6_615_616":{
+          "add_lxy_stencil_6_447_448":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_7_614_615":{
+          "add_lxy_stencil_7_446_447":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_8_lxy_stencil_9_614":{
+          "add_lxy_stencil_8_lxy_stencil_9_446":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_620_621.in0"],
-          ["add_lxy_stencil_2_619_620.out","add_lgxy_stencil_1_620_621.in1"],
-          ["add_lxy_stencil_1_621_622.in1","add_lgxy_stencil_1_620_621.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_621_622.in0"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_1_621_622.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_619_620.in0"],
-          ["add_lxy_stencil_3_618_619.out","add_lxy_stencil_2_619_620.in1"],
-          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_618_619.in0"],
-          ["add_lxy_stencil_4_617_618.out","add_lxy_stencil_3_618_619.in1"],
-          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_617_618.in0"],
-          ["add_lxy_stencil_5_616_617.out","add_lxy_stencil_4_617_618.in1"],
-          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_616_617.in0"],
-          ["add_lxy_stencil_6_615_616.out","add_lxy_stencil_5_616_617.in1"],
-          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_615_616.in0"],
-          ["add_lxy_stencil_7_614_615.out","add_lxy_stencil_6_615_616.in1"],
-          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_614_615.in0"],
-          ["add_lxy_stencil_8_lxy_stencil_9_614.out","add_lxy_stencil_7_614_615.in1"],
-          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_614.in0"],
-          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_614.in1"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_452_453.in0"],
+          ["add_lxy_stencil_2_451_452.out","add_lgxy_stencil_1_452_453.in1"],
+          ["add_lxy_stencil_1_453_454.in1","add_lgxy_stencil_1_452_453.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_453_454.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_1_453_454.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_451_452.in0"],
+          ["add_lxy_stencil_3_450_451.out","add_lxy_stencil_2_451_452.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_450_451.in0"],
+          ["add_lxy_stencil_4_449_450.out","add_lxy_stencil_3_450_451.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_449_450.in0"],
+          ["add_lxy_stencil_5_448_449.out","add_lxy_stencil_4_449_450.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_448_449.in0"],
+          ["add_lxy_stencil_6_447_448.out","add_lxy_stencil_5_448_449.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_447_448.in0"],
+          ["add_lxy_stencil_7_446_447.out","add_lxy_stencil_6_447_448.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_446_447.in0"],
+          ["add_lxy_stencil_8_lxy_stencil_9_446.out","add_lxy_stencil_7_446_447.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_446.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_446.in1"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -1186,14 +634,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__657":{
+          "const_p0__489":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__657.out"]
+          ["self.out_lgyy_stencil","const_p0__489.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
@@ -1203,63 +651,63 @@
           ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_674_675":{
+          "add_lgyy_stencil_1_506_507":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_1_675_676":{
+          "add_lyy_stencil_1_507_508":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_2_673_674":{
+          "add_lyy_stencil_2_505_506":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_3_672_673":{
+          "add_lyy_stencil_3_504_505":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_4_671_672":{
+          "add_lyy_stencil_4_503_504":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_5_670_671":{
+          "add_lyy_stencil_5_502_503":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_6_669_670":{
+          "add_lyy_stencil_6_501_502":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_7_668_669":{
+          "add_lyy_stencil_7_500_501":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_8_lyy_stencil_9_668":{
+          "add_lyy_stencil_8_lyy_stencil_9_500":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_674_675.in0"],
-          ["add_lyy_stencil_2_673_674.out","add_lgyy_stencil_1_674_675.in1"],
-          ["add_lyy_stencil_1_675_676.in1","add_lgyy_stencil_1_674_675.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_675_676.in0"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_1_675_676.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_673_674.in0"],
-          ["add_lyy_stencil_3_672_673.out","add_lyy_stencil_2_673_674.in1"],
-          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_672_673.in0"],
-          ["add_lyy_stencil_4_671_672.out","add_lyy_stencil_3_672_673.in1"],
-          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_671_672.in0"],
-          ["add_lyy_stencil_5_670_671.out","add_lyy_stencil_4_671_672.in1"],
-          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_670_671.in0"],
-          ["add_lyy_stencil_6_669_670.out","add_lyy_stencil_5_670_671.in1"],
-          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_669_670.in0"],
-          ["add_lyy_stencil_7_668_669.out","add_lyy_stencil_6_669_670.in1"],
-          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_668_669.in0"],
-          ["add_lyy_stencil_8_lyy_stencil_9_668.out","add_lyy_stencil_7_668_669.in1"],
-          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_668.in0"],
-          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_668.in1"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_506_507.in0"],
+          ["add_lyy_stencil_2_505_506.out","add_lgyy_stencil_1_506_507.in1"],
+          ["add_lyy_stencil_1_507_508.in1","add_lgyy_stencil_1_506_507.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_507_508.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_1_507_508.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_505_506.in0"],
+          ["add_lyy_stencil_3_504_505.out","add_lyy_stencil_2_505_506.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_504_505.in0"],
+          ["add_lyy_stencil_4_503_504.out","add_lyy_stencil_3_504_505.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_503_504.in0"],
+          ["add_lyy_stencil_5_502_503.out","add_lyy_stencil_4_503_504.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_502_503.in0"],
+          ["add_lyy_stencil_6_501_502.out","add_lyy_stencil_5_502_503.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_501_502.in0"],
+          ["add_lyy_stencil_7_500_501.out","add_lyy_stencil_6_501_502.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_500_501.in0"],
+          ["add_lyy_stencil_8_lyy_stencil_9_500.out","add_lyy_stencil_7_500_501.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_500.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_500.in1"]
         ]
       },
       "hcompute_lxx_stencil":{
@@ -1268,26 +716,26 @@
           ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_402_403_404":{
+          "ashr_318_319_320":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__403":{
+          "const_p6__319":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_x_stencil_1_grad_x_stencil_1_402":{
+          "mul_grad_x_stencil_1_grad_x_stencil_1_318":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_1_grad_x_stencil_1_402.out","ashr_402_403_404.in0"],
-          ["const_p6__403.out","ashr_402_403_404.in1"],
-          ["self.out_lxx_stencil","ashr_402_403_404.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_402.in0"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_402.in1"]
+          ["mul_grad_x_stencil_1_grad_x_stencil_1_318.out","ashr_318_319_320.in0"],
+          ["const_p6__319.out","ashr_318_319_320.in1"],
+          ["self.out_lxx_stencil","ashr_318_319_320.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_318.in0"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_318.in1"]
         ]
       },
       "hcompute_lxy_stencil":{
@@ -1297,26 +745,26 @@
           ["in1_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_594_595_596":{
+          "ashr_426_427_428":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__595":{
+          "const_p6__427":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_x_stencil_2_grad_y_stencil_1_594":{
+          "mul_grad_x_stencil_2_grad_y_stencil_1_426":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_2_grad_y_stencil_1_594.out","ashr_594_595_596.in0"],
-          ["const_p6__595.out","ashr_594_595_596.in1"],
-          ["self.out_lxy_stencil","ashr_594_595_596.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_594.in0"],
-          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_594.in1"]
+          ["mul_grad_x_stencil_2_grad_y_stencil_1_426.out","ashr_426_427_428.in0"],
+          ["const_p6__427.out","ashr_426_427_428.in1"],
+          ["self.out_lxy_stencil","ashr_426_427_428.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_426.in0"],
+          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_426.in1"]
         ]
       },
       "hcompute_lyy_stencil":{
@@ -1325,26 +773,26 @@
           ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_649_650_651":{
+          "ashr_481_482_483":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__650":{
+          "const_p6__482":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_y_stencil_2_grad_y_stencil_2_649":{
+          "mul_grad_y_stencil_2_grad_y_stencil_2_481":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_y_stencil_2_grad_y_stencil_2_649.out","ashr_649_650_651.in0"],
-          ["const_p6__650.out","ashr_649_650_651.in1"],
-          ["self.out_lyy_stencil","ashr_649_650_651.out"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_649.in0"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_649.in1"]
+          ["mul_grad_y_stencil_2_grad_y_stencil_2_481.out","ashr_481_482_483.in0"],
+          ["const_p6__482.out","ashr_481_482_483.in1"],
+          ["self.out_lyy_stencil","ashr_481_482_483.out"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_481.in0"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_481.in1"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{

--- a/coreir_compute/harris_sch6_2ppc_compute.json
+++ b/coreir_compute/harris_sch6_2ppc_compute.json
@@ -8,28 +8,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_1228_1229_1230":{
+          "bitand_982_983_984":{
             "modref":"corebit.and"
           },
-          "bitand_1230_1231_1232":{
+          "bitand_984_985_986":{
             "modref":"corebit.and"
           },
-          "bitand_1232_1233_1234":{
+          "bitand_986_987_988":{
             "modref":"corebit.and"
           },
-          "bitand_1234_1235_1236":{
+          "bitand_988_989_990":{
             "modref":"corebit.and"
           },
-          "bitand_1236_1237_1238":{
+          "bitand_990_991_992":{
             "modref":"corebit.and"
           },
-          "bitand_1238_1239_1240":{
+          "bitand_992_993_994":{
             "modref":"corebit.and"
           },
-          "bitand_1240_1241_1242":{
+          "bitand_994_995_996":{
             "modref":"corebit.and"
           },
-          "bitand_1242_1244_1245":{
+          "bitand_996_998_999":{
             "modref":"corebit.and"
           },
           "const_p0_0":{
@@ -37,7 +37,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__1243":{
+          "const_p1__997":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -47,86 +47,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_12452550":{
+          "mux_9992550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_1243_cim_stencil_2_1244":{
+          "sle_997_cim_stencil_2_998":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_1_cim_stencil_2_1228":{
+          "slt_cim_stencil_1_cim_stencil_2_982":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_3_cim_stencil_2_1229":{
+          "slt_cim_stencil_3_cim_stencil_2_983":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_4_cim_stencil_2_1231":{
+          "slt_cim_stencil_4_cim_stencil_2_985":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_5_cim_stencil_2_1233":{
+          "slt_cim_stencil_5_cim_stencil_2_987":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_6_cim_stencil_2_1235":{
+          "slt_cim_stencil_6_cim_stencil_2_989":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_7_cim_stencil_2_1237":{
+          "slt_cim_stencil_7_cim_stencil_2_991":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_8_cim_stencil_2_1239":{
+          "slt_cim_stencil_8_cim_stencil_2_993":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_9_cim_stencil_2_1241":{
+          "slt_cim_stencil_9_cim_stencil_2_995":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_1_cim_stencil_2_1228.out","bitand_1228_1229_1230.in0"],
-          ["slt_cim_stencil_3_cim_stencil_2_1229.out","bitand_1228_1229_1230.in1"],
-          ["bitand_1230_1231_1232.in0","bitand_1228_1229_1230.out"],
-          ["slt_cim_stencil_4_cim_stencil_2_1231.out","bitand_1230_1231_1232.in1"],
-          ["bitand_1232_1233_1234.in0","bitand_1230_1231_1232.out"],
-          ["slt_cim_stencil_5_cim_stencil_2_1233.out","bitand_1232_1233_1234.in1"],
-          ["bitand_1234_1235_1236.in0","bitand_1232_1233_1234.out"],
-          ["slt_cim_stencil_6_cim_stencil_2_1235.out","bitand_1234_1235_1236.in1"],
-          ["bitand_1236_1237_1238.in0","bitand_1234_1235_1236.out"],
-          ["slt_cim_stencil_7_cim_stencil_2_1237.out","bitand_1236_1237_1238.in1"],
-          ["bitand_1238_1239_1240.in0","bitand_1236_1237_1238.out"],
-          ["slt_cim_stencil_8_cim_stencil_2_1239.out","bitand_1238_1239_1240.in1"],
-          ["bitand_1240_1241_1242.in0","bitand_1238_1239_1240.out"],
-          ["slt_cim_stencil_9_cim_stencil_2_1241.out","bitand_1240_1241_1242.in1"],
-          ["bitand_1242_1244_1245.in0","bitand_1240_1241_1242.out"],
-          ["sle_1243_cim_stencil_2_1244.out","bitand_1242_1244_1245.in1"],
-          ["mux_12452550.sel","bitand_1242_1244_1245.out"],
-          ["mux_12452550.in0","const_p0_0.out"],
-          ["sle_1243_cim_stencil_2_1244.in0","const_p1__1243.out"],
-          ["mux_12452550.in1","const_p255_255.out"],
-          ["self.out_cim_output_stencil","mux_12452550.out"],
-          ["slt_cim_stencil_1_cim_stencil_2_1228.in0","self.in0_cim_stencil.0"],
-          ["sle_1243_cim_stencil_2_1244.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_1_cim_stencil_2_1228.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_1229.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_4_cim_stencil_2_1231.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_5_cim_stencil_2_1233.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_6_cim_stencil_2_1235.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_7_cim_stencil_2_1237.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_8_cim_stencil_2_1239.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_9_cim_stencil_2_1241.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_1229.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_4_cim_stencil_2_1231.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_5_cim_stencil_2_1233.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_6_cim_stencil_2_1235.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_7_cim_stencil_2_1237.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_8_cim_stencil_2_1239.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_9_cim_stencil_2_1241.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_1_cim_stencil_2_982.out","bitand_982_983_984.in0"],
+          ["slt_cim_stencil_3_cim_stencil_2_983.out","bitand_982_983_984.in1"],
+          ["bitand_984_985_986.in0","bitand_982_983_984.out"],
+          ["slt_cim_stencil_4_cim_stencil_2_985.out","bitand_984_985_986.in1"],
+          ["bitand_986_987_988.in0","bitand_984_985_986.out"],
+          ["slt_cim_stencil_5_cim_stencil_2_987.out","bitand_986_987_988.in1"],
+          ["bitand_988_989_990.in0","bitand_986_987_988.out"],
+          ["slt_cim_stencil_6_cim_stencil_2_989.out","bitand_988_989_990.in1"],
+          ["bitand_990_991_992.in0","bitand_988_989_990.out"],
+          ["slt_cim_stencil_7_cim_stencil_2_991.out","bitand_990_991_992.in1"],
+          ["bitand_992_993_994.in0","bitand_990_991_992.out"],
+          ["slt_cim_stencil_8_cim_stencil_2_993.out","bitand_992_993_994.in1"],
+          ["bitand_994_995_996.in0","bitand_992_993_994.out"],
+          ["slt_cim_stencil_9_cim_stencil_2_995.out","bitand_994_995_996.in1"],
+          ["bitand_996_998_999.in0","bitand_994_995_996.out"],
+          ["sle_997_cim_stencil_2_998.out","bitand_996_998_999.in1"],
+          ["mux_9992550.sel","bitand_996_998_999.out"],
+          ["mux_9992550.in0","const_p0_0.out"],
+          ["sle_997_cim_stencil_2_998.in0","const_p1__997.out"],
+          ["mux_9992550.in1","const_p255_255.out"],
+          ["self.out_cim_output_stencil","mux_9992550.out"],
+          ["slt_cim_stencil_1_cim_stencil_2_982.in0","self.in0_cim_stencil.0"],
+          ["sle_997_cim_stencil_2_998.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_1_cim_stencil_2_982.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_983.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_4_cim_stencil_2_985.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_5_cim_stencil_2_987.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_6_cim_stencil_2_989.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_7_cim_stencil_2_991.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_8_cim_stencil_2_993.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_9_cim_stencil_2_995.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_983.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_4_cim_stencil_2_985.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_5_cim_stencil_2_987.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_6_cim_stencil_2_989.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_7_cim_stencil_2_991.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_8_cim_stencil_2_993.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_9_cim_stencil_2_995.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_output_stencil_1":{
@@ -135,28 +135,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_1302_1303_1304":{
+          "bitand_1056_1057_1058":{
             "modref":"corebit.and"
           },
-          "bitand_1304_1305_1306":{
+          "bitand_1058_1059_1060":{
             "modref":"corebit.and"
           },
-          "bitand_1306_1307_1308":{
+          "bitand_1060_1061_1062":{
             "modref":"corebit.and"
           },
-          "bitand_1308_1309_1310":{
+          "bitand_1062_1063_1064":{
             "modref":"corebit.and"
           },
-          "bitand_1310_1311_1312":{
+          "bitand_1064_1065_1066":{
             "modref":"corebit.and"
           },
-          "bitand_1312_1313_1314":{
+          "bitand_1066_1067_1068":{
             "modref":"corebit.and"
           },
-          "bitand_1314_1315_1316":{
+          "bitand_1068_1069_1070":{
             "modref":"corebit.and"
           },
-          "bitand_1316_1318_1319":{
+          "bitand_1070_1072_1073":{
             "modref":"corebit.and"
           },
           "const_p0_0$1":{
@@ -164,7 +164,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__1317":{
+          "const_p1__1071":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -174,86 +174,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_13192550":{
+          "mux_10732550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_1317_cim_stencil_11_1318":{
+          "sle_1071_cim_stencil_11_1072":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_10_cim_stencil_11_1302":{
+          "slt_cim_stencil_10_cim_stencil_11_1056":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_12_cim_stencil_11_1303":{
+          "slt_cim_stencil_12_cim_stencil_11_1057":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_13_cim_stencil_11_1305":{
+          "slt_cim_stencil_13_cim_stencil_11_1059":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_14_cim_stencil_11_1307":{
+          "slt_cim_stencil_14_cim_stencil_11_1061":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_15_cim_stencil_11_1309":{
+          "slt_cim_stencil_15_cim_stencil_11_1063":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_16_cim_stencil_11_1311":{
+          "slt_cim_stencil_16_cim_stencil_11_1065":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_17_cim_stencil_11_1313":{
+          "slt_cim_stencil_17_cim_stencil_11_1067":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_18_cim_stencil_11_1315":{
+          "slt_cim_stencil_18_cim_stencil_11_1069":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_10_cim_stencil_11_1302.out","bitand_1302_1303_1304.in0"],
-          ["slt_cim_stencil_12_cim_stencil_11_1303.out","bitand_1302_1303_1304.in1"],
-          ["bitand_1304_1305_1306.in0","bitand_1302_1303_1304.out"],
-          ["slt_cim_stencil_13_cim_stencil_11_1305.out","bitand_1304_1305_1306.in1"],
-          ["bitand_1306_1307_1308.in0","bitand_1304_1305_1306.out"],
-          ["slt_cim_stencil_14_cim_stencil_11_1307.out","bitand_1306_1307_1308.in1"],
-          ["bitand_1308_1309_1310.in0","bitand_1306_1307_1308.out"],
-          ["slt_cim_stencil_15_cim_stencil_11_1309.out","bitand_1308_1309_1310.in1"],
-          ["bitand_1310_1311_1312.in0","bitand_1308_1309_1310.out"],
-          ["slt_cim_stencil_16_cim_stencil_11_1311.out","bitand_1310_1311_1312.in1"],
-          ["bitand_1312_1313_1314.in0","bitand_1310_1311_1312.out"],
-          ["slt_cim_stencil_17_cim_stencil_11_1313.out","bitand_1312_1313_1314.in1"],
-          ["bitand_1314_1315_1316.in0","bitand_1312_1313_1314.out"],
-          ["slt_cim_stencil_18_cim_stencil_11_1315.out","bitand_1314_1315_1316.in1"],
-          ["bitand_1316_1318_1319.in0","bitand_1314_1315_1316.out"],
-          ["sle_1317_cim_stencil_11_1318.out","bitand_1316_1318_1319.in1"],
-          ["mux_13192550.sel","bitand_1316_1318_1319.out"],
-          ["mux_13192550.in0","const_p0_0$1.out"],
-          ["sle_1317_cim_stencil_11_1318.in0","const_p1__1317.out"],
-          ["mux_13192550.in1","const_p255_255$1.out"],
-          ["self.out_cim_output_stencil","mux_13192550.out"],
-          ["slt_cim_stencil_10_cim_stencil_11_1302.in0","self.in0_cim_stencil.0"],
-          ["sle_1317_cim_stencil_11_1318.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_10_cim_stencil_11_1302.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_12_cim_stencil_11_1303.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_13_cim_stencil_11_1305.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_14_cim_stencil_11_1307.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_15_cim_stencil_11_1309.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_16_cim_stencil_11_1311.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_17_cim_stencil_11_1313.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_18_cim_stencil_11_1315.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_12_cim_stencil_11_1303.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_13_cim_stencil_11_1305.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_14_cim_stencil_11_1307.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_15_cim_stencil_11_1309.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_16_cim_stencil_11_1311.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_17_cim_stencil_11_1313.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_18_cim_stencil_11_1315.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_10_cim_stencil_11_1056.out","bitand_1056_1057_1058.in0"],
+          ["slt_cim_stencil_12_cim_stencil_11_1057.out","bitand_1056_1057_1058.in1"],
+          ["bitand_1058_1059_1060.in0","bitand_1056_1057_1058.out"],
+          ["slt_cim_stencil_13_cim_stencil_11_1059.out","bitand_1058_1059_1060.in1"],
+          ["bitand_1060_1061_1062.in0","bitand_1058_1059_1060.out"],
+          ["slt_cim_stencil_14_cim_stencil_11_1061.out","bitand_1060_1061_1062.in1"],
+          ["bitand_1062_1063_1064.in0","bitand_1060_1061_1062.out"],
+          ["slt_cim_stencil_15_cim_stencil_11_1063.out","bitand_1062_1063_1064.in1"],
+          ["bitand_1064_1065_1066.in0","bitand_1062_1063_1064.out"],
+          ["slt_cim_stencil_16_cim_stencil_11_1065.out","bitand_1064_1065_1066.in1"],
+          ["bitand_1066_1067_1068.in0","bitand_1064_1065_1066.out"],
+          ["slt_cim_stencil_17_cim_stencil_11_1067.out","bitand_1066_1067_1068.in1"],
+          ["bitand_1068_1069_1070.in0","bitand_1066_1067_1068.out"],
+          ["slt_cim_stencil_18_cim_stencil_11_1069.out","bitand_1068_1069_1070.in1"],
+          ["bitand_1070_1072_1073.in0","bitand_1068_1069_1070.out"],
+          ["sle_1071_cim_stencil_11_1072.out","bitand_1070_1072_1073.in1"],
+          ["mux_10732550.sel","bitand_1070_1072_1073.out"],
+          ["mux_10732550.in0","const_p0_0$1.out"],
+          ["sle_1071_cim_stencil_11_1072.in0","const_p1__1071.out"],
+          ["mux_10732550.in1","const_p255_255$1.out"],
+          ["self.out_cim_output_stencil","mux_10732550.out"],
+          ["slt_cim_stencil_10_cim_stencil_11_1056.in0","self.in0_cim_stencil.0"],
+          ["sle_1071_cim_stencil_11_1072.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_10_cim_stencil_11_1056.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_12_cim_stencil_11_1057.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_13_cim_stencil_11_1059.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_14_cim_stencil_11_1061.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_15_cim_stencil_11_1063.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_16_cim_stencil_11_1065.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_17_cim_stencil_11_1067.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_18_cim_stencil_11_1069.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_12_cim_stencil_11_1057.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_13_cim_stencil_11_1059.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_14_cim_stencil_11_1061.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_15_cim_stencil_11_1063.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_16_cim_stencil_11_1065.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_17_cim_stencil_11_1067.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_18_cim_stencil_11_1069.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_stencil":{
@@ -264,89 +264,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_1140_1141_1146":{
+          "add_894_895_900":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_1147_1148_1149":{
+          "ashr_901_902_903":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_3_1139_1140":{
+          "ashr_lgxx_stencil_3_893_894":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_3_1139_1143":{
+          "ashr_lgxy_stencil_3_893_897":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_3_1139_1141":{
+          "ashr_lgyy_stencil_3_893_895":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__1148":{
+          "const_p4__902":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__1139":{
+          "const_p6__893":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__1139$1":{
+          "const_p6__893$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__1139$2":{
+          "const_p6__893$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_1140_1141_1142":{
+          "mul_894_895_896":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_1143_1143_1144":{
+          "mul_897_897_898":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_1146_1146_1147":{
+          "mul_900_900_901":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_1142_1144_1145":{
+          "sub_896_898_899":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_1145_1149_1150":{
+          "sub_899_903_904":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_3_1139_1140.out","add_1140_1141_1146.in0"],
-          ["ashr_lgyy_stencil_3_1139_1141.out","add_1140_1141_1146.in1"],
-          ["mul_1146_1146_1147.in0","add_1140_1141_1146.out"],
-          ["mul_1146_1146_1147.in1","add_1140_1141_1146.out"],
-          ["mul_1146_1146_1147.out","ashr_1147_1148_1149.in0"],
-          ["const_p4__1148.out","ashr_1147_1148_1149.in1"],
-          ["sub_1145_1149_1150.in1","ashr_1147_1148_1149.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_3_1139_1140.in0"],
-          ["const_p6__1139.out","ashr_lgxx_stencil_3_1139_1140.in1"],
-          ["mul_1140_1141_1142.in0","ashr_lgxx_stencil_3_1139_1140.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_3_1139_1143.in0"],
-          ["const_p6__1139$2.out","ashr_lgxy_stencil_3_1139_1143.in1"],
-          ["mul_1143_1143_1144.in0","ashr_lgxy_stencil_3_1139_1143.out"],
-          ["mul_1143_1143_1144.in1","ashr_lgxy_stencil_3_1139_1143.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_3_1139_1141.in0"],
-          ["const_p6__1139$1.out","ashr_lgyy_stencil_3_1139_1141.in1"],
-          ["mul_1140_1141_1142.in1","ashr_lgyy_stencil_3_1139_1141.out"],
-          ["sub_1142_1144_1145.in0","mul_1140_1141_1142.out"],
-          ["sub_1142_1144_1145.in1","mul_1143_1143_1144.out"],
-          ["sub_1145_1149_1150.out","self.out_cim_stencil"],
-          ["sub_1145_1149_1150.in0","sub_1142_1144_1145.out"]
+          ["ashr_lgxx_stencil_3_893_894.out","add_894_895_900.in0"],
+          ["ashr_lgyy_stencil_3_893_895.out","add_894_895_900.in1"],
+          ["mul_900_900_901.in0","add_894_895_900.out"],
+          ["mul_900_900_901.in1","add_894_895_900.out"],
+          ["mul_900_900_901.out","ashr_901_902_903.in0"],
+          ["const_p4__902.out","ashr_901_902_903.in1"],
+          ["sub_899_903_904.in1","ashr_901_902_903.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_3_893_894.in0"],
+          ["const_p6__893.out","ashr_lgxx_stencil_3_893_894.in1"],
+          ["mul_894_895_896.in0","ashr_lgxx_stencil_3_893_894.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_3_893_897.in0"],
+          ["const_p6__893$2.out","ashr_lgxy_stencil_3_893_897.in1"],
+          ["mul_897_897_898.in0","ashr_lgxy_stencil_3_893_897.out"],
+          ["mul_897_897_898.in1","ashr_lgxy_stencil_3_893_897.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_3_893_895.in0"],
+          ["const_p6__893$1.out","ashr_lgyy_stencil_3_893_895.in1"],
+          ["mul_894_895_896.in1","ashr_lgyy_stencil_3_893_895.out"],
+          ["sub_896_898_899.in0","mul_894_895_896.out"],
+          ["sub_896_898_899.in1","mul_897_897_898.out"],
+          ["sub_899_903_904.out","self.out_cim_stencil"],
+          ["sub_899_903_904.in0","sub_896_898_899.out"]
         ]
       },
       "hcompute_cim_stencil_1":{
@@ -357,89 +357,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_1181_1182_1187":{
+          "add_935_936_941":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_1188_1189_1190":{
+          "ashr_942_943_944":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_4_1180_1181":{
+          "ashr_lgxx_stencil_4_934_935":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_4_1180_1184":{
+          "ashr_lgxy_stencil_4_934_938":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_4_1180_1182":{
+          "ashr_lgyy_stencil_4_934_936":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__1189":{
+          "const_p4__943":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__1180":{
+          "const_p6__934":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__1180$1":{
+          "const_p6__934$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__1180$2":{
+          "const_p6__934$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_1181_1182_1183":{
+          "mul_935_936_937":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_1184_1184_1185":{
+          "mul_938_938_939":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_1187_1187_1188":{
+          "mul_941_941_942":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_1183_1185_1186":{
+          "sub_937_939_940":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_1186_1190_1191":{
+          "sub_940_944_945":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_4_1180_1181.out","add_1181_1182_1187.in0"],
-          ["ashr_lgyy_stencil_4_1180_1182.out","add_1181_1182_1187.in1"],
-          ["mul_1187_1187_1188.in0","add_1181_1182_1187.out"],
-          ["mul_1187_1187_1188.in1","add_1181_1182_1187.out"],
-          ["mul_1187_1187_1188.out","ashr_1188_1189_1190.in0"],
-          ["const_p4__1189.out","ashr_1188_1189_1190.in1"],
-          ["sub_1186_1190_1191.in1","ashr_1188_1189_1190.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_4_1180_1181.in0"],
-          ["const_p6__1180.out","ashr_lgxx_stencil_4_1180_1181.in1"],
-          ["mul_1181_1182_1183.in0","ashr_lgxx_stencil_4_1180_1181.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_4_1180_1184.in0"],
-          ["const_p6__1180$2.out","ashr_lgxy_stencil_4_1180_1184.in1"],
-          ["mul_1184_1184_1185.in0","ashr_lgxy_stencil_4_1180_1184.out"],
-          ["mul_1184_1184_1185.in1","ashr_lgxy_stencil_4_1180_1184.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_4_1180_1182.in0"],
-          ["const_p6__1180$1.out","ashr_lgyy_stencil_4_1180_1182.in1"],
-          ["mul_1181_1182_1183.in1","ashr_lgyy_stencil_4_1180_1182.out"],
-          ["sub_1183_1185_1186.in0","mul_1181_1182_1183.out"],
-          ["sub_1183_1185_1186.in1","mul_1184_1184_1185.out"],
-          ["sub_1186_1190_1191.out","self.out_cim_stencil"],
-          ["sub_1186_1190_1191.in0","sub_1183_1185_1186.out"]
+          ["ashr_lgxx_stencil_4_934_935.out","add_935_936_941.in0"],
+          ["ashr_lgyy_stencil_4_934_936.out","add_935_936_941.in1"],
+          ["mul_941_941_942.in0","add_935_936_941.out"],
+          ["mul_941_941_942.in1","add_935_936_941.out"],
+          ["mul_941_941_942.out","ashr_942_943_944.in0"],
+          ["const_p4__943.out","ashr_942_943_944.in1"],
+          ["sub_940_944_945.in1","ashr_942_943_944.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_4_934_935.in0"],
+          ["const_p6__934.out","ashr_lgxx_stencil_4_934_935.in1"],
+          ["mul_935_936_937.in0","ashr_lgxx_stencil_4_934_935.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_4_934_938.in0"],
+          ["const_p6__934$2.out","ashr_lgxy_stencil_4_934_938.in1"],
+          ["mul_938_938_939.in0","ashr_lgxy_stencil_4_934_938.out"],
+          ["mul_938_938_939.in1","ashr_lgxy_stencil_4_934_938.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_4_934_936.in0"],
+          ["const_p6__934$1.out","ashr_lgyy_stencil_4_934_936.in1"],
+          ["mul_935_936_937.in1","ashr_lgyy_stencil_4_934_936.out"],
+          ["sub_937_939_940.in0","mul_935_936_937.out"],
+          ["sub_937_939_940.in1","mul_938_938_939.out"],
+          ["sub_940_944_945.out","self.out_cim_stencil"],
+          ["sub_940_944_945.in0","sub_937_939_940.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil":{
@@ -447,14 +447,14 @@
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__312":{
+          "const_p0__267":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_x_unclamp_stencil","const_p0__312.out"]
+          ["self.out_grad_x_unclamp_stencil","const_p0__267.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil_1":{
@@ -462,256 +462,154 @@
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__317":{
+          "const_p0__272":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_x_unclamp_stencil","const_p0__317.out"]
+          ["self.out_grad_x_unclamp_stencil","const_p0__272.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil_2":{
         "type":["Record",[
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_x_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_339_355_356":{
+          "add_grad_x_unclamp_stencil_1_288_289":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_340_353_354":{
+          "add_padded16_global_wrapper_stencil_1_287_288":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_341_352_353":{
+          "add_padded16_global_wrapper_stencil_2_286_287":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_342_351_352":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__285":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_343_350_351":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__285$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_344_349_350":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_345_348_349":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_346_347_348":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_x_unclamp_stencil_1_354_355":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_339":{
+          "mul_padded16_global_wrapper_stencil_3_285_286":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_340":{
+          "mul_padded16_global_wrapper_stencil_5_285_291":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_341":{
-            "genref":"coreir.mul",
+          "sub_289_padded16_global_wrapper_stencil_4_290":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_342":{
-            "genref":"coreir.mul",
+          "sub_290_291_292":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_343":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_344":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_345":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_346":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_347":{
-            "genref":"coreir.mul",
+          "sub_292_padded16_global_wrapper_stencil_6_293":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_339.out","add_339_355_356.in0"],
-          ["add_grad_x_unclamp_stencil_1_354_355.out","add_339_355_356.in1"],
-          ["self.out_grad_x_unclamp_stencil","add_339_355_356.out"],
-          ["mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_340.out","add_340_353_354.in0"],
-          ["add_341_352_353.out","add_340_353_354.in1"],
-          ["add_grad_x_unclamp_stencil_1_354_355.in1","add_340_353_354.out"],
-          ["mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_341.out","add_341_352_353.in0"],
-          ["add_342_351_352.out","add_341_352_353.in1"],
-          ["mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_342.out","add_342_351_352.in0"],
-          ["add_343_350_351.out","add_342_351_352.in1"],
-          ["mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_343.out","add_343_350_351.in0"],
-          ["add_344_349_350.out","add_343_350_351.in1"],
-          ["mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_344.out","add_344_349_350.in0"],
-          ["add_345_348_349.out","add_344_349_350.in1"],
-          ["mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_345.out","add_345_348_349.in0"],
-          ["add_346_347_348.out","add_345_348_349.in1"],
-          ["mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_346.out","add_346_347_348.in0"],
-          ["mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_347.out","add_346_347_348.in1"],
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_354_355.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_339.in0"],
-          ["self.in1_kernel_x_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_339.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_340.in0"],
-          ["self.in1_kernel_x_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_340.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_341.in0"],
-          ["self.in1_kernel_x_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_341.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_342.in0"],
-          ["self.in1_kernel_x_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_342.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_343.in0"],
-          ["self.in1_kernel_x_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_343.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_344.in0"],
-          ["self.in1_kernel_x_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_344.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_345.in0"],
-          ["self.in1_kernel_x_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_345.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_346.in0"],
-          ["self.in1_kernel_x_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_346.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_347.in0"],
-          ["self.in1_kernel_x_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_347.in1"]
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_288_289.in0"],
+          ["add_padded16_global_wrapper_stencil_1_287_288.out","add_grad_x_unclamp_stencil_1_288_289.in1"],
+          ["sub_289_padded16_global_wrapper_stencil_4_290.in0","add_grad_x_unclamp_stencil_1_288_289.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_1_287_288.in0"],
+          ["add_padded16_global_wrapper_stencil_2_286_287.out","add_padded16_global_wrapper_stencil_1_287_288.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_2_286_287.in0"],
+          ["mul_padded16_global_wrapper_stencil_3_285_286.out","add_padded16_global_wrapper_stencil_2_286_287.in1"],
+          ["mul_padded16_global_wrapper_stencil_5_285_291.in1","const_p2__285$1.out"],
+          ["mul_padded16_global_wrapper_stencil_3_285_286.in1","const_p2__285.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_285_286.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_285_291.in0"],
+          ["sub_290_291_292.in1","mul_padded16_global_wrapper_stencil_5_285_291.out"],
+          ["sub_289_padded16_global_wrapper_stencil_4_290.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_292_padded16_global_wrapper_stencil_6_293.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_292_padded16_global_wrapper_stencil_6_293.out","self.out_grad_x_unclamp_stencil"],
+          ["sub_290_291_292.in0","sub_289_padded16_global_wrapper_stencil_4_290.out"],
+          ["sub_292_padded16_global_wrapper_stencil_6_293.in0","sub_290_291_292.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil_3":{
         "type":["Record",[
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_x_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_418_434_435":{
+          "add_grad_x_unclamp_stencil_2_328_329":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_419_432_433":{
+          "add_padded16_global_wrapper_stencil_7_327_328":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_420_431_432":{
+          "add_padded16_global_wrapper_stencil_8_326_327":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_421_430_431":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__325":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_422_429_430":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__325$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_423_428_429":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_424_427_428":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_425_426_427":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_x_unclamp_stencil_2_433_434":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_10_kernel_x_stencil_10_418":{
+          "mul_padded16_global_wrapper_stencil_11_325_331":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_11_kernel_x_stencil_11_419":{
+          "mul_padded16_global_wrapper_stencil_9_325_326":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_12_kernel_x_stencil_12_420":{
-            "genref":"coreir.mul",
+          "sub_329_padded16_global_wrapper_stencil_10_330":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_13_kernel_x_stencil_13_421":{
-            "genref":"coreir.mul",
+          "sub_330_331_332":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_14_kernel_x_stencil_14_422":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_15_kernel_x_stencil_15_423":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_16_kernel_x_stencil_16_424":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_17_kernel_x_stencil_17_425":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_18_kernel_x_stencil_18_426":{
-            "genref":"coreir.mul",
+          "sub_332_padded16_global_wrapper_stencil_12_333":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_10_kernel_x_stencil_10_418.out","add_418_434_435.in0"],
-          ["add_grad_x_unclamp_stencil_2_433_434.out","add_418_434_435.in1"],
-          ["self.out_grad_x_unclamp_stencil","add_418_434_435.out"],
-          ["mul_padded16_global_wrapper_stencil_11_kernel_x_stencil_11_419.out","add_419_432_433.in0"],
-          ["add_420_431_432.out","add_419_432_433.in1"],
-          ["add_grad_x_unclamp_stencil_2_433_434.in1","add_419_432_433.out"],
-          ["mul_padded16_global_wrapper_stencil_12_kernel_x_stencil_12_420.out","add_420_431_432.in0"],
-          ["add_421_430_431.out","add_420_431_432.in1"],
-          ["mul_padded16_global_wrapper_stencil_13_kernel_x_stencil_13_421.out","add_421_430_431.in0"],
-          ["add_422_429_430.out","add_421_430_431.in1"],
-          ["mul_padded16_global_wrapper_stencil_14_kernel_x_stencil_14_422.out","add_422_429_430.in0"],
-          ["add_423_428_429.out","add_422_429_430.in1"],
-          ["mul_padded16_global_wrapper_stencil_15_kernel_x_stencil_15_423.out","add_423_428_429.in0"],
-          ["add_424_427_428.out","add_423_428_429.in1"],
-          ["mul_padded16_global_wrapper_stencil_16_kernel_x_stencil_16_424.out","add_424_427_428.in0"],
-          ["add_425_426_427.out","add_424_427_428.in1"],
-          ["mul_padded16_global_wrapper_stencil_17_kernel_x_stencil_17_425.out","add_425_426_427.in0"],
-          ["mul_padded16_global_wrapper_stencil_18_kernel_x_stencil_18_426.out","add_425_426_427.in1"],
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_2_433_434.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_x_stencil_10_418.in0"],
-          ["self.in1_kernel_x_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_x_stencil_10_418.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_x_stencil_11_419.in0"],
-          ["self.in1_kernel_x_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_x_stencil_11_419.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_x_stencil_12_420.in0"],
-          ["self.in1_kernel_x_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_x_stencil_12_420.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_x_stencil_13_421.in0"],
-          ["self.in1_kernel_x_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_x_stencil_13_421.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_x_stencil_14_422.in0"],
-          ["self.in1_kernel_x_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_x_stencil_14_422.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_x_stencil_15_423.in0"],
-          ["self.in1_kernel_x_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_x_stencil_15_423.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_x_stencil_16_424.in0"],
-          ["self.in1_kernel_x_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_x_stencil_16_424.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_x_stencil_17_425.in0"],
-          ["self.in1_kernel_x_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_x_stencil_17_425.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_x_stencil_18_426.in0"],
-          ["self.in1_kernel_x_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_x_stencil_18_426.in1"]
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_2_328_329.in0"],
+          ["add_padded16_global_wrapper_stencil_7_327_328.out","add_grad_x_unclamp_stencil_2_328_329.in1"],
+          ["sub_329_padded16_global_wrapper_stencil_10_330.in0","add_grad_x_unclamp_stencil_2_328_329.out"],
+          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_327_328.in0"],
+          ["add_padded16_global_wrapper_stencil_8_326_327.out","add_padded16_global_wrapper_stencil_7_327_328.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_326_327.in0"],
+          ["mul_padded16_global_wrapper_stencil_9_325_326.out","add_padded16_global_wrapper_stencil_8_326_327.in1"],
+          ["mul_padded16_global_wrapper_stencil_11_325_331.in1","const_p2__325$1.out"],
+          ["mul_padded16_global_wrapper_stencil_9_325_326.in1","const_p2__325.out"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_325_331.in0"],
+          ["sub_330_331_332.in1","mul_padded16_global_wrapper_stencil_11_325_331.out"],
+          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_325_326.in0"],
+          ["sub_329_padded16_global_wrapper_stencil_10_330.in1","self.in1_padded16_global_wrapper_stencil.0"],
+          ["sub_332_padded16_global_wrapper_stencil_12_333.in1","self.in1_padded16_global_wrapper_stencil.2"],
+          ["sub_332_padded16_global_wrapper_stencil_12_333.out","self.out_grad_x_unclamp_stencil"],
+          ["sub_330_331_332.in0","sub_329_padded16_global_wrapper_stencil_10_330.out"],
+          ["sub_332_padded16_global_wrapper_stencil_12_333.in0","sub_330_331_332.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil":{
@@ -719,14 +617,14 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__665":{
+          "const_p0__497":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__665.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__497.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_1":{
@@ -734,256 +632,154 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__670":{
+          "const_p0__502":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__670.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__502.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_2":{
         "type":["Record",[
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_y_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_692_708_709":{
+          "add_grad_y_unclamp_stencil_1_518_519":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_693_706_707":{
+          "add_padded16_global_wrapper_stencil_13_517_518":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_694_705_706":{
+          "add_padded16_global_wrapper_stencil_14_516_517":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_695_704_705":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__515":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_696_703_704":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__515$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_697_702_703":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_698_701_702":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_699_700_701":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_y_unclamp_stencil_1_707_708":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_19_kernel_y_stencil_1_692":{
+          "mul_padded16_global_wrapper_stencil_15_515_516":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_20_kernel_y_stencil_2_693":{
+          "mul_padded16_global_wrapper_stencil_17_515_521":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_21_kernel_y_stencil_3_694":{
-            "genref":"coreir.mul",
+          "sub_519_padded16_global_wrapper_stencil_16_520":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_22_kernel_y_stencil_4_695":{
-            "genref":"coreir.mul",
+          "sub_520_521_522":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_23_kernel_y_stencil_5_696":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_24_kernel_y_stencil_6_697":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_25_kernel_y_stencil_7_698":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_26_kernel_y_stencil_8_699":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_27_kernel_y_stencil_9_700":{
-            "genref":"coreir.mul",
+          "sub_522_padded16_global_wrapper_stencil_18_523":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_19_kernel_y_stencil_1_692.out","add_692_708_709.in0"],
-          ["add_grad_y_unclamp_stencil_1_707_708.out","add_692_708_709.in1"],
-          ["self.out_grad_y_unclamp_stencil","add_692_708_709.out"],
-          ["mul_padded16_global_wrapper_stencil_20_kernel_y_stencil_2_693.out","add_693_706_707.in0"],
-          ["add_694_705_706.out","add_693_706_707.in1"],
-          ["add_grad_y_unclamp_stencil_1_707_708.in1","add_693_706_707.out"],
-          ["mul_padded16_global_wrapper_stencil_21_kernel_y_stencil_3_694.out","add_694_705_706.in0"],
-          ["add_695_704_705.out","add_694_705_706.in1"],
-          ["mul_padded16_global_wrapper_stencil_22_kernel_y_stencil_4_695.out","add_695_704_705.in0"],
-          ["add_696_703_704.out","add_695_704_705.in1"],
-          ["mul_padded16_global_wrapper_stencil_23_kernel_y_stencil_5_696.out","add_696_703_704.in0"],
-          ["add_697_702_703.out","add_696_703_704.in1"],
-          ["mul_padded16_global_wrapper_stencil_24_kernel_y_stencil_6_697.out","add_697_702_703.in0"],
-          ["add_698_701_702.out","add_697_702_703.in1"],
-          ["mul_padded16_global_wrapper_stencil_25_kernel_y_stencil_7_698.out","add_698_701_702.in0"],
-          ["add_699_700_701.out","add_698_701_702.in1"],
-          ["mul_padded16_global_wrapper_stencil_26_kernel_y_stencil_8_699.out","add_699_700_701.in0"],
-          ["mul_padded16_global_wrapper_stencil_27_kernel_y_stencil_9_700.out","add_699_700_701.in1"],
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_707_708.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_19_kernel_y_stencil_1_692.in0"],
-          ["self.in1_kernel_y_stencil.0","mul_padded16_global_wrapper_stencil_19_kernel_y_stencil_1_692.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_20_kernel_y_stencil_2_693.in0"],
-          ["self.in1_kernel_y_stencil.1","mul_padded16_global_wrapper_stencil_20_kernel_y_stencil_2_693.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_21_kernel_y_stencil_3_694.in0"],
-          ["self.in1_kernel_y_stencil.2","mul_padded16_global_wrapper_stencil_21_kernel_y_stencil_3_694.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_22_kernel_y_stencil_4_695.in0"],
-          ["self.in1_kernel_y_stencil.3","mul_padded16_global_wrapper_stencil_22_kernel_y_stencil_4_695.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_23_kernel_y_stencil_5_696.in0"],
-          ["self.in1_kernel_y_stencil.4","mul_padded16_global_wrapper_stencil_23_kernel_y_stencil_5_696.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_24_kernel_y_stencil_6_697.in0"],
-          ["self.in1_kernel_y_stencil.5","mul_padded16_global_wrapper_stencil_24_kernel_y_stencil_6_697.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_25_kernel_y_stencil_7_698.in0"],
-          ["self.in1_kernel_y_stencil.6","mul_padded16_global_wrapper_stencil_25_kernel_y_stencil_7_698.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_26_kernel_y_stencil_8_699.in0"],
-          ["self.in1_kernel_y_stencil.7","mul_padded16_global_wrapper_stencil_26_kernel_y_stencil_8_699.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_27_kernel_y_stencil_9_700.in0"],
-          ["self.in1_kernel_y_stencil.8","mul_padded16_global_wrapper_stencil_27_kernel_y_stencil_9_700.in1"]
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_518_519.in0"],
+          ["add_padded16_global_wrapper_stencil_13_517_518.out","add_grad_y_unclamp_stencil_1_518_519.in1"],
+          ["sub_519_padded16_global_wrapper_stencil_16_520.in0","add_grad_y_unclamp_stencil_1_518_519.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_13_517_518.in0"],
+          ["add_padded16_global_wrapper_stencil_14_516_517.out","add_padded16_global_wrapper_stencil_13_517_518.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_14_516_517.in0"],
+          ["mul_padded16_global_wrapper_stencil_15_515_516.out","add_padded16_global_wrapper_stencil_14_516_517.in1"],
+          ["mul_padded16_global_wrapper_stencil_17_515_521.in1","const_p2__515$1.out"],
+          ["mul_padded16_global_wrapper_stencil_15_515_516.in1","const_p2__515.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_15_515_516.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_17_515_521.in0"],
+          ["sub_520_521_522.in1","mul_padded16_global_wrapper_stencil_17_515_521.out"],
+          ["sub_519_padded16_global_wrapper_stencil_16_520.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_522_padded16_global_wrapper_stencil_18_523.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_522_padded16_global_wrapper_stencil_18_523.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_520_521_522.in0","sub_519_padded16_global_wrapper_stencil_16_520.out"],
+          ["sub_522_padded16_global_wrapper_stencil_18_523.in0","sub_520_521_522.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_3":{
         "type":["Record",[
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_y_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_771_787_788":{
+          "add_grad_y_unclamp_stencil_2_558_559":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_772_785_786":{
+          "add_padded16_global_wrapper_stencil_19_557_558":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_773_784_785":{
+          "add_padded16_global_wrapper_stencil_20_556_557":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_774_783_784":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__555":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_775_782_783":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__555$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_776_781_782":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_777_780_781":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_778_779_780":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_y_unclamp_stencil_2_786_787":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_28_kernel_y_stencil_10_771":{
+          "mul_padded16_global_wrapper_stencil_21_555_556":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_29_kernel_y_stencil_11_772":{
+          "mul_padded16_global_wrapper_stencil_23_555_561":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_30_kernel_y_stencil_12_773":{
-            "genref":"coreir.mul",
+          "sub_559_padded16_global_wrapper_stencil_22_560":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_31_kernel_y_stencil_13_774":{
-            "genref":"coreir.mul",
+          "sub_560_561_562":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_32_kernel_y_stencil_14_775":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_33_kernel_y_stencil_15_776":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_34_kernel_y_stencil_16_777":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_35_kernel_y_stencil_17_778":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_36_kernel_y_stencil_18_779":{
-            "genref":"coreir.mul",
+          "sub_562_padded16_global_wrapper_stencil_24_563":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_28_kernel_y_stencil_10_771.out","add_771_787_788.in0"],
-          ["add_grad_y_unclamp_stencil_2_786_787.out","add_771_787_788.in1"],
-          ["self.out_grad_y_unclamp_stencil","add_771_787_788.out"],
-          ["mul_padded16_global_wrapper_stencil_29_kernel_y_stencil_11_772.out","add_772_785_786.in0"],
-          ["add_773_784_785.out","add_772_785_786.in1"],
-          ["add_grad_y_unclamp_stencil_2_786_787.in1","add_772_785_786.out"],
-          ["mul_padded16_global_wrapper_stencil_30_kernel_y_stencil_12_773.out","add_773_784_785.in0"],
-          ["add_774_783_784.out","add_773_784_785.in1"],
-          ["mul_padded16_global_wrapper_stencil_31_kernel_y_stencil_13_774.out","add_774_783_784.in0"],
-          ["add_775_782_783.out","add_774_783_784.in1"],
-          ["mul_padded16_global_wrapper_stencil_32_kernel_y_stencil_14_775.out","add_775_782_783.in0"],
-          ["add_776_781_782.out","add_775_782_783.in1"],
-          ["mul_padded16_global_wrapper_stencil_33_kernel_y_stencil_15_776.out","add_776_781_782.in0"],
-          ["add_777_780_781.out","add_776_781_782.in1"],
-          ["mul_padded16_global_wrapper_stencil_34_kernel_y_stencil_16_777.out","add_777_780_781.in0"],
-          ["add_778_779_780.out","add_777_780_781.in1"],
-          ["mul_padded16_global_wrapper_stencil_35_kernel_y_stencil_17_778.out","add_778_779_780.in0"],
-          ["mul_padded16_global_wrapper_stencil_36_kernel_y_stencil_18_779.out","add_778_779_780.in1"],
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_2_786_787.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_28_kernel_y_stencil_10_771.in0"],
-          ["self.in1_kernel_y_stencil.0","mul_padded16_global_wrapper_stencil_28_kernel_y_stencil_10_771.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_29_kernel_y_stencil_11_772.in0"],
-          ["self.in1_kernel_y_stencil.1","mul_padded16_global_wrapper_stencil_29_kernel_y_stencil_11_772.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_30_kernel_y_stencil_12_773.in0"],
-          ["self.in1_kernel_y_stencil.2","mul_padded16_global_wrapper_stencil_30_kernel_y_stencil_12_773.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_31_kernel_y_stencil_13_774.in0"],
-          ["self.in1_kernel_y_stencil.3","mul_padded16_global_wrapper_stencil_31_kernel_y_stencil_13_774.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_32_kernel_y_stencil_14_775.in0"],
-          ["self.in1_kernel_y_stencil.4","mul_padded16_global_wrapper_stencil_32_kernel_y_stencil_14_775.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_33_kernel_y_stencil_15_776.in0"],
-          ["self.in1_kernel_y_stencil.5","mul_padded16_global_wrapper_stencil_33_kernel_y_stencil_15_776.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_34_kernel_y_stencil_16_777.in0"],
-          ["self.in1_kernel_y_stencil.6","mul_padded16_global_wrapper_stencil_34_kernel_y_stencil_16_777.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_35_kernel_y_stencil_17_778.in0"],
-          ["self.in1_kernel_y_stencil.7","mul_padded16_global_wrapper_stencil_35_kernel_y_stencil_17_778.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_36_kernel_y_stencil_18_779.in0"],
-          ["self.in1_kernel_y_stencil.8","mul_padded16_global_wrapper_stencil_36_kernel_y_stencil_18_779.in1"]
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_2_558_559.in0"],
+          ["add_padded16_global_wrapper_stencil_19_557_558.out","add_grad_y_unclamp_stencil_2_558_559.in1"],
+          ["sub_559_padded16_global_wrapper_stencil_22_560.in0","add_grad_y_unclamp_stencil_2_558_559.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_19_557_558.in0"],
+          ["add_padded16_global_wrapper_stencil_20_556_557.out","add_padded16_global_wrapper_stencil_19_557_558.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_20_556_557.in0"],
+          ["mul_padded16_global_wrapper_stencil_21_555_556.out","add_padded16_global_wrapper_stencil_20_556_557.in1"],
+          ["mul_padded16_global_wrapper_stencil_23_555_561.in1","const_p2__555$1.out"],
+          ["mul_padded16_global_wrapper_stencil_21_555_556.in1","const_p2__555.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_21_555_556.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_23_555_561.in0"],
+          ["sub_560_561_562.in1","mul_padded16_global_wrapper_stencil_23_555_561.out"],
+          ["sub_559_padded16_global_wrapper_stencil_22_560.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_562_padded16_global_wrapper_stencil_24_563.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_562_padded16_global_wrapper_stencil_24_563.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_560_561_562.in0","sub_559_padded16_global_wrapper_stencil_22_560.out"],
+          ["sub_562_padded16_global_wrapper_stencil_24_563.in0","sub_560_561_562.out"]
         ]
       },
       "hcompute_hw_output_stencil":{
@@ -1004,469 +800,19 @@
           ["self.out_hw_output_stencil","self.in0_cim_output_stencil.0"]
         ]
       },
-      "hcompute_kernel_x_stencil":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__261":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__261.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__264":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__264.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__291":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n2__291.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__294":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__294.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__297":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__297.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__300":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p2__300.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__303":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__303.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__267":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__267.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__270":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__270.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__273":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__273.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__276":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__276.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__279":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__279.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__282":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__282.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__285":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__285.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__288":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__288.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__620":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__620.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__623":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__623.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__650":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p2__650.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__653":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__653.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__656":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__656.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__659":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n2__659.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__662":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__662.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__626":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__626.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__629":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__629.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__632":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__632.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__635":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__635.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__638":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__638.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__641":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__641.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__644":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__644.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__647":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__647.out"]
-        ]
-      },
       "hcompute_lgxx_stencil":{
         "type":["Record",[
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__527":{
+          "const_p0__404":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__527.out"]
+          ["self.out_lgxx_stencil","const_p0__404.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
@@ -1474,14 +820,14 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__532":{
+          "const_p0__409":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__532.out"]
+          ["self.out_lgxx_stencil","const_p0__409.out"]
         ]
       },
       "hcompute_lgxx_stencil_2":{
@@ -1491,63 +837,63 @@
           ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_550_551":{
+          "add_lgxx_stencil_1_427_428":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_1_551_552":{
+          "add_lxx_stencil_1_428_429":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_2_549_550":{
+          "add_lxx_stencil_2_426_427":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_3_548_549":{
+          "add_lxx_stencil_3_425_426":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_4_547_548":{
+          "add_lxx_stencil_4_424_425":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_5_546_547":{
+          "add_lxx_stencil_5_423_424":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_6_545_546":{
+          "add_lxx_stencil_6_422_423":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_7_544_545":{
+          "add_lxx_stencil_7_421_422":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_8_lxx_stencil_9_544":{
+          "add_lxx_stencil_8_lxx_stencil_9_421":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_550_551.in0"],
-          ["add_lxx_stencil_2_549_550.out","add_lgxx_stencil_1_550_551.in1"],
-          ["add_lxx_stencil_1_551_552.in1","add_lgxx_stencil_1_550_551.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_551_552.in0"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_1_551_552.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_549_550.in0"],
-          ["add_lxx_stencil_3_548_549.out","add_lxx_stencil_2_549_550.in1"],
-          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_548_549.in0"],
-          ["add_lxx_stencil_4_547_548.out","add_lxx_stencil_3_548_549.in1"],
-          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_547_548.in0"],
-          ["add_lxx_stencil_5_546_547.out","add_lxx_stencil_4_547_548.in1"],
-          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_546_547.in0"],
-          ["add_lxx_stencil_6_545_546.out","add_lxx_stencil_5_546_547.in1"],
-          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_545_546.in0"],
-          ["add_lxx_stencil_7_544_545.out","add_lxx_stencil_6_545_546.in1"],
-          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_544_545.in0"],
-          ["add_lxx_stencil_8_lxx_stencil_9_544.out","add_lxx_stencil_7_544_545.in1"],
-          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_544.in0"],
-          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_544.in1"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_427_428.in0"],
+          ["add_lxx_stencil_2_426_427.out","add_lgxx_stencil_1_427_428.in1"],
+          ["add_lxx_stencil_1_428_429.in1","add_lgxx_stencil_1_427_428.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_428_429.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_1_428_429.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_426_427.in0"],
+          ["add_lxx_stencil_3_425_426.out","add_lxx_stencil_2_426_427.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_425_426.in0"],
+          ["add_lxx_stencil_4_424_425.out","add_lxx_stencil_3_425_426.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_424_425.in0"],
+          ["add_lxx_stencil_5_423_424.out","add_lxx_stencil_4_424_425.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_423_424.in0"],
+          ["add_lxx_stencil_6_422_423.out","add_lxx_stencil_5_423_424.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_422_423.in0"],
+          ["add_lxx_stencil_7_421_422.out","add_lxx_stencil_6_422_423.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_421_422.in0"],
+          ["add_lxx_stencil_8_lxx_stencil_9_421.out","add_lxx_stencil_7_421_422.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_421.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_421.in1"]
         ]
       },
       "hcompute_lgxx_stencil_3":{
@@ -1557,63 +903,63 @@
           ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_2_592_593":{
+          "add_lgxx_stencil_2_469_470":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_10_593_594":{
+          "add_lxx_stencil_10_470_471":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_11_591_592":{
+          "add_lxx_stencil_11_468_469":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_12_590_591":{
+          "add_lxx_stencil_12_467_468":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_13_589_590":{
+          "add_lxx_stencil_13_466_467":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_14_588_589":{
+          "add_lxx_stencil_14_465_466":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_15_587_588":{
+          "add_lxx_stencil_15_464_465":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_16_586_587":{
+          "add_lxx_stencil_16_463_464":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_17_lxx_stencil_18_586":{
+          "add_lxx_stencil_17_lxx_stencil_18_463":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_2_592_593.in0"],
-          ["add_lxx_stencil_11_591_592.out","add_lgxx_stencil_2_592_593.in1"],
-          ["add_lxx_stencil_10_593_594.in1","add_lgxx_stencil_2_592_593.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_10_593_594.in0"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_10_593_594.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_11_591_592.in0"],
-          ["add_lxx_stencil_12_590_591.out","add_lxx_stencil_11_591_592.in1"],
-          ["self.in1_lxx_stencil.2","add_lxx_stencil_12_590_591.in0"],
-          ["add_lxx_stencil_13_589_590.out","add_lxx_stencil_12_590_591.in1"],
-          ["self.in1_lxx_stencil.3","add_lxx_stencil_13_589_590.in0"],
-          ["add_lxx_stencil_14_588_589.out","add_lxx_stencil_13_589_590.in1"],
-          ["self.in1_lxx_stencil.4","add_lxx_stencil_14_588_589.in0"],
-          ["add_lxx_stencil_15_587_588.out","add_lxx_stencil_14_588_589.in1"],
-          ["self.in1_lxx_stencil.5","add_lxx_stencil_15_587_588.in0"],
-          ["add_lxx_stencil_16_586_587.out","add_lxx_stencil_15_587_588.in1"],
-          ["self.in1_lxx_stencil.6","add_lxx_stencil_16_586_587.in0"],
-          ["add_lxx_stencil_17_lxx_stencil_18_586.out","add_lxx_stencil_16_586_587.in1"],
-          ["self.in1_lxx_stencil.7","add_lxx_stencil_17_lxx_stencil_18_586.in0"],
-          ["self.in1_lxx_stencil.8","add_lxx_stencil_17_lxx_stencil_18_586.in1"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_2_469_470.in0"],
+          ["add_lxx_stencil_11_468_469.out","add_lgxx_stencil_2_469_470.in1"],
+          ["add_lxx_stencil_10_470_471.in1","add_lgxx_stencil_2_469_470.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_10_470_471.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_10_470_471.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_11_468_469.in0"],
+          ["add_lxx_stencil_12_467_468.out","add_lxx_stencil_11_468_469.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_12_467_468.in0"],
+          ["add_lxx_stencil_13_466_467.out","add_lxx_stencil_12_467_468.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_13_466_467.in0"],
+          ["add_lxx_stencil_14_465_466.out","add_lxx_stencil_13_466_467.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_14_465_466.in0"],
+          ["add_lxx_stencil_15_464_465.out","add_lxx_stencil_14_465_466.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_15_464_465.in0"],
+          ["add_lxx_stencil_16_463_464.out","add_lxx_stencil_15_464_465.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_16_463_464.in0"],
+          ["add_lxx_stencil_17_lxx_stencil_18_463.out","add_lxx_stencil_16_463_464.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_17_lxx_stencil_18_463.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_17_lxx_stencil_18_463.in1"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -1621,14 +967,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__894":{
+          "const_p0__648":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__894.out"]
+          ["self.out_lgxy_stencil","const_p0__648.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
@@ -1636,14 +982,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__899":{
+          "const_p0__653":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__899.out"]
+          ["self.out_lgxy_stencil","const_p0__653.out"]
         ]
       },
       "hcompute_lgxy_stencil_2":{
@@ -1653,63 +999,63 @@
           ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_917_918":{
+          "add_lgxy_stencil_1_671_672":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_1_918_919":{
+          "add_lxy_stencil_1_672_673":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_2_916_917":{
+          "add_lxy_stencil_2_670_671":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_3_915_916":{
+          "add_lxy_stencil_3_669_670":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_4_914_915":{
+          "add_lxy_stencil_4_668_669":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_5_913_914":{
+          "add_lxy_stencil_5_667_668":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_6_912_913":{
+          "add_lxy_stencil_6_666_667":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_7_911_912":{
+          "add_lxy_stencil_7_665_666":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_8_lxy_stencil_9_911":{
+          "add_lxy_stencil_8_lxy_stencil_9_665":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_917_918.in0"],
-          ["add_lxy_stencil_2_916_917.out","add_lgxy_stencil_1_917_918.in1"],
-          ["add_lxy_stencil_1_918_919.in1","add_lgxy_stencil_1_917_918.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_918_919.in0"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_1_918_919.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_916_917.in0"],
-          ["add_lxy_stencil_3_915_916.out","add_lxy_stencil_2_916_917.in1"],
-          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_915_916.in0"],
-          ["add_lxy_stencil_4_914_915.out","add_lxy_stencil_3_915_916.in1"],
-          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_914_915.in0"],
-          ["add_lxy_stencil_5_913_914.out","add_lxy_stencil_4_914_915.in1"],
-          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_913_914.in0"],
-          ["add_lxy_stencil_6_912_913.out","add_lxy_stencil_5_913_914.in1"],
-          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_912_913.in0"],
-          ["add_lxy_stencil_7_911_912.out","add_lxy_stencil_6_912_913.in1"],
-          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_911_912.in0"],
-          ["add_lxy_stencil_8_lxy_stencil_9_911.out","add_lxy_stencil_7_911_912.in1"],
-          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_911.in0"],
-          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_911.in1"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_671_672.in0"],
+          ["add_lxy_stencil_2_670_671.out","add_lgxy_stencil_1_671_672.in1"],
+          ["add_lxy_stencil_1_672_673.in1","add_lgxy_stencil_1_671_672.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_672_673.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_1_672_673.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_670_671.in0"],
+          ["add_lxy_stencil_3_669_670.out","add_lxy_stencil_2_670_671.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_669_670.in0"],
+          ["add_lxy_stencil_4_668_669.out","add_lxy_stencil_3_669_670.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_668_669.in0"],
+          ["add_lxy_stencil_5_667_668.out","add_lxy_stencil_4_668_669.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_667_668.in0"],
+          ["add_lxy_stencil_6_666_667.out","add_lxy_stencil_5_667_668.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_666_667.in0"],
+          ["add_lxy_stencil_7_665_666.out","add_lxy_stencil_6_666_667.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_665_666.in0"],
+          ["add_lxy_stencil_8_lxy_stencil_9_665.out","add_lxy_stencil_7_665_666.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_665.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_665.in1"]
         ]
       },
       "hcompute_lgxy_stencil_3":{
@@ -1719,63 +1065,63 @@
           ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_2_959_960":{
+          "add_lgxy_stencil_2_713_714":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_10_960_961":{
+          "add_lxy_stencil_10_714_715":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_11_958_959":{
+          "add_lxy_stencil_11_712_713":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_12_957_958":{
+          "add_lxy_stencil_12_711_712":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_13_956_957":{
+          "add_lxy_stencil_13_710_711":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_14_955_956":{
+          "add_lxy_stencil_14_709_710":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_15_954_955":{
+          "add_lxy_stencil_15_708_709":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_16_953_954":{
+          "add_lxy_stencil_16_707_708":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_17_lxy_stencil_18_953":{
+          "add_lxy_stencil_17_lxy_stencil_18_707":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_2_959_960.in0"],
-          ["add_lxy_stencil_11_958_959.out","add_lgxy_stencil_2_959_960.in1"],
-          ["add_lxy_stencil_10_960_961.in1","add_lgxy_stencil_2_959_960.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_10_960_961.in0"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_10_960_961.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_11_958_959.in0"],
-          ["add_lxy_stencil_12_957_958.out","add_lxy_stencil_11_958_959.in1"],
-          ["self.in1_lxy_stencil.2","add_lxy_stencil_12_957_958.in0"],
-          ["add_lxy_stencil_13_956_957.out","add_lxy_stencil_12_957_958.in1"],
-          ["self.in1_lxy_stencil.3","add_lxy_stencil_13_956_957.in0"],
-          ["add_lxy_stencil_14_955_956.out","add_lxy_stencil_13_956_957.in1"],
-          ["self.in1_lxy_stencil.4","add_lxy_stencil_14_955_956.in0"],
-          ["add_lxy_stencil_15_954_955.out","add_lxy_stencil_14_955_956.in1"],
-          ["self.in1_lxy_stencil.5","add_lxy_stencil_15_954_955.in0"],
-          ["add_lxy_stencil_16_953_954.out","add_lxy_stencil_15_954_955.in1"],
-          ["self.in1_lxy_stencil.6","add_lxy_stencil_16_953_954.in0"],
-          ["add_lxy_stencil_17_lxy_stencil_18_953.out","add_lxy_stencil_16_953_954.in1"],
-          ["self.in1_lxy_stencil.7","add_lxy_stencil_17_lxy_stencil_18_953.in0"],
-          ["self.in1_lxy_stencil.8","add_lxy_stencil_17_lxy_stencil_18_953.in1"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_2_713_714.in0"],
+          ["add_lxy_stencil_11_712_713.out","add_lgxy_stencil_2_713_714.in1"],
+          ["add_lxy_stencil_10_714_715.in1","add_lgxy_stencil_2_713_714.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_10_714_715.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_10_714_715.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_11_712_713.in0"],
+          ["add_lxy_stencil_12_711_712.out","add_lxy_stencil_11_712_713.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_12_711_712.in0"],
+          ["add_lxy_stencil_13_710_711.out","add_lxy_stencil_12_711_712.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_13_710_711.in0"],
+          ["add_lxy_stencil_14_709_710.out","add_lxy_stencil_13_710_711.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_14_709_710.in0"],
+          ["add_lxy_stencil_15_708_709.out","add_lxy_stencil_14_709_710.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_15_708_709.in0"],
+          ["add_lxy_stencil_16_707_708.out","add_lxy_stencil_15_708_709.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_16_707_708.in0"],
+          ["add_lxy_stencil_17_lxy_stencil_18_707.out","add_lxy_stencil_16_707_708.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_17_lxy_stencil_18_707.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_17_lxy_stencil_18_707.in1"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -1783,14 +1129,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__1035":{
+          "const_p0__789":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__1035.out"]
+          ["self.out_lgyy_stencil","const_p0__789.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
@@ -1798,14 +1144,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__1040":{
+          "const_p0__794":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__1040.out"]
+          ["self.out_lgyy_stencil","const_p0__794.out"]
         ]
       },
       "hcompute_lgyy_stencil_2":{
@@ -1815,63 +1161,63 @@
           ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_1058_1059":{
+          "add_lgyy_stencil_1_812_813":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_1_1059_1060":{
+          "add_lyy_stencil_1_813_814":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_2_1057_1058":{
+          "add_lyy_stencil_2_811_812":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_3_1056_1057":{
+          "add_lyy_stencil_3_810_811":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_4_1055_1056":{
+          "add_lyy_stencil_4_809_810":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_5_1054_1055":{
+          "add_lyy_stencil_5_808_809":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_6_1053_1054":{
+          "add_lyy_stencil_6_807_808":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_7_1052_1053":{
+          "add_lyy_stencil_7_806_807":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_8_lyy_stencil_9_1052":{
+          "add_lyy_stencil_8_lyy_stencil_9_806":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_1058_1059.in0"],
-          ["add_lyy_stencil_2_1057_1058.out","add_lgyy_stencil_1_1058_1059.in1"],
-          ["add_lyy_stencil_1_1059_1060.in1","add_lgyy_stencil_1_1058_1059.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_1059_1060.in0"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_1_1059_1060.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_1057_1058.in0"],
-          ["add_lyy_stencil_3_1056_1057.out","add_lyy_stencil_2_1057_1058.in1"],
-          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_1056_1057.in0"],
-          ["add_lyy_stencil_4_1055_1056.out","add_lyy_stencil_3_1056_1057.in1"],
-          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_1055_1056.in0"],
-          ["add_lyy_stencil_5_1054_1055.out","add_lyy_stencil_4_1055_1056.in1"],
-          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_1054_1055.in0"],
-          ["add_lyy_stencil_6_1053_1054.out","add_lyy_stencil_5_1054_1055.in1"],
-          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_1053_1054.in0"],
-          ["add_lyy_stencil_7_1052_1053.out","add_lyy_stencil_6_1053_1054.in1"],
-          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_1052_1053.in0"],
-          ["add_lyy_stencil_8_lyy_stencil_9_1052.out","add_lyy_stencil_7_1052_1053.in1"],
-          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_1052.in0"],
-          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_1052.in1"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_812_813.in0"],
+          ["add_lyy_stencil_2_811_812.out","add_lgyy_stencil_1_812_813.in1"],
+          ["add_lyy_stencil_1_813_814.in1","add_lgyy_stencil_1_812_813.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_813_814.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_1_813_814.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_811_812.in0"],
+          ["add_lyy_stencil_3_810_811.out","add_lyy_stencil_2_811_812.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_810_811.in0"],
+          ["add_lyy_stencil_4_809_810.out","add_lyy_stencil_3_810_811.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_809_810.in0"],
+          ["add_lyy_stencil_5_808_809.out","add_lyy_stencil_4_809_810.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_808_809.in0"],
+          ["add_lyy_stencil_6_807_808.out","add_lyy_stencil_5_808_809.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_807_808.in0"],
+          ["add_lyy_stencil_7_806_807.out","add_lyy_stencil_6_807_808.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_806_807.in0"],
+          ["add_lyy_stencil_8_lyy_stencil_9_806.out","add_lyy_stencil_7_806_807.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_806.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_806.in1"]
         ]
       },
       "hcompute_lgyy_stencil_3":{
@@ -1881,63 +1227,63 @@
           ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_2_1100_1101":{
+          "add_lgyy_stencil_2_854_855":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_10_1101_1102":{
+          "add_lyy_stencil_10_855_856":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_11_1099_1100":{
+          "add_lyy_stencil_11_853_854":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_12_1098_1099":{
+          "add_lyy_stencil_12_852_853":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_13_1097_1098":{
+          "add_lyy_stencil_13_851_852":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_14_1096_1097":{
+          "add_lyy_stencil_14_850_851":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_15_1095_1096":{
+          "add_lyy_stencil_15_849_850":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_16_1094_1095":{
+          "add_lyy_stencil_16_848_849":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_17_lyy_stencil_18_1094":{
+          "add_lyy_stencil_17_lyy_stencil_18_848":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_2_1100_1101.in0"],
-          ["add_lyy_stencil_11_1099_1100.out","add_lgyy_stencil_2_1100_1101.in1"],
-          ["add_lyy_stencil_10_1101_1102.in1","add_lgyy_stencil_2_1100_1101.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_10_1101_1102.in0"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_10_1101_1102.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_11_1099_1100.in0"],
-          ["add_lyy_stencil_12_1098_1099.out","add_lyy_stencil_11_1099_1100.in1"],
-          ["self.in1_lyy_stencil.2","add_lyy_stencil_12_1098_1099.in0"],
-          ["add_lyy_stencil_13_1097_1098.out","add_lyy_stencil_12_1098_1099.in1"],
-          ["self.in1_lyy_stencil.3","add_lyy_stencil_13_1097_1098.in0"],
-          ["add_lyy_stencil_14_1096_1097.out","add_lyy_stencil_13_1097_1098.in1"],
-          ["self.in1_lyy_stencil.4","add_lyy_stencil_14_1096_1097.in0"],
-          ["add_lyy_stencil_15_1095_1096.out","add_lyy_stencil_14_1096_1097.in1"],
-          ["self.in1_lyy_stencil.5","add_lyy_stencil_15_1095_1096.in0"],
-          ["add_lyy_stencil_16_1094_1095.out","add_lyy_stencil_15_1095_1096.in1"],
-          ["self.in1_lyy_stencil.6","add_lyy_stencil_16_1094_1095.in0"],
-          ["add_lyy_stencil_17_lyy_stencil_18_1094.out","add_lyy_stencil_16_1094_1095.in1"],
-          ["self.in1_lyy_stencil.7","add_lyy_stencil_17_lyy_stencil_18_1094.in0"],
-          ["self.in1_lyy_stencil.8","add_lyy_stencil_17_lyy_stencil_18_1094.in1"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_2_854_855.in0"],
+          ["add_lyy_stencil_11_853_854.out","add_lgyy_stencil_2_854_855.in1"],
+          ["add_lyy_stencil_10_855_856.in1","add_lgyy_stencil_2_854_855.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_10_855_856.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_10_855_856.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_11_853_854.in0"],
+          ["add_lyy_stencil_12_852_853.out","add_lyy_stencil_11_853_854.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_12_852_853.in0"],
+          ["add_lyy_stencil_13_851_852.out","add_lyy_stencil_12_852_853.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_13_851_852.in0"],
+          ["add_lyy_stencil_14_850_851.out","add_lyy_stencil_13_851_852.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_14_850_851.in0"],
+          ["add_lyy_stencil_15_849_850.out","add_lyy_stencil_14_850_851.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_15_849_850.in0"],
+          ["add_lyy_stencil_16_848_849.out","add_lyy_stencil_15_849_850.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_16_848_849.in0"],
+          ["add_lyy_stencil_17_lyy_stencil_18_848.out","add_lyy_stencil_16_848_849.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_17_lyy_stencil_18_848.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_17_lyy_stencil_18_848.in1"]
         ]
       },
       "hcompute_lxx_stencil":{
@@ -1946,48 +1292,48 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_489_490_491":{
+          "ashr_366_367_368":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n180__487":{
+          "const_n180__364":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__485":{
+          "const_p180__362":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p6__490":{
+          "const_p6__367":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_488_488_489":{
+          "mul_365_365_366":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_486_487_488":{
+          "smax_363_364_365":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_3_485_486":{
+          "smin_grad_x_unclamp_stencil_3_362_363":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_488_488_489.out","ashr_489_490_491.in0"],
-          ["const_p6__490.out","ashr_489_490_491.in1"],
-          ["self.out_lxx_stencil","ashr_489_490_491.out"],
-          ["smax_486_487_488.in1","const_n180__487.out"],
-          ["smin_grad_x_unclamp_stencil_3_485_486.in1","const_p180__485.out"],
-          ["smax_486_487_488.out","mul_488_488_489.in0"],
-          ["smax_486_487_488.out","mul_488_488_489.in1"],
-          ["smin_grad_x_unclamp_stencil_3_485_486.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_3_485_486.out","smax_486_487_488.in0"]
+          ["mul_365_365_366.out","ashr_366_367_368.in0"],
+          ["const_p6__367.out","ashr_366_367_368.in1"],
+          ["self.out_lxx_stencil","ashr_366_367_368.out"],
+          ["smax_363_364_365.in1","const_n180__364.out"],
+          ["smin_grad_x_unclamp_stencil_3_362_363.in1","const_p180__362.out"],
+          ["smax_363_364_365.out","mul_365_365_366.in0"],
+          ["smax_363_364_365.out","mul_365_365_366.in1"],
+          ["smin_grad_x_unclamp_stencil_3_362_363.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_3_362_363.out","smax_363_364_365.in0"]
         ]
       },
       "hcompute_lxx_stencil_1":{
@@ -1996,48 +1342,48 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_513_514_515":{
+          "ashr_390_391_392":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n180__511":{
+          "const_n180__388":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__509":{
+          "const_p180__386":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p6__514":{
+          "const_p6__391":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_512_512_513":{
+          "mul_389_389_390":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_510_511_512":{
+          "smax_387_388_389":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_4_509_510":{
+          "smin_grad_x_unclamp_stencil_4_386_387":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_512_512_513.out","ashr_513_514_515.in0"],
-          ["const_p6__514.out","ashr_513_514_515.in1"],
-          ["self.out_lxx_stencil","ashr_513_514_515.out"],
-          ["smax_510_511_512.in1","const_n180__511.out"],
-          ["smin_grad_x_unclamp_stencil_4_509_510.in1","const_p180__509.out"],
-          ["smax_510_511_512.out","mul_512_512_513.in0"],
-          ["smax_510_511_512.out","mul_512_512_513.in1"],
-          ["smin_grad_x_unclamp_stencil_4_509_510.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_4_509_510.out","smax_510_511_512.in0"]
+          ["mul_389_389_390.out","ashr_390_391_392.in0"],
+          ["const_p6__391.out","ashr_390_391_392.in1"],
+          ["self.out_lxx_stencil","ashr_390_391_392.out"],
+          ["smax_387_388_389.in1","const_n180__388.out"],
+          ["smin_grad_x_unclamp_stencil_4_386_387.in1","const_p180__386.out"],
+          ["smax_387_388_389.out","mul_389_389_390.in0"],
+          ["smax_387_388_389.out","mul_389_389_390.in1"],
+          ["smin_grad_x_unclamp_stencil_4_386_387.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_4_386_387.out","smax_387_388_389.in0"]
         ]
       },
       "hcompute_lxy_stencil":{
@@ -2047,70 +1393,70 @@
           ["in1_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_846_847_848":{
+          "ashr_600_601_602":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n180__842$1":{
+          "const_n180__596":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_n180__842$2":{
+          "const_n180__596$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__840":{
+          "const_p180__594":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p180__840$1":{
+          "const_p180__594$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p6__847":{
+          "const_p6__601":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_843_845_846":{
+          "mul_597_599_600":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_841_842_843":{
+          "smax_595_596_597":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smax_844_842_845":{
+          "smax_598_596_599":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_5_840_841":{
+          "smin_grad_x_unclamp_stencil_5_594_595":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_3_840_844":{
+          "smin_grad_y_unclamp_stencil_3_594_598":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_843_845_846.out","ashr_846_847_848.in0"],
-          ["const_p6__847.out","ashr_846_847_848.in1"],
-          ["self.out_lxy_stencil","ashr_846_847_848.out"],
-          ["smax_841_842_843.in1","const_n180__842$1.out"],
-          ["smax_844_842_845.in1","const_n180__842$2.out"],
-          ["smin_grad_y_unclamp_stencil_3_840_844.in1","const_p180__840$1.out"],
-          ["smin_grad_x_unclamp_stencil_5_840_841.in1","const_p180__840.out"],
-          ["smax_841_842_843.out","mul_843_845_846.in0"],
-          ["smax_844_842_845.out","mul_843_845_846.in1"],
-          ["smin_grad_x_unclamp_stencil_5_840_841.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_3_840_844.in0","self.in1_grad_y_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_5_840_841.out","smax_841_842_843.in0"],
-          ["smin_grad_y_unclamp_stencil_3_840_844.out","smax_844_842_845.in0"]
+          ["mul_597_599_600.out","ashr_600_601_602.in0"],
+          ["const_p6__601.out","ashr_600_601_602.in1"],
+          ["self.out_lxy_stencil","ashr_600_601_602.out"],
+          ["smax_598_596_599.in1","const_n180__596$1.out"],
+          ["smax_595_596_597.in1","const_n180__596.out"],
+          ["smin_grad_y_unclamp_stencil_3_594_598.in1","const_p180__594$1.out"],
+          ["smin_grad_x_unclamp_stencil_5_594_595.in1","const_p180__594.out"],
+          ["smax_595_596_597.out","mul_597_599_600.in0"],
+          ["smax_598_596_599.out","mul_597_599_600.in1"],
+          ["smin_grad_x_unclamp_stencil_5_594_595.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_3_594_598.in0","self.in1_grad_y_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_5_594_595.out","smax_595_596_597.in0"],
+          ["smin_grad_y_unclamp_stencil_3_594_598.out","smax_598_596_599.in0"]
         ]
       },
       "hcompute_lxy_stencil_1":{
@@ -2120,70 +1466,70 @@
           ["in1_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_877_878_879":{
+          "ashr_631_632_633":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n180__873":{
+          "const_n180__627":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_n180__873$1":{
+          "const_n180__627$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__871":{
+          "const_p180__625":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p180__871$1":{
+          "const_p180__625$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p6__878":{
+          "const_p6__632":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_874_876_877":{
+          "mul_628_630_631":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_872_873_874":{
+          "smax_626_627_628":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smax_875_873_876":{
+          "smax_629_627_630":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_6_871_872":{
+          "smin_grad_x_unclamp_stencil_6_625_626":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_4_871_875":{
+          "smin_grad_y_unclamp_stencil_4_625_629":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_874_876_877.out","ashr_877_878_879.in0"],
-          ["const_p6__878.out","ashr_877_878_879.in1"],
-          ["self.out_lxy_stencil","ashr_877_878_879.out"],
-          ["smax_875_873_876.in1","const_n180__873$1.out"],
-          ["smax_872_873_874.in1","const_n180__873.out"],
-          ["smin_grad_y_unclamp_stencil_4_871_875.in1","const_p180__871$1.out"],
-          ["smin_grad_x_unclamp_stencil_6_871_872.in1","const_p180__871.out"],
-          ["smax_872_873_874.out","mul_874_876_877.in0"],
-          ["smax_875_873_876.out","mul_874_876_877.in1"],
-          ["smin_grad_x_unclamp_stencil_6_871_872.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_4_871_875.in0","self.in1_grad_y_unclamp_stencil.0"],
-          ["smin_grad_x_unclamp_stencil_6_871_872.out","smax_872_873_874.in0"],
-          ["smin_grad_y_unclamp_stencil_4_871_875.out","smax_875_873_876.in0"]
+          ["mul_628_630_631.out","ashr_631_632_633.in0"],
+          ["const_p6__632.out","ashr_631_632_633.in1"],
+          ["self.out_lxy_stencil","ashr_631_632_633.out"],
+          ["smax_629_627_630.in1","const_n180__627$1.out"],
+          ["smax_626_627_628.in1","const_n180__627.out"],
+          ["smin_grad_y_unclamp_stencil_4_625_629.in1","const_p180__625$1.out"],
+          ["smin_grad_x_unclamp_stencil_6_625_626.in1","const_p180__625.out"],
+          ["smax_626_627_628.out","mul_628_630_631.in0"],
+          ["smax_629_627_630.out","mul_628_630_631.in1"],
+          ["smin_grad_x_unclamp_stencil_6_625_626.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_4_625_629.in0","self.in1_grad_y_unclamp_stencil.0"],
+          ["smin_grad_x_unclamp_stencil_6_625_626.out","smax_626_627_628.in0"],
+          ["smin_grad_y_unclamp_stencil_4_625_629.out","smax_629_627_630.in0"]
         ]
       },
       "hcompute_lyy_stencil":{
@@ -2192,48 +1538,48 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_997_998_999":{
+          "ashr_751_752_753":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n180__995":{
+          "const_n180__749":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__993":{
+          "const_p180__747":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p6__998":{
+          "const_p6__752":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_996_996_997":{
+          "mul_750_750_751":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_994_995_996":{
+          "smax_748_749_750":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_5_993_994":{
+          "smin_grad_y_unclamp_stencil_5_747_748":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_996_996_997.out","ashr_997_998_999.in0"],
-          ["const_p6__998.out","ashr_997_998_999.in1"],
-          ["self.out_lyy_stencil","ashr_997_998_999.out"],
-          ["smax_994_995_996.in1","const_n180__995.out"],
-          ["smin_grad_y_unclamp_stencil_5_993_994.in1","const_p180__993.out"],
-          ["smax_994_995_996.out","mul_996_996_997.in0"],
-          ["smax_994_995_996.out","mul_996_996_997.in1"],
-          ["smin_grad_y_unclamp_stencil_5_993_994.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_5_993_994.out","smax_994_995_996.in0"]
+          ["mul_750_750_751.out","ashr_751_752_753.in0"],
+          ["const_p6__752.out","ashr_751_752_753.in1"],
+          ["self.out_lyy_stencil","ashr_751_752_753.out"],
+          ["smax_748_749_750.in1","const_n180__749.out"],
+          ["smin_grad_y_unclamp_stencil_5_747_748.in1","const_p180__747.out"],
+          ["smax_748_749_750.out","mul_750_750_751.in0"],
+          ["smax_748_749_750.out","mul_750_750_751.in1"],
+          ["smin_grad_y_unclamp_stencil_5_747_748.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_5_747_748.out","smax_748_749_750.in0"]
         ]
       },
       "hcompute_lyy_stencil_1":{
@@ -2242,48 +1588,48 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_1021_1022_1023":{
+          "ashr_775_776_777":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_n180__1019":{
+          "const_n180__773":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__1017":{
+          "const_p180__771":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "const_p6__1022":{
+          "const_p6__776":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_1020_1020_1021":{
+          "mul_774_774_775":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "smax_1018_1019_1020":{
+          "smax_772_773_774":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_6_1017_1018":{
+          "smin_grad_y_unclamp_stencil_6_771_772":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_1020_1020_1021.out","ashr_1021_1022_1023.in0"],
-          ["const_p6__1022.out","ashr_1021_1022_1023.in1"],
-          ["self.out_lyy_stencil","ashr_1021_1022_1023.out"],
-          ["smax_1018_1019_1020.in1","const_n180__1019.out"],
-          ["smin_grad_y_unclamp_stencil_6_1017_1018.in1","const_p180__1017.out"],
-          ["smax_1018_1019_1020.out","mul_1020_1020_1021.in0"],
-          ["smax_1018_1019_1020.out","mul_1020_1020_1021.in1"],
-          ["smin_grad_y_unclamp_stencil_6_1017_1018.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smin_grad_y_unclamp_stencil_6_1017_1018.out","smax_1018_1019_1020.in0"]
+          ["mul_774_774_775.out","ashr_775_776_777.in0"],
+          ["const_p6__776.out","ashr_775_776_777.in1"],
+          ["self.out_lyy_stencil","ashr_775_776_777.out"],
+          ["smax_772_773_774.in1","const_n180__773.out"],
+          ["smin_grad_y_unclamp_stencil_6_771_772.in1","const_p180__771.out"],
+          ["smax_772_773_774.out","mul_774_774_775.in0"],
+          ["smax_772_773_774.out","mul_774_774_775.in1"],
+          ["smin_grad_y_unclamp_stencil_6_771_772.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smin_grad_y_unclamp_stencil_6_771_772.out","smax_772_773_774.in0"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{

--- a/coreir_compute/harris_sch7_bigtile_compute.json
+++ b/coreir_compute/harris_sch7_bigtile_compute.json
@@ -8,28 +8,28 @@
           ["in0_cim_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "bitand_759_760_761":{
+          "bitand_591_592_593":{
             "modref":"corebit.and"
           },
-          "bitand_761_762_763":{
+          "bitand_593_594_595":{
             "modref":"corebit.and"
           },
-          "bitand_763_764_765":{
+          "bitand_595_596_597":{
             "modref":"corebit.and"
           },
-          "bitand_765_766_767":{
+          "bitand_597_598_599":{
             "modref":"corebit.and"
           },
-          "bitand_767_768_769":{
+          "bitand_599_600_601":{
             "modref":"corebit.and"
           },
-          "bitand_769_770_771":{
+          "bitand_601_602_603":{
             "modref":"corebit.and"
           },
-          "bitand_771_772_773":{
+          "bitand_603_604_605":{
             "modref":"corebit.and"
           },
-          "bitand_773_775_776":{
+          "bitand_605_607_608":{
             "modref":"corebit.and"
           },
           "const_p0_0":{
@@ -37,7 +37,7 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           },
-          "const_p1__774":{
+          "const_p1__606":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0001"]}
@@ -47,86 +47,86 @@
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00ff"]}
           },
-          "mux_7762550":{
+          "mux_6082550":{
             "genref":"coreir.mux",
             "genargs":{"width":["Int",16]}
           },
-          "sle_774_cim_stencil_2_775":{
+          "sle_606_cim_stencil_2_607":{
             "genref":"coreir.sle",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_1_cim_stencil_2_759":{
+          "slt_cim_stencil_1_cim_stencil_2_591":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_3_cim_stencil_2_760":{
+          "slt_cim_stencil_3_cim_stencil_2_592":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_4_cim_stencil_2_762":{
+          "slt_cim_stencil_4_cim_stencil_2_594":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_5_cim_stencil_2_764":{
+          "slt_cim_stencil_5_cim_stencil_2_596":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_6_cim_stencil_2_766":{
+          "slt_cim_stencil_6_cim_stencil_2_598":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_7_cim_stencil_2_768":{
+          "slt_cim_stencil_7_cim_stencil_2_600":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_8_cim_stencil_2_770":{
+          "slt_cim_stencil_8_cim_stencil_2_602":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           },
-          "slt_cim_stencil_9_cim_stencil_2_772":{
+          "slt_cim_stencil_9_cim_stencil_2_604":{
             "genref":"coreir.slt",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["slt_cim_stencil_1_cim_stencil_2_759.out","bitand_759_760_761.in0"],
-          ["slt_cim_stencil_3_cim_stencil_2_760.out","bitand_759_760_761.in1"],
-          ["bitand_761_762_763.in0","bitand_759_760_761.out"],
-          ["slt_cim_stencil_4_cim_stencil_2_762.out","bitand_761_762_763.in1"],
-          ["bitand_763_764_765.in0","bitand_761_762_763.out"],
-          ["slt_cim_stencil_5_cim_stencil_2_764.out","bitand_763_764_765.in1"],
-          ["bitand_765_766_767.in0","bitand_763_764_765.out"],
-          ["slt_cim_stencil_6_cim_stencil_2_766.out","bitand_765_766_767.in1"],
-          ["bitand_767_768_769.in0","bitand_765_766_767.out"],
-          ["slt_cim_stencil_7_cim_stencil_2_768.out","bitand_767_768_769.in1"],
-          ["bitand_769_770_771.in0","bitand_767_768_769.out"],
-          ["slt_cim_stencil_8_cim_stencil_2_770.out","bitand_769_770_771.in1"],
-          ["bitand_771_772_773.in0","bitand_769_770_771.out"],
-          ["slt_cim_stencil_9_cim_stencil_2_772.out","bitand_771_772_773.in1"],
-          ["bitand_773_775_776.in0","bitand_771_772_773.out"],
-          ["sle_774_cim_stencil_2_775.out","bitand_773_775_776.in1"],
-          ["mux_7762550.sel","bitand_773_775_776.out"],
-          ["mux_7762550.in0","const_p0_0.out"],
-          ["sle_774_cim_stencil_2_775.in0","const_p1__774.out"],
-          ["mux_7762550.in1","const_p255_255.out"],
-          ["self.out_cim_output_stencil","mux_7762550.out"],
-          ["slt_cim_stencil_1_cim_stencil_2_759.in0","self.in0_cim_stencil.0"],
-          ["sle_774_cim_stencil_2_775.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_1_cim_stencil_2_759.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_760.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_4_cim_stencil_2_762.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_5_cim_stencil_2_764.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_6_cim_stencil_2_766.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_7_cim_stencil_2_768.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_8_cim_stencil_2_770.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_9_cim_stencil_2_772.in1","self.in0_cim_stencil.1"],
-          ["slt_cim_stencil_3_cim_stencil_2_760.in0","self.in0_cim_stencil.2"],
-          ["slt_cim_stencil_4_cim_stencil_2_762.in0","self.in0_cim_stencil.3"],
-          ["slt_cim_stencil_5_cim_stencil_2_764.in0","self.in0_cim_stencil.4"],
-          ["slt_cim_stencil_6_cim_stencil_2_766.in0","self.in0_cim_stencil.5"],
-          ["slt_cim_stencil_7_cim_stencil_2_768.in0","self.in0_cim_stencil.6"],
-          ["slt_cim_stencil_8_cim_stencil_2_770.in0","self.in0_cim_stencil.7"],
-          ["slt_cim_stencil_9_cim_stencil_2_772.in0","self.in0_cim_stencil.8"]
+          ["slt_cim_stencil_1_cim_stencil_2_591.out","bitand_591_592_593.in0"],
+          ["slt_cim_stencil_3_cim_stencil_2_592.out","bitand_591_592_593.in1"],
+          ["bitand_593_594_595.in0","bitand_591_592_593.out"],
+          ["slt_cim_stencil_4_cim_stencil_2_594.out","bitand_593_594_595.in1"],
+          ["bitand_595_596_597.in0","bitand_593_594_595.out"],
+          ["slt_cim_stencil_5_cim_stencil_2_596.out","bitand_595_596_597.in1"],
+          ["bitand_597_598_599.in0","bitand_595_596_597.out"],
+          ["slt_cim_stencil_6_cim_stencil_2_598.out","bitand_597_598_599.in1"],
+          ["bitand_599_600_601.in0","bitand_597_598_599.out"],
+          ["slt_cim_stencil_7_cim_stencil_2_600.out","bitand_599_600_601.in1"],
+          ["bitand_601_602_603.in0","bitand_599_600_601.out"],
+          ["slt_cim_stencil_8_cim_stencil_2_602.out","bitand_601_602_603.in1"],
+          ["bitand_603_604_605.in0","bitand_601_602_603.out"],
+          ["slt_cim_stencil_9_cim_stencil_2_604.out","bitand_603_604_605.in1"],
+          ["bitand_605_607_608.in0","bitand_603_604_605.out"],
+          ["sle_606_cim_stencil_2_607.out","bitand_605_607_608.in1"],
+          ["mux_6082550.sel","bitand_605_607_608.out"],
+          ["mux_6082550.in0","const_p0_0.out"],
+          ["sle_606_cim_stencil_2_607.in0","const_p1__606.out"],
+          ["mux_6082550.in1","const_p255_255.out"],
+          ["self.out_cim_output_stencil","mux_6082550.out"],
+          ["slt_cim_stencil_1_cim_stencil_2_591.in0","self.in0_cim_stencil.0"],
+          ["sle_606_cim_stencil_2_607.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_1_cim_stencil_2_591.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_592.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_4_cim_stencil_2_594.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_5_cim_stencil_2_596.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_6_cim_stencil_2_598.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_7_cim_stencil_2_600.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_8_cim_stencil_2_602.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_9_cim_stencil_2_604.in1","self.in0_cim_stencil.1"],
+          ["slt_cim_stencil_3_cim_stencil_2_592.in0","self.in0_cim_stencil.2"],
+          ["slt_cim_stencil_4_cim_stencil_2_594.in0","self.in0_cim_stencil.3"],
+          ["slt_cim_stencil_5_cim_stencil_2_596.in0","self.in0_cim_stencil.4"],
+          ["slt_cim_stencil_6_cim_stencil_2_598.in0","self.in0_cim_stencil.5"],
+          ["slt_cim_stencil_7_cim_stencil_2_600.in0","self.in0_cim_stencil.6"],
+          ["slt_cim_stencil_8_cim_stencil_2_602.in0","self.in0_cim_stencil.7"],
+          ["slt_cim_stencil_9_cim_stencil_2_604.in0","self.in0_cim_stencil.8"]
         ]
       },
       "hcompute_cim_stencil":{
@@ -137,89 +137,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_713_714_719":{
+          "add_545_546_551":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_720_721_722":{
+          "ashr_552_553_554":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_2_712_713":{
+          "ashr_lgxx_stencil_2_544_545":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_2_712_716":{
+          "ashr_lgxy_stencil_2_544_548":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_2_712_714":{
+          "ashr_lgyy_stencil_2_544_546":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__721":{
+          "const_p4__553":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__712":{
+          "const_p6__544":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__712$1":{
+          "const_p6__544$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__712$2":{
+          "const_p6__544$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_713_714_715":{
+          "mul_545_546_547":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_716_716_717":{
+          "mul_548_548_549":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_719_719_720":{
+          "mul_551_551_552":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_715_717_718":{
+          "sub_547_549_550":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_718_722_723":{
+          "sub_550_554_555":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_2_712_713.out","add_713_714_719.in0"],
-          ["ashr_lgyy_stencil_2_712_714.out","add_713_714_719.in1"],
-          ["mul_719_719_720.in0","add_713_714_719.out"],
-          ["mul_719_719_720.in1","add_713_714_719.out"],
-          ["mul_719_719_720.out","ashr_720_721_722.in0"],
-          ["const_p4__721.out","ashr_720_721_722.in1"],
-          ["sub_718_722_723.in1","ashr_720_721_722.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_712_713.in0"],
-          ["const_p6__712.out","ashr_lgxx_stencil_2_712_713.in1"],
-          ["mul_713_714_715.in0","ashr_lgxx_stencil_2_712_713.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_712_716.in0"],
-          ["const_p6__712$2.out","ashr_lgxy_stencil_2_712_716.in1"],
-          ["mul_716_716_717.in0","ashr_lgxy_stencil_2_712_716.out"],
-          ["mul_716_716_717.in1","ashr_lgxy_stencil_2_712_716.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_712_714.in0"],
-          ["const_p6__712$1.out","ashr_lgyy_stencil_2_712_714.in1"],
-          ["mul_713_714_715.in1","ashr_lgyy_stencil_2_712_714.out"],
-          ["sub_715_717_718.in0","mul_713_714_715.out"],
-          ["sub_715_717_718.in1","mul_716_716_717.out"],
-          ["sub_718_722_723.out","self.out_cim_stencil"],
-          ["sub_718_722_723.in0","sub_715_717_718.out"]
+          ["ashr_lgxx_stencil_2_544_545.out","add_545_546_551.in0"],
+          ["ashr_lgyy_stencil_2_544_546.out","add_545_546_551.in1"],
+          ["mul_551_551_552.in0","add_545_546_551.out"],
+          ["mul_551_551_552.in1","add_545_546_551.out"],
+          ["mul_551_551_552.out","ashr_552_553_554.in0"],
+          ["const_p4__553.out","ashr_552_553_554.in1"],
+          ["sub_550_554_555.in1","ashr_552_553_554.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_544_545.in0"],
+          ["const_p6__544.out","ashr_lgxx_stencil_2_544_545.in1"],
+          ["mul_545_546_547.in0","ashr_lgxx_stencil_2_544_545.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_544_548.in0"],
+          ["const_p6__544$2.out","ashr_lgxy_stencil_2_544_548.in1"],
+          ["mul_548_548_549.in0","ashr_lgxy_stencil_2_544_548.out"],
+          ["mul_548_548_549.in1","ashr_lgxy_stencil_2_544_548.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_544_546.in0"],
+          ["const_p6__544$1.out","ashr_lgyy_stencil_2_544_546.in1"],
+          ["mul_545_546_547.in1","ashr_lgyy_stencil_2_544_546.out"],
+          ["sub_547_549_550.in0","mul_545_546_547.out"],
+          ["sub_547_549_550.in1","mul_548_548_549.out"],
+          ["sub_550_554_555.out","self.out_cim_stencil"],
+          ["sub_550_554_555.in0","sub_547_549_550.out"]
         ]
       },
       "hcompute_grad_x_stencil":{
@@ -228,31 +228,31 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n180__392":{
+          "const_n180__308":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__390":{
+          "const_p180__306":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "smax_391_392_393":{
+          "smax_307_308_309":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_2_390_391":{
+          "smin_grad_x_unclamp_stencil_2_306_307":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_391_392_393.in1","const_n180__392.out"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.in1","const_p180__390.out"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smax_391_392_393.out","self.out_grad_x_stencil"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.out","smax_391_392_393.in0"]
+          ["smax_307_308_309.in1","const_n180__308.out"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.in1","const_p180__306.out"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smax_307_308_309.out","self.out_grad_x_stencil"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.out","smax_307_308_309.in0"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil":{
@@ -260,135 +260,84 @@
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__307":{
+          "const_p0__262":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_x_unclamp_stencil","const_p0__307.out"]
+          ["self.out_grad_x_unclamp_stencil","const_p0__262.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil_1":{
         "type":["Record",[
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_x_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_327_343_344":{
+          "add_grad_x_unclamp_stencil_1_276_277":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_328_341_342":{
+          "add_padded16_global_wrapper_stencil_1_275_276":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_329_340_341":{
+          "add_padded16_global_wrapper_stencil_2_274_275":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_330_339_340":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__273":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_331_338_339":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__273$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_332_337_338":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_333_336_337":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_334_335_336":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_x_unclamp_stencil_1_342_343":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327":{
+          "mul_padded16_global_wrapper_stencil_3_273_274":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328":{
+          "mul_padded16_global_wrapper_stencil_5_273_279":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329":{
-            "genref":"coreir.mul",
+          "sub_277_padded16_global_wrapper_stencil_4_278":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330":{
-            "genref":"coreir.mul",
+          "sub_278_279_280":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335":{
-            "genref":"coreir.mul",
+          "sub_280_padded16_global_wrapper_stencil_6_281":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.out","add_327_343_344.in0"],
-          ["add_grad_x_unclamp_stencil_1_342_343.out","add_327_343_344.in1"],
-          ["self.out_grad_x_unclamp_stencil","add_327_343_344.out"],
-          ["mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.out","add_328_341_342.in0"],
-          ["add_329_340_341.out","add_328_341_342.in1"],
-          ["add_grad_x_unclamp_stencil_1_342_343.in1","add_328_341_342.out"],
-          ["mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.out","add_329_340_341.in0"],
-          ["add_330_339_340.out","add_329_340_341.in1"],
-          ["mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.out","add_330_339_340.in0"],
-          ["add_331_338_339.out","add_330_339_340.in1"],
-          ["mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.out","add_331_338_339.in0"],
-          ["add_332_337_338.out","add_331_338_339.in1"],
-          ["mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.out","add_332_337_338.in0"],
-          ["add_333_336_337.out","add_332_337_338.in1"],
-          ["mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.out","add_333_336_337.in0"],
-          ["add_334_335_336.out","add_333_336_337.in1"],
-          ["mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.out","add_334_335_336.in0"],
-          ["mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.out","add_334_335_336.in1"],
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_342_343.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.in0"],
-          ["self.in1_kernel_x_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.in0"],
-          ["self.in1_kernel_x_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.in0"],
-          ["self.in1_kernel_x_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.in0"],
-          ["self.in1_kernel_x_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.in0"],
-          ["self.in1_kernel_x_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.in0"],
-          ["self.in1_kernel_x_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.in0"],
-          ["self.in1_kernel_x_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.in0"],
-          ["self.in1_kernel_x_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.in0"],
-          ["self.in1_kernel_x_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.in1"]
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_276_277.in0"],
+          ["add_padded16_global_wrapper_stencil_1_275_276.out","add_grad_x_unclamp_stencil_1_276_277.in1"],
+          ["sub_277_padded16_global_wrapper_stencil_4_278.in0","add_grad_x_unclamp_stencil_1_276_277.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_1_275_276.in0"],
+          ["add_padded16_global_wrapper_stencil_2_274_275.out","add_padded16_global_wrapper_stencil_1_275_276.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_2_274_275.in0"],
+          ["mul_padded16_global_wrapper_stencil_3_273_274.out","add_padded16_global_wrapper_stencil_2_274_275.in1"],
+          ["mul_padded16_global_wrapper_stencil_5_273_279.in1","const_p2__273$1.out"],
+          ["mul_padded16_global_wrapper_stencil_3_273_274.in1","const_p2__273.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_273_274.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_273_279.in0"],
+          ["sub_278_279_280.in1","mul_padded16_global_wrapper_stencil_5_273_279.out"],
+          ["sub_277_padded16_global_wrapper_stencil_4_278.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.out","self.out_grad_x_unclamp_stencil"],
+          ["sub_278_279_280.in0","sub_277_padded16_global_wrapper_stencil_4_278.out"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.in0","sub_278_279_280.out"]
         ]
       },
       "hcompute_grad_y_stencil":{
@@ -397,31 +346,31 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n180__584":{
+          "const_n180__416":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__582":{
+          "const_p180__414":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "smax_583_584_585":{
+          "smax_415_416_417":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_2_582_583":{
+          "smin_grad_y_unclamp_stencil_2_414_415":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_583_584_585.in1","const_n180__584.out"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.in1","const_p180__582.out"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smax_583_584_585.out","self.out_grad_y_stencil"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.out","smax_583_584_585.in0"]
+          ["smax_415_416_417.in1","const_n180__416.out"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.in1","const_p180__414.out"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smax_415_416_417.out","self.out_grad_y_stencil"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.out","smax_415_416_417.in0"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil":{
@@ -429,135 +378,84 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__499":{
+          "const_p0__370":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__499.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__370.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_1":{
         "type":["Record",[
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_y_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_519_535_536":{
+          "add_grad_y_unclamp_stencil_1_384_385":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_520_533_534":{
+          "add_padded16_global_wrapper_stencil_7_383_384":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_521_532_533":{
+          "add_padded16_global_wrapper_stencil_8_382_383":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_522_531_532":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__381":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_523_530_531":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__381$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_524_529_530":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_525_528_529":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_526_527_528":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_y_unclamp_stencil_1_534_535":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519":{
+          "mul_padded16_global_wrapper_stencil_11_381_387":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520":{
+          "mul_padded16_global_wrapper_stencil_9_381_382":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521":{
-            "genref":"coreir.mul",
+          "sub_385_padded16_global_wrapper_stencil_10_386":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522":{
-            "genref":"coreir.mul",
+          "sub_386_387_388":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527":{
-            "genref":"coreir.mul",
+          "sub_388_padded16_global_wrapper_stencil_12_389":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.out","add_519_535_536.in0"],
-          ["add_grad_y_unclamp_stencil_1_534_535.out","add_519_535_536.in1"],
-          ["self.out_grad_y_unclamp_stencil","add_519_535_536.out"],
-          ["mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.out","add_520_533_534.in0"],
-          ["add_521_532_533.out","add_520_533_534.in1"],
-          ["add_grad_y_unclamp_stencil_1_534_535.in1","add_520_533_534.out"],
-          ["mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.out","add_521_532_533.in0"],
-          ["add_522_531_532.out","add_521_532_533.in1"],
-          ["mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.out","add_522_531_532.in0"],
-          ["add_523_530_531.out","add_522_531_532.in1"],
-          ["mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.out","add_523_530_531.in0"],
-          ["add_524_529_530.out","add_523_530_531.in1"],
-          ["mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.out","add_524_529_530.in0"],
-          ["add_525_528_529.out","add_524_529_530.in1"],
-          ["mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.out","add_525_528_529.in0"],
-          ["add_526_527_528.out","add_525_528_529.in1"],
-          ["mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.out","add_526_527_528.in0"],
-          ["mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.out","add_526_527_528.in1"],
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_534_535.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.in0"],
-          ["self.in1_kernel_y_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.in0"],
-          ["self.in1_kernel_y_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.in0"],
-          ["self.in1_kernel_y_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.in0"],
-          ["self.in1_kernel_y_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.in0"],
-          ["self.in1_kernel_y_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.in0"],
-          ["self.in1_kernel_y_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.in0"],
-          ["self.in1_kernel_y_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.in0"],
-          ["self.in1_kernel_y_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.in0"],
-          ["self.in1_kernel_y_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.in1"]
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_384_385.in0"],
+          ["add_padded16_global_wrapper_stencil_7_383_384.out","add_grad_y_unclamp_stencil_1_384_385.in1"],
+          ["sub_385_padded16_global_wrapper_stencil_10_386.in0","add_grad_y_unclamp_stencil_1_384_385.out"],
+          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_383_384.in0"],
+          ["add_padded16_global_wrapper_stencil_8_382_383.out","add_padded16_global_wrapper_stencil_7_383_384.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_382_383.in0"],
+          ["mul_padded16_global_wrapper_stencil_9_381_382.out","add_padded16_global_wrapper_stencil_8_382_383.in1"],
+          ["mul_padded16_global_wrapper_stencil_11_381_387.in1","const_p2__381$1.out"],
+          ["mul_padded16_global_wrapper_stencil_9_381_382.in1","const_p2__381.out"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_381_387.in0"],
+          ["sub_386_387_388.in1","mul_padded16_global_wrapper_stencil_11_381_387.out"],
+          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_381_382.in0"],
+          ["sub_385_padded16_global_wrapper_stencil_10_386.in1","self.in1_padded16_global_wrapper_stencil.0"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.in1","self.in1_padded16_global_wrapper_stencil.2"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_386_387_388.in0","sub_385_padded16_global_wrapper_stencil_10_386.out"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.in0","sub_386_387_388.out"]
         ]
       },
       "hcompute_hw_output_stencil":{
@@ -569,469 +467,19 @@
           ["self.out_hw_output_stencil","self.in0_cim_output_stencil.0"]
         ]
       },
-      "hcompute_kernel_x_stencil":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__261":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__261.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__264":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__264.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__291":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n2__291.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__294":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__294.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__297":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__297.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__300":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p2__300.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__303":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__303.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__267":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__267.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__270":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__270.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__273":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__273.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__276":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__276.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__279":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__279.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__282":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__282.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__285":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__285.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__288":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__288.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__454":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__454.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__457":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__457.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__484":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p2__484.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__487":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__487.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__490":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__490.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__493":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n2__493.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__496":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__496.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__460":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__460.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__463":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__463.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__466":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__466.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__469":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__469.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__472":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__472.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__475":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__475.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__478":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__478.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__481":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__481.out"]
-        ]
-      },
       "hcompute_lgxx_stencil":{
         "type":["Record",[
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__410":{
+          "const_p0__326":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__410.out"]
+          ["self.out_lgxx_stencil","const_p0__326.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
@@ -1041,63 +489,63 @@
           ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_427_428":{
+          "add_lgxx_stencil_1_343_344":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_1_428_429":{
+          "add_lxx_stencil_1_344_345":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_2_426_427":{
+          "add_lxx_stencil_2_342_343":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_3_425_426":{
+          "add_lxx_stencil_3_341_342":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_4_424_425":{
+          "add_lxx_stencil_4_340_341":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_5_423_424":{
+          "add_lxx_stencil_5_339_340":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_6_422_423":{
+          "add_lxx_stencil_6_338_339":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_7_421_422":{
+          "add_lxx_stencil_7_337_338":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_8_lxx_stencil_9_421":{
+          "add_lxx_stencil_8_lxx_stencil_9_337":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_427_428.in0"],
-          ["add_lxx_stencil_2_426_427.out","add_lgxx_stencil_1_427_428.in1"],
-          ["add_lxx_stencil_1_428_429.in1","add_lgxx_stencil_1_427_428.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_428_429.in0"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_1_428_429.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_426_427.in0"],
-          ["add_lxx_stencil_3_425_426.out","add_lxx_stencil_2_426_427.in1"],
-          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_425_426.in0"],
-          ["add_lxx_stencil_4_424_425.out","add_lxx_stencil_3_425_426.in1"],
-          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_424_425.in0"],
-          ["add_lxx_stencil_5_423_424.out","add_lxx_stencil_4_424_425.in1"],
-          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_423_424.in0"],
-          ["add_lxx_stencil_6_422_423.out","add_lxx_stencil_5_423_424.in1"],
-          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_422_423.in0"],
-          ["add_lxx_stencil_7_421_422.out","add_lxx_stencil_6_422_423.in1"],
-          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_421_422.in0"],
-          ["add_lxx_stencil_8_lxx_stencil_9_421.out","add_lxx_stencil_7_421_422.in1"],
-          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_421.in0"],
-          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_421.in1"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_343_344.in0"],
+          ["add_lxx_stencil_2_342_343.out","add_lgxx_stencil_1_343_344.in1"],
+          ["add_lxx_stencil_1_344_345.in1","add_lgxx_stencil_1_343_344.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_344_345.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_1_344_345.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_342_343.in0"],
+          ["add_lxx_stencil_3_341_342.out","add_lxx_stencil_2_342_343.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_341_342.in0"],
+          ["add_lxx_stencil_4_340_341.out","add_lxx_stencil_3_341_342.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_340_341.in0"],
+          ["add_lxx_stencil_5_339_340.out","add_lxx_stencil_4_340_341.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_339_340.in0"],
+          ["add_lxx_stencil_6_338_339.out","add_lxx_stencil_5_339_340.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_338_339.in0"],
+          ["add_lxx_stencil_7_337_338.out","add_lxx_stencil_6_338_339.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_337_338.in0"],
+          ["add_lxx_stencil_8_lxx_stencil_9_337.out","add_lxx_stencil_7_337_338.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_337.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_337.in1"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -1105,14 +553,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__603":{
+          "const_p0__435":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__603.out"]
+          ["self.out_lgxy_stencil","const_p0__435.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
@@ -1122,63 +570,63 @@
           ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_620_621":{
+          "add_lgxy_stencil_1_452_453":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_1_621_622":{
+          "add_lxy_stencil_1_453_454":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_2_619_620":{
+          "add_lxy_stencil_2_451_452":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_3_618_619":{
+          "add_lxy_stencil_3_450_451":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_4_617_618":{
+          "add_lxy_stencil_4_449_450":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_5_616_617":{
+          "add_lxy_stencil_5_448_449":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_6_615_616":{
+          "add_lxy_stencil_6_447_448":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_7_614_615":{
+          "add_lxy_stencil_7_446_447":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_8_lxy_stencil_9_614":{
+          "add_lxy_stencil_8_lxy_stencil_9_446":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_620_621.in0"],
-          ["add_lxy_stencil_2_619_620.out","add_lgxy_stencil_1_620_621.in1"],
-          ["add_lxy_stencil_1_621_622.in1","add_lgxy_stencil_1_620_621.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_621_622.in0"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_1_621_622.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_619_620.in0"],
-          ["add_lxy_stencil_3_618_619.out","add_lxy_stencil_2_619_620.in1"],
-          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_618_619.in0"],
-          ["add_lxy_stencil_4_617_618.out","add_lxy_stencil_3_618_619.in1"],
-          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_617_618.in0"],
-          ["add_lxy_stencil_5_616_617.out","add_lxy_stencil_4_617_618.in1"],
-          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_616_617.in0"],
-          ["add_lxy_stencil_6_615_616.out","add_lxy_stencil_5_616_617.in1"],
-          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_615_616.in0"],
-          ["add_lxy_stencil_7_614_615.out","add_lxy_stencil_6_615_616.in1"],
-          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_614_615.in0"],
-          ["add_lxy_stencil_8_lxy_stencil_9_614.out","add_lxy_stencil_7_614_615.in1"],
-          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_614.in0"],
-          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_614.in1"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_452_453.in0"],
+          ["add_lxy_stencil_2_451_452.out","add_lgxy_stencil_1_452_453.in1"],
+          ["add_lxy_stencil_1_453_454.in1","add_lgxy_stencil_1_452_453.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_453_454.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_1_453_454.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_451_452.in0"],
+          ["add_lxy_stencil_3_450_451.out","add_lxy_stencil_2_451_452.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_450_451.in0"],
+          ["add_lxy_stencil_4_449_450.out","add_lxy_stencil_3_450_451.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_449_450.in0"],
+          ["add_lxy_stencil_5_448_449.out","add_lxy_stencil_4_449_450.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_448_449.in0"],
+          ["add_lxy_stencil_6_447_448.out","add_lxy_stencil_5_448_449.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_447_448.in0"],
+          ["add_lxy_stencil_7_446_447.out","add_lxy_stencil_6_447_448.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_446_447.in0"],
+          ["add_lxy_stencil_8_lxy_stencil_9_446.out","add_lxy_stencil_7_446_447.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_446.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_446.in1"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -1186,14 +634,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__657":{
+          "const_p0__489":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__657.out"]
+          ["self.out_lgyy_stencil","const_p0__489.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
@@ -1203,63 +651,63 @@
           ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_674_675":{
+          "add_lgyy_stencil_1_506_507":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_1_675_676":{
+          "add_lyy_stencil_1_507_508":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_2_673_674":{
+          "add_lyy_stencil_2_505_506":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_3_672_673":{
+          "add_lyy_stencil_3_504_505":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_4_671_672":{
+          "add_lyy_stencil_4_503_504":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_5_670_671":{
+          "add_lyy_stencil_5_502_503":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_6_669_670":{
+          "add_lyy_stencil_6_501_502":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_7_668_669":{
+          "add_lyy_stencil_7_500_501":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_8_lyy_stencil_9_668":{
+          "add_lyy_stencil_8_lyy_stencil_9_500":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_674_675.in0"],
-          ["add_lyy_stencil_2_673_674.out","add_lgyy_stencil_1_674_675.in1"],
-          ["add_lyy_stencil_1_675_676.in1","add_lgyy_stencil_1_674_675.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_675_676.in0"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_1_675_676.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_673_674.in0"],
-          ["add_lyy_stencil_3_672_673.out","add_lyy_stencil_2_673_674.in1"],
-          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_672_673.in0"],
-          ["add_lyy_stencil_4_671_672.out","add_lyy_stencil_3_672_673.in1"],
-          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_671_672.in0"],
-          ["add_lyy_stencil_5_670_671.out","add_lyy_stencil_4_671_672.in1"],
-          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_670_671.in0"],
-          ["add_lyy_stencil_6_669_670.out","add_lyy_stencil_5_670_671.in1"],
-          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_669_670.in0"],
-          ["add_lyy_stencil_7_668_669.out","add_lyy_stencil_6_669_670.in1"],
-          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_668_669.in0"],
-          ["add_lyy_stencil_8_lyy_stencil_9_668.out","add_lyy_stencil_7_668_669.in1"],
-          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_668.in0"],
-          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_668.in1"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_506_507.in0"],
+          ["add_lyy_stencil_2_505_506.out","add_lgyy_stencil_1_506_507.in1"],
+          ["add_lyy_stencil_1_507_508.in1","add_lgyy_stencil_1_506_507.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_507_508.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_1_507_508.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_505_506.in0"],
+          ["add_lyy_stencil_3_504_505.out","add_lyy_stencil_2_505_506.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_504_505.in0"],
+          ["add_lyy_stencil_4_503_504.out","add_lyy_stencil_3_504_505.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_503_504.in0"],
+          ["add_lyy_stencil_5_502_503.out","add_lyy_stencil_4_503_504.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_502_503.in0"],
+          ["add_lyy_stencil_6_501_502.out","add_lyy_stencil_5_502_503.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_501_502.in0"],
+          ["add_lyy_stencil_7_500_501.out","add_lyy_stencil_6_501_502.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_500_501.in0"],
+          ["add_lyy_stencil_8_lyy_stencil_9_500.out","add_lyy_stencil_7_500_501.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_500.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_500.in1"]
         ]
       },
       "hcompute_lxx_stencil":{
@@ -1268,26 +716,26 @@
           ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_402_403_404":{
+          "ashr_318_319_320":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__403":{
+          "const_p6__319":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_x_stencil_1_grad_x_stencil_1_402":{
+          "mul_grad_x_stencil_1_grad_x_stencil_1_318":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_1_grad_x_stencil_1_402.out","ashr_402_403_404.in0"],
-          ["const_p6__403.out","ashr_402_403_404.in1"],
-          ["self.out_lxx_stencil","ashr_402_403_404.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_402.in0"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_402.in1"]
+          ["mul_grad_x_stencil_1_grad_x_stencil_1_318.out","ashr_318_319_320.in0"],
+          ["const_p6__319.out","ashr_318_319_320.in1"],
+          ["self.out_lxx_stencil","ashr_318_319_320.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_318.in0"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_318.in1"]
         ]
       },
       "hcompute_lxy_stencil":{
@@ -1297,26 +745,26 @@
           ["in1_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_594_595_596":{
+          "ashr_426_427_428":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__595":{
+          "const_p6__427":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_x_stencil_2_grad_y_stencil_1_594":{
+          "mul_grad_x_stencil_2_grad_y_stencil_1_426":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_2_grad_y_stencil_1_594.out","ashr_594_595_596.in0"],
-          ["const_p6__595.out","ashr_594_595_596.in1"],
-          ["self.out_lxy_stencil","ashr_594_595_596.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_594.in0"],
-          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_594.in1"]
+          ["mul_grad_x_stencil_2_grad_y_stencil_1_426.out","ashr_426_427_428.in0"],
+          ["const_p6__427.out","ashr_426_427_428.in1"],
+          ["self.out_lxy_stencil","ashr_426_427_428.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_426.in0"],
+          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_426.in1"]
         ]
       },
       "hcompute_lyy_stencil":{
@@ -1325,26 +773,26 @@
           ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_649_650_651":{
+          "ashr_481_482_483":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__650":{
+          "const_p6__482":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_y_stencil_2_grad_y_stencil_2_649":{
+          "mul_grad_y_stencil_2_grad_y_stencil_2_481":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_y_stencil_2_grad_y_stencil_2_649.out","ashr_649_650_651.in0"],
-          ["const_p6__650.out","ashr_649_650_651.in1"],
-          ["self.out_lyy_stencil","ashr_649_650_651.out"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_649.in0"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_649.in1"]
+          ["mul_grad_y_stencil_2_grad_y_stencil_2_481.out","ashr_481_482_483.in0"],
+          ["const_p6__482.out","ashr_481_482_483.in1"],
+          ["self.out_lyy_stencil","ashr_481_482_483.out"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_481.in0"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_481.in1"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{

--- a/coreir_compute/harris_sch8_endcim_compute.json
+++ b/coreir_compute/harris_sch8_endcim_compute.json
@@ -10,89 +10,89 @@
           ["in2_lgyy_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_713_714_719":{
+          "add_545_546_551":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_720_721_722":{
+          "ashr_552_553_554":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxx_stencil_2_712_713":{
+          "ashr_lgxx_stencil_2_544_545":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgxy_stencil_2_712_716":{
+          "ashr_lgxy_stencil_2_544_548":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "ashr_lgyy_stencil_2_712_714":{
+          "ashr_lgyy_stencil_2_544_546":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p4__721":{
+          "const_p4__553":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0004"]}
           },
-          "const_p6__712":{
+          "const_p6__544":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__712$1":{
+          "const_p6__544$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "const_p6__712$2":{
+          "const_p6__544$2":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_713_714_715":{
+          "mul_545_546_547":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_716_716_717":{
+          "mul_548_548_549":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_719_719_720":{
+          "mul_551_551_552":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "sub_715_717_718":{
+          "sub_547_549_550":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "sub_718_722_723":{
+          "sub_550_554_555":{
             "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["ashr_lgxx_stencil_2_712_713.out","add_713_714_719.in0"],
-          ["ashr_lgyy_stencil_2_712_714.out","add_713_714_719.in1"],
-          ["mul_719_719_720.in0","add_713_714_719.out"],
-          ["mul_719_719_720.in1","add_713_714_719.out"],
-          ["mul_719_719_720.out","ashr_720_721_722.in0"],
-          ["const_p4__721.out","ashr_720_721_722.in1"],
-          ["sub_718_722_723.in1","ashr_720_721_722.out"],
-          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_712_713.in0"],
-          ["const_p6__712.out","ashr_lgxx_stencil_2_712_713.in1"],
-          ["mul_713_714_715.in0","ashr_lgxx_stencil_2_712_713.out"],
-          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_712_716.in0"],
-          ["const_p6__712$2.out","ashr_lgxy_stencil_2_712_716.in1"],
-          ["mul_716_716_717.in0","ashr_lgxy_stencil_2_712_716.out"],
-          ["mul_716_716_717.in1","ashr_lgxy_stencil_2_712_716.out"],
-          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_712_714.in0"],
-          ["const_p6__712$1.out","ashr_lgyy_stencil_2_712_714.in1"],
-          ["mul_713_714_715.in1","ashr_lgyy_stencil_2_712_714.out"],
-          ["sub_715_717_718.in0","mul_713_714_715.out"],
-          ["sub_715_717_718.in1","mul_716_716_717.out"],
-          ["sub_718_722_723.out","self.out_cim_stencil"],
-          ["sub_718_722_723.in0","sub_715_717_718.out"]
+          ["ashr_lgxx_stencil_2_544_545.out","add_545_546_551.in0"],
+          ["ashr_lgyy_stencil_2_544_546.out","add_545_546_551.in1"],
+          ["mul_551_551_552.in0","add_545_546_551.out"],
+          ["mul_551_551_552.in1","add_545_546_551.out"],
+          ["mul_551_551_552.out","ashr_552_553_554.in0"],
+          ["const_p4__553.out","ashr_552_553_554.in1"],
+          ["sub_550_554_555.in1","ashr_552_553_554.out"],
+          ["self.in0_lgxx_stencil.0","ashr_lgxx_stencil_2_544_545.in0"],
+          ["const_p6__544.out","ashr_lgxx_stencil_2_544_545.in1"],
+          ["mul_545_546_547.in0","ashr_lgxx_stencil_2_544_545.out"],
+          ["self.in1_lgxy_stencil.0","ashr_lgxy_stencil_2_544_548.in0"],
+          ["const_p6__544$2.out","ashr_lgxy_stencil_2_544_548.in1"],
+          ["mul_548_548_549.in0","ashr_lgxy_stencil_2_544_548.out"],
+          ["mul_548_548_549.in1","ashr_lgxy_stencil_2_544_548.out"],
+          ["self.in2_lgyy_stencil.0","ashr_lgyy_stencil_2_544_546.in0"],
+          ["const_p6__544$1.out","ashr_lgyy_stencil_2_544_546.in1"],
+          ["mul_545_546_547.in1","ashr_lgyy_stencil_2_544_546.out"],
+          ["sub_547_549_550.in0","mul_545_546_547.out"],
+          ["sub_547_549_550.in1","mul_548_548_549.out"],
+          ["sub_550_554_555.out","self.out_cim_stencil"],
+          ["sub_550_554_555.in0","sub_547_549_550.out"]
         ]
       },
       "hcompute_grad_x_stencil":{
@@ -101,31 +101,31 @@
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n180__392":{
+          "const_n180__308":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__390":{
+          "const_p180__306":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "smax_391_392_393":{
+          "smax_307_308_309":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_x_unclamp_stencil_2_390_391":{
+          "smin_grad_x_unclamp_stencil_2_306_307":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_391_392_393.in1","const_n180__392.out"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.in1","const_p180__390.out"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.in0","self.in0_grad_x_unclamp_stencil.0"],
-          ["smax_391_392_393.out","self.out_grad_x_stencil"],
-          ["smin_grad_x_unclamp_stencil_2_390_391.out","smax_391_392_393.in0"]
+          ["smax_307_308_309.in1","const_n180__308.out"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.in1","const_p180__306.out"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.in0","self.in0_grad_x_unclamp_stencil.0"],
+          ["smax_307_308_309.out","self.out_grad_x_stencil"],
+          ["smin_grad_x_unclamp_stencil_2_306_307.out","smax_307_308_309.in0"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil":{
@@ -133,135 +133,84 @@
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__307":{
+          "const_p0__262":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_x_unclamp_stencil","const_p0__307.out"]
+          ["self.out_grad_x_unclamp_stencil","const_p0__262.out"]
         ]
       },
       "hcompute_grad_x_unclamp_stencil_1":{
         "type":["Record",[
           ["out_grad_x_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_x_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_x_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_327_343_344":{
+          "add_grad_x_unclamp_stencil_1_276_277":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_328_341_342":{
+          "add_padded16_global_wrapper_stencil_1_275_276":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_329_340_341":{
+          "add_padded16_global_wrapper_stencil_2_274_275":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_330_339_340":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__273":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_331_338_339":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
+          "const_p2__273$1":{
+            "genref":"coreir.const",
+            "genargs":{"width":["Int",16]},
+            "modargs":{"value":[["BitVector",16],"16'h0002"]}
           },
-          "add_332_337_338":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_333_336_337":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_334_335_336":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_x_unclamp_stencil_1_342_343":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327":{
+          "mul_padded16_global_wrapper_stencil_3_273_274":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328":{
+          "mul_padded16_global_wrapper_stencil_5_273_279":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329":{
-            "genref":"coreir.mul",
+          "sub_277_padded16_global_wrapper_stencil_4_278":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330":{
-            "genref":"coreir.mul",
+          "sub_278_279_280":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           },
-          "mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335":{
-            "genref":"coreir.mul",
+          "sub_280_padded16_global_wrapper_stencil_6_281":{
+            "genref":"coreir.sub",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.out","add_327_343_344.in0"],
-          ["add_grad_x_unclamp_stencil_1_342_343.out","add_327_343_344.in1"],
-          ["self.out_grad_x_unclamp_stencil","add_327_343_344.out"],
-          ["mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.out","add_328_341_342.in0"],
-          ["add_329_340_341.out","add_328_341_342.in1"],
-          ["add_grad_x_unclamp_stencil_1_342_343.in1","add_328_341_342.out"],
-          ["mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.out","add_329_340_341.in0"],
-          ["add_330_339_340.out","add_329_340_341.in1"],
-          ["mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.out","add_330_339_340.in0"],
-          ["add_331_338_339.out","add_330_339_340.in1"],
-          ["mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.out","add_331_338_339.in0"],
-          ["add_332_337_338.out","add_331_338_339.in1"],
-          ["mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.out","add_332_337_338.in0"],
-          ["add_333_336_337.out","add_332_337_338.in1"],
-          ["mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.out","add_333_336_337.in0"],
-          ["add_334_335_336.out","add_333_336_337.in1"],
-          ["mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.out","add_334_335_336.in0"],
-          ["mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.out","add_334_335_336.in1"],
-          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_342_343.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.in0"],
-          ["self.in1_kernel_x_stencil.0","mul_padded16_global_wrapper_stencil_1_kernel_x_stencil_1_327.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.in0"],
-          ["self.in1_kernel_x_stencil.1","mul_padded16_global_wrapper_stencil_2_kernel_x_stencil_2_328.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.in0"],
-          ["self.in1_kernel_x_stencil.2","mul_padded16_global_wrapper_stencil_3_kernel_x_stencil_3_329.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.in0"],
-          ["self.in1_kernel_x_stencil.3","mul_padded16_global_wrapper_stencil_4_kernel_x_stencil_4_330.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.in0"],
-          ["self.in1_kernel_x_stencil.4","mul_padded16_global_wrapper_stencil_5_kernel_x_stencil_5_331.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.in0"],
-          ["self.in1_kernel_x_stencil.5","mul_padded16_global_wrapper_stencil_6_kernel_x_stencil_6_332.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.in0"],
-          ["self.in1_kernel_x_stencil.6","mul_padded16_global_wrapper_stencil_7_kernel_x_stencil_7_333.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.in0"],
-          ["self.in1_kernel_x_stencil.7","mul_padded16_global_wrapper_stencil_8_kernel_x_stencil_8_334.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.in0"],
-          ["self.in1_kernel_x_stencil.8","mul_padded16_global_wrapper_stencil_9_kernel_x_stencil_9_335.in1"]
+          ["self.in0_grad_x_unclamp_stencil.0","add_grad_x_unclamp_stencil_1_276_277.in0"],
+          ["add_padded16_global_wrapper_stencil_1_275_276.out","add_grad_x_unclamp_stencil_1_276_277.in1"],
+          ["sub_277_padded16_global_wrapper_stencil_4_278.in0","add_grad_x_unclamp_stencil_1_276_277.out"],
+          ["self.in1_padded16_global_wrapper_stencil.0","add_padded16_global_wrapper_stencil_1_275_276.in0"],
+          ["add_padded16_global_wrapper_stencil_2_274_275.out","add_padded16_global_wrapper_stencil_1_275_276.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.1","add_padded16_global_wrapper_stencil_2_274_275.in0"],
+          ["mul_padded16_global_wrapper_stencil_3_273_274.out","add_padded16_global_wrapper_stencil_2_274_275.in1"],
+          ["mul_padded16_global_wrapper_stencil_5_273_279.in1","const_p2__273$1.out"],
+          ["mul_padded16_global_wrapper_stencil_3_273_274.in1","const_p2__273.out"],
+          ["self.in1_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_3_273_274.in0"],
+          ["self.in1_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_5_273_279.in0"],
+          ["sub_278_279_280.in1","mul_padded16_global_wrapper_stencil_5_273_279.out"],
+          ["sub_277_padded16_global_wrapper_stencil_4_278.in1","self.in1_padded16_global_wrapper_stencil.3"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.in1","self.in1_padded16_global_wrapper_stencil.5"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.out","self.out_grad_x_unclamp_stencil"],
+          ["sub_278_279_280.in0","sub_277_padded16_global_wrapper_stencil_4_278.out"],
+          ["sub_280_padded16_global_wrapper_stencil_6_281.in0","sub_278_279_280.out"]
         ]
       },
       "hcompute_grad_y_stencil":{
@@ -270,31 +219,31 @@
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "const_n180__584":{
+          "const_n180__416":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'hff4c"]}
           },
-          "const_p180__582":{
+          "const_p180__414":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h00b4"]}
           },
-          "smax_583_584_585":{
+          "smax_415_416_417":{
             "genref":"commonlib.smax",
             "genargs":{"width":["Int",16]}
           },
-          "smin_grad_y_unclamp_stencil_2_582_583":{
+          "smin_grad_y_unclamp_stencil_2_414_415":{
             "genref":"commonlib.smin",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["smax_583_584_585.in1","const_n180__584.out"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.in1","const_p180__582.out"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.in0","self.in0_grad_y_unclamp_stencil.0"],
-          ["smax_583_584_585.out","self.out_grad_y_stencil"],
-          ["smin_grad_y_unclamp_stencil_2_582_583.out","smax_583_584_585.in0"]
+          ["smax_415_416_417.in1","const_n180__416.out"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.in1","const_p180__414.out"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.in0","self.in0_grad_y_unclamp_stencil.0"],
+          ["smax_415_416_417.out","self.out_grad_y_stencil"],
+          ["smin_grad_y_unclamp_stencil_2_414_415.out","smax_415_416_417.in0"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil":{
@@ -302,585 +251,84 @@
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__499":{
+          "const_p0__370":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_grad_y_unclamp_stencil","const_p0__499.out"]
+          ["self.out_grad_y_unclamp_stencil","const_p0__370.out"]
         ]
       },
       "hcompute_grad_y_unclamp_stencil_1":{
         "type":["Record",[
           ["out_grad_y_unclamp_stencil",["Array",16,"Bit"]],
           ["in0_grad_y_unclamp_stencil",["Array",1,["Array",16,"BitIn"]]],
-          ["in1_kernel_y_stencil",["Array",9,["Array",16,"BitIn"]]],
-          ["in2_padded16_global_wrapper_stencil",["Array",9,["Array",16,"BitIn"]]]
+          ["in1_padded16_global_wrapper_stencil",["Array",6,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_519_535_536":{
+          "add_grad_y_unclamp_stencil_1_384_385":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_520_533_534":{
+          "add_padded16_global_wrapper_stencil_7_383_384":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_521_532_533":{
+          "add_padded16_global_wrapper_stencil_8_382_383":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_522_531_532":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_523_530_531":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_524_529_530":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_525_528_529":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_526_527_528":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "add_grad_y_unclamp_stencil_1_534_535":{
-            "genref":"coreir.add",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          },
-          "mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527":{
-            "genref":"coreir.mul",
-            "genargs":{"width":["Int",16]}
-          }
-        },
-        "connections":[
-          ["mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.out","add_519_535_536.in0"],
-          ["add_grad_y_unclamp_stencil_1_534_535.out","add_519_535_536.in1"],
-          ["self.out_grad_y_unclamp_stencil","add_519_535_536.out"],
-          ["mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.out","add_520_533_534.in0"],
-          ["add_521_532_533.out","add_520_533_534.in1"],
-          ["add_grad_y_unclamp_stencil_1_534_535.in1","add_520_533_534.out"],
-          ["mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.out","add_521_532_533.in0"],
-          ["add_522_531_532.out","add_521_532_533.in1"],
-          ["mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.out","add_522_531_532.in0"],
-          ["add_523_530_531.out","add_522_531_532.in1"],
-          ["mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.out","add_523_530_531.in0"],
-          ["add_524_529_530.out","add_523_530_531.in1"],
-          ["mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.out","add_524_529_530.in0"],
-          ["add_525_528_529.out","add_524_529_530.in1"],
-          ["mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.out","add_525_528_529.in0"],
-          ["add_526_527_528.out","add_525_528_529.in1"],
-          ["mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.out","add_526_527_528.in0"],
-          ["mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.out","add_526_527_528.in1"],
-          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_534_535.in0"],
-          ["self.in2_padded16_global_wrapper_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.in0"],
-          ["self.in1_kernel_y_stencil.0","mul_padded16_global_wrapper_stencil_10_kernel_y_stencil_1_519.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.in0"],
-          ["self.in1_kernel_y_stencil.1","mul_padded16_global_wrapper_stencil_11_kernel_y_stencil_2_520.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.in0"],
-          ["self.in1_kernel_y_stencil.2","mul_padded16_global_wrapper_stencil_12_kernel_y_stencil_3_521.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.in0"],
-          ["self.in1_kernel_y_stencil.3","mul_padded16_global_wrapper_stencil_13_kernel_y_stencil_4_522.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.in0"],
-          ["self.in1_kernel_y_stencil.4","mul_padded16_global_wrapper_stencil_14_kernel_y_stencil_5_523.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.in0"],
-          ["self.in1_kernel_y_stencil.5","mul_padded16_global_wrapper_stencil_15_kernel_y_stencil_6_524.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.in0"],
-          ["self.in1_kernel_y_stencil.6","mul_padded16_global_wrapper_stencil_16_kernel_y_stencil_7_525.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.in0"],
-          ["self.in1_kernel_y_stencil.7","mul_padded16_global_wrapper_stencil_17_kernel_y_stencil_8_526.in1"],
-          ["self.in2_padded16_global_wrapper_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.in0"],
-          ["self.in1_kernel_y_stencil.8","mul_padded16_global_wrapper_stencil_18_kernel_y_stencil_9_527.in1"]
-        ]
-      },
-      "hcompute_kernel_x_stencil":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__261":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__261.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__264":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__264.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__291":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n2__291.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__294":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__294.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__297":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__297.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__300":{
+          "const_p2__381":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p2__300.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__303":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p1__303.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__267":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__267.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__270":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__270.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__273":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__273.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__276":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__276.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__279":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__279.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__282":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__282.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__285":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_p0__285.out"]
-        ]
-      },
-      "hcompute_kernel_x_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_x_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__288":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_x_stencil","const_n1__288.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__454":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__454.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_1":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__457":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__457.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_10":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p2__484":{
+          },
+          "const_p2__381$1":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0002"]}
+          },
+          "mul_padded16_global_wrapper_stencil_11_381_387":{
+            "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "mul_padded16_global_wrapper_stencil_9_381_382":{
+            "genref":"coreir.mul",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_385_padded16_global_wrapper_stencil_10_386":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_386_387_388":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
+          },
+          "sub_388_padded16_global_wrapper_stencil_12_389":{
+            "genref":"coreir.sub",
+            "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.out_kernel_y_stencil","const_p2__484.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_11":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__487":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__487.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_12":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__490":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__490.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_13":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n2__493":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hfffe"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n2__493.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_14":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_n1__496":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'hffff"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_n1__496.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_2":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__460":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__460.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_3":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__463":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__463.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_4":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__466":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__466.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_5":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__469":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__469.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_6":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__472":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__472.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_7":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__475":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__475.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_8":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p0__478":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0000"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p0__478.out"]
-        ]
-      },
-      "hcompute_kernel_y_stencil_9":{
-        "type":["Record",[
-          ["out_kernel_y_stencil",["Array",16,"Bit"]]
-        ]],
-        "instances":{
-          "const_p1__481":{
-            "genref":"coreir.const",
-            "genargs":{"width":["Int",16]},
-            "modargs":{"value":[["BitVector",16],"16'h0001"]}
-          }
-        },
-        "connections":[
-          ["self.out_kernel_y_stencil","const_p1__481.out"]
+          ["self.in0_grad_y_unclamp_stencil.0","add_grad_y_unclamp_stencil_1_384_385.in0"],
+          ["add_padded16_global_wrapper_stencil_7_383_384.out","add_grad_y_unclamp_stencil_1_384_385.in1"],
+          ["sub_385_padded16_global_wrapper_stencil_10_386.in0","add_grad_y_unclamp_stencil_1_384_385.out"],
+          ["self.in1_padded16_global_wrapper_stencil.3","add_padded16_global_wrapper_stencil_7_383_384.in0"],
+          ["add_padded16_global_wrapper_stencil_8_382_383.out","add_padded16_global_wrapper_stencil_7_383_384.in1"],
+          ["self.in1_padded16_global_wrapper_stencil.4","add_padded16_global_wrapper_stencil_8_382_383.in0"],
+          ["mul_padded16_global_wrapper_stencil_9_381_382.out","add_padded16_global_wrapper_stencil_8_382_383.in1"],
+          ["mul_padded16_global_wrapper_stencil_11_381_387.in1","const_p2__381$1.out"],
+          ["mul_padded16_global_wrapper_stencil_9_381_382.in1","const_p2__381.out"],
+          ["self.in1_padded16_global_wrapper_stencil.1","mul_padded16_global_wrapper_stencil_11_381_387.in0"],
+          ["sub_386_387_388.in1","mul_padded16_global_wrapper_stencil_11_381_387.out"],
+          ["self.in1_padded16_global_wrapper_stencil.5","mul_padded16_global_wrapper_stencil_9_381_382.in0"],
+          ["sub_385_padded16_global_wrapper_stencil_10_386.in1","self.in1_padded16_global_wrapper_stencil.0"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.in1","self.in1_padded16_global_wrapper_stencil.2"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.out","self.out_grad_y_unclamp_stencil"],
+          ["sub_386_387_388.in0","sub_385_padded16_global_wrapper_stencil_10_386.out"],
+          ["sub_388_padded16_global_wrapper_stencil_12_389.in0","sub_386_387_388.out"]
         ]
       },
       "hcompute_lgxx_stencil":{
@@ -888,14 +336,14 @@
           ["out_lgxx_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__410":{
+          "const_p0__326":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxx_stencil","const_p0__410.out"]
+          ["self.out_lgxx_stencil","const_p0__326.out"]
         ]
       },
       "hcompute_lgxx_stencil_1":{
@@ -905,63 +353,63 @@
           ["in1_lxx_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxx_stencil_1_427_428":{
+          "add_lgxx_stencil_1_343_344":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_1_428_429":{
+          "add_lxx_stencil_1_344_345":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_2_426_427":{
+          "add_lxx_stencil_2_342_343":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_3_425_426":{
+          "add_lxx_stencil_3_341_342":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_4_424_425":{
+          "add_lxx_stencil_4_340_341":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_5_423_424":{
+          "add_lxx_stencil_5_339_340":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_6_422_423":{
+          "add_lxx_stencil_6_338_339":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_7_421_422":{
+          "add_lxx_stencil_7_337_338":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxx_stencil_8_lxx_stencil_9_421":{
+          "add_lxx_stencil_8_lxx_stencil_9_337":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_427_428.in0"],
-          ["add_lxx_stencil_2_426_427.out","add_lgxx_stencil_1_427_428.in1"],
-          ["add_lxx_stencil_1_428_429.in1","add_lgxx_stencil_1_427_428.out"],
-          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_428_429.in0"],
-          ["self.out_lgxx_stencil","add_lxx_stencil_1_428_429.out"],
-          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_426_427.in0"],
-          ["add_lxx_stencil_3_425_426.out","add_lxx_stencil_2_426_427.in1"],
-          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_425_426.in0"],
-          ["add_lxx_stencil_4_424_425.out","add_lxx_stencil_3_425_426.in1"],
-          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_424_425.in0"],
-          ["add_lxx_stencil_5_423_424.out","add_lxx_stencil_4_424_425.in1"],
-          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_423_424.in0"],
-          ["add_lxx_stencil_6_422_423.out","add_lxx_stencil_5_423_424.in1"],
-          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_422_423.in0"],
-          ["add_lxx_stencil_7_421_422.out","add_lxx_stencil_6_422_423.in1"],
-          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_421_422.in0"],
-          ["add_lxx_stencil_8_lxx_stencil_9_421.out","add_lxx_stencil_7_421_422.in1"],
-          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_421.in0"],
-          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_421.in1"]
+          ["self.in0_lgxx_stencil.0","add_lgxx_stencil_1_343_344.in0"],
+          ["add_lxx_stencil_2_342_343.out","add_lgxx_stencil_1_343_344.in1"],
+          ["add_lxx_stencil_1_344_345.in1","add_lgxx_stencil_1_343_344.out"],
+          ["self.in1_lxx_stencil.0","add_lxx_stencil_1_344_345.in0"],
+          ["self.out_lgxx_stencil","add_lxx_stencil_1_344_345.out"],
+          ["self.in1_lxx_stencil.1","add_lxx_stencil_2_342_343.in0"],
+          ["add_lxx_stencil_3_341_342.out","add_lxx_stencil_2_342_343.in1"],
+          ["self.in1_lxx_stencil.2","add_lxx_stencil_3_341_342.in0"],
+          ["add_lxx_stencil_4_340_341.out","add_lxx_stencil_3_341_342.in1"],
+          ["self.in1_lxx_stencil.3","add_lxx_stencil_4_340_341.in0"],
+          ["add_lxx_stencil_5_339_340.out","add_lxx_stencil_4_340_341.in1"],
+          ["self.in1_lxx_stencil.4","add_lxx_stencil_5_339_340.in0"],
+          ["add_lxx_stencil_6_338_339.out","add_lxx_stencil_5_339_340.in1"],
+          ["self.in1_lxx_stencil.5","add_lxx_stencil_6_338_339.in0"],
+          ["add_lxx_stencil_7_337_338.out","add_lxx_stencil_6_338_339.in1"],
+          ["self.in1_lxx_stencil.6","add_lxx_stencil_7_337_338.in0"],
+          ["add_lxx_stencil_8_lxx_stencil_9_337.out","add_lxx_stencil_7_337_338.in1"],
+          ["self.in1_lxx_stencil.7","add_lxx_stencil_8_lxx_stencil_9_337.in0"],
+          ["self.in1_lxx_stencil.8","add_lxx_stencil_8_lxx_stencil_9_337.in1"]
         ]
       },
       "hcompute_lgxy_stencil":{
@@ -969,14 +417,14 @@
           ["out_lgxy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__603":{
+          "const_p0__435":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgxy_stencil","const_p0__603.out"]
+          ["self.out_lgxy_stencil","const_p0__435.out"]
         ]
       },
       "hcompute_lgxy_stencil_1":{
@@ -986,63 +434,63 @@
           ["in1_lxy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgxy_stencil_1_620_621":{
+          "add_lgxy_stencil_1_452_453":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_1_621_622":{
+          "add_lxy_stencil_1_453_454":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_2_619_620":{
+          "add_lxy_stencil_2_451_452":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_3_618_619":{
+          "add_lxy_stencil_3_450_451":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_4_617_618":{
+          "add_lxy_stencil_4_449_450":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_5_616_617":{
+          "add_lxy_stencil_5_448_449":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_6_615_616":{
+          "add_lxy_stencil_6_447_448":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_7_614_615":{
+          "add_lxy_stencil_7_446_447":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lxy_stencil_8_lxy_stencil_9_614":{
+          "add_lxy_stencil_8_lxy_stencil_9_446":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_620_621.in0"],
-          ["add_lxy_stencil_2_619_620.out","add_lgxy_stencil_1_620_621.in1"],
-          ["add_lxy_stencil_1_621_622.in1","add_lgxy_stencil_1_620_621.out"],
-          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_621_622.in0"],
-          ["self.out_lgxy_stencil","add_lxy_stencil_1_621_622.out"],
-          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_619_620.in0"],
-          ["add_lxy_stencil_3_618_619.out","add_lxy_stencil_2_619_620.in1"],
-          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_618_619.in0"],
-          ["add_lxy_stencil_4_617_618.out","add_lxy_stencil_3_618_619.in1"],
-          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_617_618.in0"],
-          ["add_lxy_stencil_5_616_617.out","add_lxy_stencil_4_617_618.in1"],
-          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_616_617.in0"],
-          ["add_lxy_stencil_6_615_616.out","add_lxy_stencil_5_616_617.in1"],
-          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_615_616.in0"],
-          ["add_lxy_stencil_7_614_615.out","add_lxy_stencil_6_615_616.in1"],
-          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_614_615.in0"],
-          ["add_lxy_stencil_8_lxy_stencil_9_614.out","add_lxy_stencil_7_614_615.in1"],
-          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_614.in0"],
-          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_614.in1"]
+          ["self.in0_lgxy_stencil.0","add_lgxy_stencil_1_452_453.in0"],
+          ["add_lxy_stencil_2_451_452.out","add_lgxy_stencil_1_452_453.in1"],
+          ["add_lxy_stencil_1_453_454.in1","add_lgxy_stencil_1_452_453.out"],
+          ["self.in1_lxy_stencil.0","add_lxy_stencil_1_453_454.in0"],
+          ["self.out_lgxy_stencil","add_lxy_stencil_1_453_454.out"],
+          ["self.in1_lxy_stencil.1","add_lxy_stencil_2_451_452.in0"],
+          ["add_lxy_stencil_3_450_451.out","add_lxy_stencil_2_451_452.in1"],
+          ["self.in1_lxy_stencil.2","add_lxy_stencil_3_450_451.in0"],
+          ["add_lxy_stencil_4_449_450.out","add_lxy_stencil_3_450_451.in1"],
+          ["self.in1_lxy_stencil.3","add_lxy_stencil_4_449_450.in0"],
+          ["add_lxy_stencil_5_448_449.out","add_lxy_stencil_4_449_450.in1"],
+          ["self.in1_lxy_stencil.4","add_lxy_stencil_5_448_449.in0"],
+          ["add_lxy_stencil_6_447_448.out","add_lxy_stencil_5_448_449.in1"],
+          ["self.in1_lxy_stencil.5","add_lxy_stencil_6_447_448.in0"],
+          ["add_lxy_stencil_7_446_447.out","add_lxy_stencil_6_447_448.in1"],
+          ["self.in1_lxy_stencil.6","add_lxy_stencil_7_446_447.in0"],
+          ["add_lxy_stencil_8_lxy_stencil_9_446.out","add_lxy_stencil_7_446_447.in1"],
+          ["self.in1_lxy_stencil.7","add_lxy_stencil_8_lxy_stencil_9_446.in0"],
+          ["self.in1_lxy_stencil.8","add_lxy_stencil_8_lxy_stencil_9_446.in1"]
         ]
       },
       "hcompute_lgyy_stencil":{
@@ -1050,14 +498,14 @@
           ["out_lgyy_stencil",["Array",16,"Bit"]]
         ]],
         "instances":{
-          "const_p0__657":{
+          "const_p0__489":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0000"]}
           }
         },
         "connections":[
-          ["self.out_lgyy_stencil","const_p0__657.out"]
+          ["self.out_lgyy_stencil","const_p0__489.out"]
         ]
       },
       "hcompute_lgyy_stencil_1":{
@@ -1067,63 +515,63 @@
           ["in1_lyy_stencil",["Array",9,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "add_lgyy_stencil_1_674_675":{
+          "add_lgyy_stencil_1_506_507":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_1_675_676":{
+          "add_lyy_stencil_1_507_508":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_2_673_674":{
+          "add_lyy_stencil_2_505_506":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_3_672_673":{
+          "add_lyy_stencil_3_504_505":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_4_671_672":{
+          "add_lyy_stencil_4_503_504":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_5_670_671":{
+          "add_lyy_stencil_5_502_503":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_6_669_670":{
+          "add_lyy_stencil_6_501_502":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_7_668_669":{
+          "add_lyy_stencil_7_500_501":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           },
-          "add_lyy_stencil_8_lyy_stencil_9_668":{
+          "add_lyy_stencil_8_lyy_stencil_9_500":{
             "genref":"coreir.add",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_674_675.in0"],
-          ["add_lyy_stencil_2_673_674.out","add_lgyy_stencil_1_674_675.in1"],
-          ["add_lyy_stencil_1_675_676.in1","add_lgyy_stencil_1_674_675.out"],
-          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_675_676.in0"],
-          ["self.out_lgyy_stencil","add_lyy_stencil_1_675_676.out"],
-          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_673_674.in0"],
-          ["add_lyy_stencil_3_672_673.out","add_lyy_stencil_2_673_674.in1"],
-          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_672_673.in0"],
-          ["add_lyy_stencil_4_671_672.out","add_lyy_stencil_3_672_673.in1"],
-          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_671_672.in0"],
-          ["add_lyy_stencil_5_670_671.out","add_lyy_stencil_4_671_672.in1"],
-          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_670_671.in0"],
-          ["add_lyy_stencil_6_669_670.out","add_lyy_stencil_5_670_671.in1"],
-          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_669_670.in0"],
-          ["add_lyy_stencil_7_668_669.out","add_lyy_stencil_6_669_670.in1"],
-          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_668_669.in0"],
-          ["add_lyy_stencil_8_lyy_stencil_9_668.out","add_lyy_stencil_7_668_669.in1"],
-          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_668.in0"],
-          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_668.in1"]
+          ["self.in0_lgyy_stencil.0","add_lgyy_stencil_1_506_507.in0"],
+          ["add_lyy_stencil_2_505_506.out","add_lgyy_stencil_1_506_507.in1"],
+          ["add_lyy_stencil_1_507_508.in1","add_lgyy_stencil_1_506_507.out"],
+          ["self.in1_lyy_stencil.0","add_lyy_stencil_1_507_508.in0"],
+          ["self.out_lgyy_stencil","add_lyy_stencil_1_507_508.out"],
+          ["self.in1_lyy_stencil.1","add_lyy_stencil_2_505_506.in0"],
+          ["add_lyy_stencil_3_504_505.out","add_lyy_stencil_2_505_506.in1"],
+          ["self.in1_lyy_stencil.2","add_lyy_stencil_3_504_505.in0"],
+          ["add_lyy_stencil_4_503_504.out","add_lyy_stencil_3_504_505.in1"],
+          ["self.in1_lyy_stencil.3","add_lyy_stencil_4_503_504.in0"],
+          ["add_lyy_stencil_5_502_503.out","add_lyy_stencil_4_503_504.in1"],
+          ["self.in1_lyy_stencil.4","add_lyy_stencil_5_502_503.in0"],
+          ["add_lyy_stencil_6_501_502.out","add_lyy_stencil_5_502_503.in1"],
+          ["self.in1_lyy_stencil.5","add_lyy_stencil_6_501_502.in0"],
+          ["add_lyy_stencil_7_500_501.out","add_lyy_stencil_6_501_502.in1"],
+          ["self.in1_lyy_stencil.6","add_lyy_stencil_7_500_501.in0"],
+          ["add_lyy_stencil_8_lyy_stencil_9_500.out","add_lyy_stencil_7_500_501.in1"],
+          ["self.in1_lyy_stencil.7","add_lyy_stencil_8_lyy_stencil_9_500.in0"],
+          ["self.in1_lyy_stencil.8","add_lyy_stencil_8_lyy_stencil_9_500.in1"]
         ]
       },
       "hcompute_lxx_stencil":{
@@ -1132,26 +580,26 @@
           ["in0_grad_x_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_402_403_404":{
+          "ashr_318_319_320":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__403":{
+          "const_p6__319":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_x_stencil_1_grad_x_stencil_1_402":{
+          "mul_grad_x_stencil_1_grad_x_stencil_1_318":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_1_grad_x_stencil_1_402.out","ashr_402_403_404.in0"],
-          ["const_p6__403.out","ashr_402_403_404.in1"],
-          ["self.out_lxx_stencil","ashr_402_403_404.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_402.in0"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_402.in1"]
+          ["mul_grad_x_stencil_1_grad_x_stencil_1_318.out","ashr_318_319_320.in0"],
+          ["const_p6__319.out","ashr_318_319_320.in1"],
+          ["self.out_lxx_stencil","ashr_318_319_320.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_318.in0"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_1_grad_x_stencil_1_318.in1"]
         ]
       },
       "hcompute_lxy_stencil":{
@@ -1161,26 +609,26 @@
           ["in1_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_594_595_596":{
+          "ashr_426_427_428":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__595":{
+          "const_p6__427":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_x_stencil_2_grad_y_stencil_1_594":{
+          "mul_grad_x_stencil_2_grad_y_stencil_1_426":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_x_stencil_2_grad_y_stencil_1_594.out","ashr_594_595_596.in0"],
-          ["const_p6__595.out","ashr_594_595_596.in1"],
-          ["self.out_lxy_stencil","ashr_594_595_596.out"],
-          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_594.in0"],
-          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_594.in1"]
+          ["mul_grad_x_stencil_2_grad_y_stencil_1_426.out","ashr_426_427_428.in0"],
+          ["const_p6__427.out","ashr_426_427_428.in1"],
+          ["self.out_lxy_stencil","ashr_426_427_428.out"],
+          ["self.in0_grad_x_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_426.in0"],
+          ["self.in1_grad_y_stencil.0","mul_grad_x_stencil_2_grad_y_stencil_1_426.in1"]
         ]
       },
       "hcompute_lyy_stencil":{
@@ -1189,26 +637,26 @@
           ["in0_grad_y_stencil",["Array",1,["Array",16,"BitIn"]]]
         ]],
         "instances":{
-          "ashr_649_650_651":{
+          "ashr_481_482_483":{
             "genref":"coreir.ashr",
             "genargs":{"width":["Int",16]}
           },
-          "const_p6__650":{
+          "const_p6__482":{
             "genref":"coreir.const",
             "genargs":{"width":["Int",16]},
             "modargs":{"value":[["BitVector",16],"16'h0006"]}
           },
-          "mul_grad_y_stencil_2_grad_y_stencil_2_649":{
+          "mul_grad_y_stencil_2_grad_y_stencil_2_481":{
             "genref":"coreir.mul",
             "genargs":{"width":["Int",16]}
           }
         },
         "connections":[
-          ["mul_grad_y_stencil_2_grad_y_stencil_2_649.out","ashr_649_650_651.in0"],
-          ["const_p6__650.out","ashr_649_650_651.in1"],
-          ["self.out_lyy_stencil","ashr_649_650_651.out"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_649.in0"],
-          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_649.in1"]
+          ["mul_grad_y_stencil_2_grad_y_stencil_2_481.out","ashr_481_482_483.in0"],
+          ["const_p6__482.out","ashr_481_482_483.in1"],
+          ["self.out_lyy_stencil","ashr_481_482_483.out"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_481.in0"],
+          ["self.in0_grad_y_stencil.0","mul_grad_y_stencil_2_grad_y_stencil_2_481.in1"]
         ]
       },
       "hcompute_padded16_global_wrapper_stencil":{

--- a/example_progs.cpp
+++ b/example_progs.cpp
@@ -5340,85 +5340,6 @@ prog harris_sch5_1ppc() {
   prg.add_output("hw_output_stencil");
   prg.buffer_port_widths["hw_output_stencil"] = 16;
 
-////producing kernel_x.stencil
-
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil = prg.add_op("op_hcompute_kernel_x_stencil");
-  hcompute_kernel_x_stencil->add_function("hcompute_kernel_x_stencil");
-  prg.buffer_port_widths["kernel_x_stencil"] = 16;
-  hcompute_kernel_x_stencil->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_1 = prg.add_op("op_hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_function("hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_store("kernel_x_stencil", "-1", "0");
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_2 = prg.add_op("op_hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_function("hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_3 = prg.add_op("op_hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_function("hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_4 = prg.add_op("op_hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_function("hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_store("kernel_x_stencil", "0", "0");
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_5 = prg.add_op("op_hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_function("hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_6 = prg.add_op("op_hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_function("hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_7 = prg.add_op("op_hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_function("hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_store("kernel_x_stencil", "1", "0");
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_8 = prg.add_op("op_hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_function("hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_store("kernel_x_stencil", "1", "1");
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_x_stencil_9 = prg.add_op("op_hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_function("hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-  auto hcompute_kernel_x_stencil_10 = prg.add_op("op_hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_function("hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-  auto hcompute_kernel_x_stencil_11 = prg.add_op("op_hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_function("hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-  auto hcompute_kernel_x_stencil_12 = prg.add_op("op_hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_function("hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-  auto hcompute_kernel_x_stencil_13 = prg.add_op("op_hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_function("hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_x_stencil_14 = prg.add_op("op_hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_function("hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_store("kernel_x_stencil", "1", "1");
-
-//consuming kernel_x.stencil
 ////producing padded16_global_wrapper.stencil
   auto padded16_global_wrapper_s0_y = prg.add_loop("padded16_global_wrapper_s0_y", -3, 61);
   auto padded16_global_wrapper_s0_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x", -3, 61);
@@ -5442,28 +5363,16 @@ prog harris_sch5_1ppc() {
   prg.buffer_port_widths["grad_x_unclamp_stencil"] = 16;
   hcompute_grad_x_unclamp_stencil->add_store("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
 
-//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + ((padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_x_s0_x, grad_x_s0_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + 1))*kernel_x.stencil(0, 1)))))))))))
+//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((((grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1)))
   auto hcompute_grad_x_unclamp_stencil_1 = grad_x_s0_x->add_op("op_hcompute_grad_x_unclamp_stencil_1");
   hcompute_grad_x_unclamp_stencil_1->add_function("hcompute_grad_x_unclamp_stencil_1");
   hcompute_grad_x_unclamp_stencil_1->add_load("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + -1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "grad_x_s0_x");
   hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + -1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "grad_x_s0_x");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + -1)");
   hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "grad_x_s0_x");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + 1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + -1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + -1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + -1)");
   hcompute_grad_x_unclamp_stencil_1->add_store("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
 
 //consuming grad_x_unclamp.stencil
@@ -5516,85 +5425,6 @@ prog harris_sch5_1ppc() {
   hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
 
 //consuming lgxx.stencil
-////producing kernel_y.stencil
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil = prg.add_op("op_hcompute_kernel_y_stencil");
-  hcompute_kernel_y_stencil->add_function("hcompute_kernel_y_stencil");
-  prg.buffer_port_widths["kernel_y_stencil"] = 16;
-  hcompute_kernel_y_stencil->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_1 = prg.add_op("op_hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_function("hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_2 = prg.add_op("op_hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_function("hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_store("kernel_y_stencil", "-1", "1");
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_3 = prg.add_op("op_hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_function("hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_store("kernel_y_stencil", "0", "-1");
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_4 = prg.add_op("op_hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_function("hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_store("kernel_y_stencil", "0", "0");
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_5 = prg.add_op("op_hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_function("hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_store("kernel_y_stencil", "0", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_6 = prg.add_op("op_hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_function("hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_7 = prg.add_op("op_hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_function("hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_8 = prg.add_op("op_hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_function("hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_9 = prg.add_op("op_hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_function("hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-  auto hcompute_kernel_y_stencil_10 = prg.add_op("op_hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_function("hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_11 = prg.add_op("op_hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_function("hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_12 = prg.add_op("op_hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_function("hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-  auto hcompute_kernel_y_stencil_13 = prg.add_op("op_hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_function("hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_14 = prg.add_op("op_hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_function("hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_store("kernel_y_stencil", "-1", "1");
-
-//consuming kernel_y.stencil
 ////producing grad_y.stencil
   auto grad_y_s0_y = prg.add_loop("grad_y_s0_y", -2, 60);
   auto grad_y_s0_x = grad_y_s0_y->add_loop("grad_y_s0_x", -2, 60);
@@ -5606,25 +5436,13 @@ prog harris_sch5_1ppc() {
   prg.buffer_port_widths["grad_y_unclamp_stencil"] = 16;
   hcompute_grad_y_unclamp_stencil->add_store("grad_y_unclamp_stencil", "grad_y_s0_y", "grad_y_s0_x");
 
-//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + ((padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), grad_y_s0_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_y_s0_x, grad_y_s0_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), grad_y_s0_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*kernel_y.stencil(0, 1)))))))))))
+//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((((grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))) - (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1)))
   auto hcompute_grad_y_unclamp_stencil_1 = grad_y_s0_x->add_op("op_hcompute_grad_y_unclamp_stencil_1");
   hcompute_grad_y_unclamp_stencil_1->add_function("hcompute_grad_y_unclamp_stencil_1");
   hcompute_grad_y_unclamp_stencil_1->add_load("grad_y_unclamp_stencil", "grad_y_s0_y", "grad_y_s0_x");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "0");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "0");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "0");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "(grad_y_s0_x + -1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "grad_y_s0_x");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "(grad_y_s0_x + 1)");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "(grad_y_s0_x + -1)");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "grad_y_s0_x");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "(grad_y_s0_x + 1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "(grad_y_s0_x + -1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "(grad_y_s0_x + 1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "grad_y_s0_x");
@@ -5779,85 +5597,6 @@ prog harris_sch6_2ppc() {
   prg.add_output("hw_output_stencil");
   prg.buffer_port_widths["hw_output_stencil"] = 16;
 
-////producing kernel_x.stencil
-
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil = prg.add_op("op_hcompute_kernel_x_stencil");
-  hcompute_kernel_x_stencil->add_function("hcompute_kernel_x_stencil");
-  prg.buffer_port_widths["kernel_x_stencil"] = 16;
-  hcompute_kernel_x_stencil->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_1 = prg.add_op("op_hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_function("hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_store("kernel_x_stencil", "-1", "0");
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_2 = prg.add_op("op_hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_function("hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_3 = prg.add_op("op_hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_function("hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_4 = prg.add_op("op_hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_function("hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_store("kernel_x_stencil", "0", "0");
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_5 = prg.add_op("op_hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_function("hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_6 = prg.add_op("op_hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_function("hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_7 = prg.add_op("op_hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_function("hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_store("kernel_x_stencil", "1", "0");
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_8 = prg.add_op("op_hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_function("hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_store("kernel_x_stencil", "1", "1");
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_x_stencil_9 = prg.add_op("op_hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_function("hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-  auto hcompute_kernel_x_stencil_10 = prg.add_op("op_hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_function("hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-  auto hcompute_kernel_x_stencil_11 = prg.add_op("op_hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_function("hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-  auto hcompute_kernel_x_stencil_12 = prg.add_op("op_hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_function("hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-  auto hcompute_kernel_x_stencil_13 = prg.add_op("op_hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_function("hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_x_stencil_14 = prg.add_op("op_hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_function("hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_store("kernel_x_stencil", "1", "1");
-
-//consuming kernel_x.stencil
 ////producing padded16_global_wrapper.stencil
   auto padded16_global_wrapper_s0_y = prg.add_loop("padded16_global_wrapper_s0_y", -3, 61);
   auto padded16_global_wrapper_s0_x_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x_x", 0, 32);
@@ -5893,52 +5632,28 @@ prog harris_sch6_2ppc() {
   auto grad_x_unclamp_s1_y = prg.add_loop("grad_x_unclamp_s1_y", -2, 60);
   auto grad_x_unclamp_s1_x_x = grad_x_unclamp_s1_y->add_loop("grad_x_unclamp_s1_x_x", 0, 31);
 
-//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), grad_x_unclamp_s1_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(0, 1)))))))))))
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + 1)))
   auto hcompute_grad_x_unclamp_stencil_2 = grad_x_unclamp_s1_x_x->add_op("op_hcompute_grad_x_unclamp_stencil_2");
   hcompute_grad_x_unclamp_stencil_2->add_function("hcompute_grad_x_unclamp_stencil_2");
   hcompute_grad_x_unclamp_stencil_2->add_load("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "-1", "-1");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "-1", "0");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "-1", "1");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "0", "-1");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "0", "0");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "0", "1");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "1", "-1");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "1", "1");
-  hcompute_grad_x_unclamp_stencil_2->add_load("kernel_x_stencil", "1", "0");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -3)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -2)");
   hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -3)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -3)");
   hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_x_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -3)");
   hcompute_grad_x_unclamp_stencil_2->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -2)");
 
-//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), grad_x_unclamp_s1_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(0, 1)))))))))))
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1)))
   auto hcompute_grad_x_unclamp_stencil_3 = grad_x_unclamp_s1_x_x->add_op("op_hcompute_grad_x_unclamp_stencil_3");
   hcompute_grad_x_unclamp_stencil_3->add_function("hcompute_grad_x_unclamp_stencil_3");
   hcompute_grad_x_unclamp_stencil_3->add_load("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "-1", "-1");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "-1", "0");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "-1", "1");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "0", "-1");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "0", "0");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "0", "1");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "1", "-1");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "1", "1");
-  hcompute_grad_x_unclamp_stencil_3->add_load("kernel_x_stencil", "1", "0");
   hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "((grad_x_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "(grad_x_unclamp_s1_x_x*2)");
   hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "(grad_x_unclamp_s1_x_x*2)");
   hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + -1)", "(grad_x_unclamp_s1_x_x*2)");
   hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "(grad_x_unclamp_s1_x_x*2)");
-  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_x_unclamp_s1_y + 1)", "((grad_x_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_x_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_x_unclamp_s1_y", "(grad_x_unclamp_s1_x_x*2)");
   hcompute_grad_x_unclamp_stencil_3->add_store("grad_x_unclamp_stencil", "grad_x_unclamp_s1_y", "((grad_x_unclamp_s1_x_x*2) + -1)");
 
 //consuming grad_x_unclamp.stencil
@@ -6008,85 +5723,6 @@ prog harris_sch6_2ppc() {
   hcompute_lgxx_stencil_3->add_store("lgxx_stencil", "lgxx_s1_y", "(lgxx_s1_x_x*2)");
 
 //consuming lgxx.stencil
-////producing kernel_y.stencil
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil = prg.add_op("op_hcompute_kernel_y_stencil");
-  hcompute_kernel_y_stencil->add_function("hcompute_kernel_y_stencil");
-  prg.buffer_port_widths["kernel_y_stencil"] = 16;
-  hcompute_kernel_y_stencil->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_1 = prg.add_op("op_hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_function("hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_2 = prg.add_op("op_hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_function("hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_store("kernel_y_stencil", "-1", "1");
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_3 = prg.add_op("op_hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_function("hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_store("kernel_y_stencil", "0", "-1");
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_4 = prg.add_op("op_hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_function("hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_store("kernel_y_stencil", "0", "0");
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_5 = prg.add_op("op_hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_function("hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_store("kernel_y_stencil", "0", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_6 = prg.add_op("op_hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_function("hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_7 = prg.add_op("op_hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_function("hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_8 = prg.add_op("op_hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_function("hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_9 = prg.add_op("op_hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_function("hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-  auto hcompute_kernel_y_stencil_10 = prg.add_op("op_hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_function("hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_11 = prg.add_op("op_hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_function("hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_12 = prg.add_op("op_hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_function("hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-  auto hcompute_kernel_y_stencil_13 = prg.add_op("op_hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_function("hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_14 = prg.add_op("op_hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_function("hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_store("kernel_y_stencil", "-1", "1");
-
-//consuming kernel_y.stencil
 ////producing grad_y_unclamp.stencil
   auto grad_y_unclamp_s0_y = prg.add_loop("grad_y_unclamp_s0_y", -2, 60);
   auto grad_y_unclamp_s0_x_x = grad_y_unclamp_s0_y->add_loop("grad_y_unclamp_s0_x_x", 0, 31);
@@ -6104,52 +5740,28 @@ prog harris_sch6_2ppc() {
   auto grad_y_unclamp_s1_y = prg.add_loop("grad_y_unclamp_s1_y", -2, 60);
   auto grad_y_unclamp_s1_x_x = grad_y_unclamp_s1_y->add_loop("grad_y_unclamp_s1_x_x", 0, 31);
 
-//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), grad_y_unclamp_s1_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(0, 1)))))))))))
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1)))
   auto hcompute_grad_y_unclamp_stencil_2 = grad_y_unclamp_s1_x_x->add_op("op_hcompute_grad_y_unclamp_stencil_2");
   hcompute_grad_y_unclamp_stencil_2->add_function("hcompute_grad_y_unclamp_stencil_2");
   hcompute_grad_y_unclamp_stencil_2->add_load("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "-1", "-1");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "-1", "0");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "-1", "1");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "0", "-1");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "0", "0");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "0", "1");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "1", "-1");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "1", "1");
-  hcompute_grad_y_unclamp_stencil_2->add_load("kernel_y_stencil", "1", "0");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -3)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -3)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -1)");
   hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -3)");
   hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
   hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -3)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_2->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
   hcompute_grad_y_unclamp_stencil_2->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -2)");
 
-//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), grad_y_unclamp_s1_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(0, 1)))))))))))
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + -1)))
   auto hcompute_grad_y_unclamp_stencil_3 = grad_y_unclamp_s1_x_x->add_op("op_hcompute_grad_y_unclamp_stencil_3");
   hcompute_grad_y_unclamp_stencil_3->add_function("hcompute_grad_y_unclamp_stencil_3");
   hcompute_grad_y_unclamp_stencil_3->add_load("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "-1", "-1");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "-1", "0");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "-1", "1");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "0", "-1");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "0", "0");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "0", "1");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "1", "-1");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "1", "1");
-  hcompute_grad_y_unclamp_stencil_3->add_load("kernel_y_stencil", "1", "0");
-  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "(grad_y_unclamp_s1_x_x*2)");
-  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -2)");
-  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -1)");
-  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "grad_y_unclamp_s1_y", "(grad_y_unclamp_s1_x_x*2)");
   hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
   hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "(grad_y_unclamp_s1_x_x*2)");
   hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + 1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -2)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "((grad_y_unclamp_s1_x_x*2) + -1)");
+  hcompute_grad_y_unclamp_stencil_3->add_load("padded16_global_wrapper_stencil", "(grad_y_unclamp_s1_y + -1)", "(grad_y_unclamp_s1_x_x*2)");
   hcompute_grad_y_unclamp_stencil_3->add_store("grad_y_unclamp_stencil", "grad_y_unclamp_s1_y", "((grad_y_unclamp_s1_x_x*2) + -1)");
 
 //consuming grad_y_unclamp.stencil
@@ -6373,88 +5985,9 @@ prog harris_sch7_bigtile() {
   prg.add_output("hw_output_stencil");
   prg.buffer_port_widths["hw_output_stencil"] = 16;
 
-////producing kernel_x.stencil
-
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil = prg.add_op("op_hcompute_kernel_x_stencil");
-  hcompute_kernel_x_stencil->add_function("hcompute_kernel_x_stencil");
-  prg.buffer_port_widths["kernel_x_stencil"] = 16;
-  hcompute_kernel_x_stencil->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_1 = prg.add_op("op_hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_function("hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_store("kernel_x_stencil", "-1", "0");
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_2 = prg.add_op("op_hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_function("hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_3 = prg.add_op("op_hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_function("hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_4 = prg.add_op("op_hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_function("hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_store("kernel_x_stencil", "0", "0");
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_5 = prg.add_op("op_hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_function("hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_6 = prg.add_op("op_hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_function("hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_7 = prg.add_op("op_hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_function("hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_store("kernel_x_stencil", "1", "0");
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_8 = prg.add_op("op_hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_function("hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_store("kernel_x_stencil", "1", "1");
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_x_stencil_9 = prg.add_op("op_hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_function("hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-  auto hcompute_kernel_x_stencil_10 = prg.add_op("op_hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_function("hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-  auto hcompute_kernel_x_stencil_11 = prg.add_op("op_hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_function("hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-  auto hcompute_kernel_x_stencil_12 = prg.add_op("op_hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_function("hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-  auto hcompute_kernel_x_stencil_13 = prg.add_op("op_hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_function("hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_x_stencil_14 = prg.add_op("op_hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_function("hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_store("kernel_x_stencil", "1", "1");
-
-//consuming kernel_x.stencil
 ////producing padded16_global_wrapper.stencil
-  auto padded16_global_wrapper_s0_y = prg.add_loop("padded16_global_wrapper_s0_y", -3, 125);
-  auto padded16_global_wrapper_s0_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x", -3, 125);
+  auto padded16_global_wrapper_s0_y = prg.add_loop("padded16_global_wrapper_s0_y", -67, 61);
+  auto padded16_global_wrapper_s0_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x", -67, 61);
 
 //store is: padded16_global_wrapper.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y) = padded16.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y)
   auto hcompute_padded16_global_wrapper_stencil = padded16_global_wrapper_s0_x->add_op("op_hcompute_padded16_global_wrapper_stencil");
@@ -6465,8 +5998,8 @@ prog harris_sch7_bigtile() {
 
 //consuming padded16_global_wrapper.stencil
 ////producing grad_x.stencil
-  auto grad_x_s0_y = prg.add_loop("grad_x_s0_y", -2, 124);
-  auto grad_x_s0_x = grad_x_s0_y->add_loop("grad_x_s0_x", -2, 124);
+  auto grad_x_s0_y = prg.add_loop("grad_x_s0_y", -66, 60);
+  auto grad_x_s0_x = grad_x_s0_y->add_loop("grad_x_s0_x", -66, 60);
 ////producing grad_x_unclamp.stencil
 
 //store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = (int16)0
@@ -6475,28 +6008,16 @@ prog harris_sch7_bigtile() {
   prg.buffer_port_widths["grad_x_unclamp_stencil"] = 16;
   hcompute_grad_x_unclamp_stencil->add_store("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
 
-//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + ((padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_x_s0_x, grad_x_s0_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + 1))*kernel_x.stencil(0, 1)))))))))))
+//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((((grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1)))
   auto hcompute_grad_x_unclamp_stencil_1 = grad_x_s0_x->add_op("op_hcompute_grad_x_unclamp_stencil_1");
   hcompute_grad_x_unclamp_stencil_1->add_function("hcompute_grad_x_unclamp_stencil_1");
   hcompute_grad_x_unclamp_stencil_1->add_load("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + -1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "grad_x_s0_x");
   hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + -1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "grad_x_s0_x");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + -1)");
   hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "grad_x_s0_x");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + 1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + -1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + -1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + -1)");
   hcompute_grad_x_unclamp_stencil_1->add_store("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
 
 //consuming grad_x_unclamp.stencil
@@ -6510,8 +6031,8 @@ prog harris_sch7_bigtile() {
 
 //consuming grad_x.stencil
 ////producing lxx.stencil
-  auto lxx_s0_y = prg.add_loop("lxx_s0_y", -2, 124);
-  auto lxx_s0_x = lxx_s0_y->add_loop("lxx_s0_x", -2, 124);
+  auto lxx_s0_y = prg.add_loop("lxx_s0_y", -66, 60);
+  auto lxx_s0_x = lxx_s0_y->add_loop("lxx_s0_x", -66, 60);
 
 //store is: lxx.stencil(lxx_s0_x, lxx_s0_y) = ((grad_x.stencil(lxx_s0_x, lxx_s0_y)*grad_x.stencil(lxx_s0_x, lxx_s0_y))/(int16)64)
   auto hcompute_lxx_stencil = lxx_s0_x->add_op("op_hcompute_lxx_stencil");
@@ -6522,16 +6043,16 @@ prog harris_sch7_bigtile() {
 
 //consuming lxx.stencil
 ////producing lgxx.stencil
-  auto lgxx_s0_y = prg.add_loop("lgxx_s0_y", -1, 123);
-  auto lgxx_s0_x = lgxx_s0_y->add_loop("lgxx_s0_x", -1, 123);
+  auto lgxx_s0_y = prg.add_loop("lgxx_s0_y", -65, 59);
+  auto lgxx_s0_x = lgxx_s0_y->add_loop("lgxx_s0_x", -65, 59);
 
 //store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
   auto hcompute_lgxx_stencil = lgxx_s0_x->add_op("op_hcompute_lgxx_stencil");
   hcompute_lgxx_stencil->add_function("hcompute_lgxx_stencil");
   prg.buffer_port_widths["lgxx_stencil"] = 16;
   hcompute_lgxx_stencil->add_store("lgxx_stencil", "lgxx_s0_y", "lgxx_s0_x");
-  auto lgxx_s1_y = prg.add_loop("lgxx_s1_y", -1, 123);
-  auto lgxx_s1_x = lgxx_s1_y->add_loop("lgxx_s1_x", -1, 123);
+  auto lgxx_s1_y = prg.add_loop("lgxx_s1_y", -65, 59);
+  auto lgxx_s1_x = lgxx_s1_y->add_loop("lgxx_s1_x", -65, 59);
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + -1)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + -1), lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + 1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + 1)) + lxx.stencil(lgxx_s1_x, (lgxx_s1_y + 1)))))))))))
   auto hcompute_lgxx_stencil_1 = lgxx_s1_x->add_op("op_hcompute_lgxx_stencil_1");
@@ -6549,88 +6070,9 @@ prog harris_sch7_bigtile() {
   hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
 
 //consuming lgxx.stencil
-////producing kernel_y.stencil
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil = prg.add_op("op_hcompute_kernel_y_stencil");
-  hcompute_kernel_y_stencil->add_function("hcompute_kernel_y_stencil");
-  prg.buffer_port_widths["kernel_y_stencil"] = 16;
-  hcompute_kernel_y_stencil->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_1 = prg.add_op("op_hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_function("hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_2 = prg.add_op("op_hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_function("hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_store("kernel_y_stencil", "-1", "1");
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_3 = prg.add_op("op_hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_function("hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_store("kernel_y_stencil", "0", "-1");
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_4 = prg.add_op("op_hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_function("hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_store("kernel_y_stencil", "0", "0");
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_5 = prg.add_op("op_hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_function("hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_store("kernel_y_stencil", "0", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_6 = prg.add_op("op_hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_function("hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_7 = prg.add_op("op_hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_function("hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_8 = prg.add_op("op_hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_function("hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_9 = prg.add_op("op_hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_function("hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-  auto hcompute_kernel_y_stencil_10 = prg.add_op("op_hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_function("hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_11 = prg.add_op("op_hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_function("hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_12 = prg.add_op("op_hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_function("hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-  auto hcompute_kernel_y_stencil_13 = prg.add_op("op_hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_function("hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_14 = prg.add_op("op_hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_function("hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_store("kernel_y_stencil", "-1", "1");
-
-//consuming kernel_y.stencil
 ////producing grad_y.stencil
-  auto grad_y_s0_y = prg.add_loop("grad_y_s0_y", -2, 124);
-  auto grad_y_s0_x = grad_y_s0_y->add_loop("grad_y_s0_x", -2, 124);
+  auto grad_y_s0_y = prg.add_loop("grad_y_s0_y", -66, 60);
+  auto grad_y_s0_x = grad_y_s0_y->add_loop("grad_y_s0_x", -66, 60);
 ////producing grad_y_unclamp.stencil
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (int16)0
@@ -6639,25 +6081,13 @@ prog harris_sch7_bigtile() {
   prg.buffer_port_widths["grad_y_unclamp_stencil"] = 16;
   hcompute_grad_y_unclamp_stencil->add_store("grad_y_unclamp_stencil", "grad_y_s0_y", "grad_y_s0_x");
 
-//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + ((padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), grad_y_s0_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_y_s0_x, grad_y_s0_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), grad_y_s0_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*kernel_y.stencil(0, 1)))))))))))
+//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((((grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))) - (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1)))
   auto hcompute_grad_y_unclamp_stencil_1 = grad_y_s0_x->add_op("op_hcompute_grad_y_unclamp_stencil_1");
   hcompute_grad_y_unclamp_stencil_1->add_function("hcompute_grad_y_unclamp_stencil_1");
   hcompute_grad_y_unclamp_stencil_1->add_load("grad_y_unclamp_stencil", "grad_y_s0_y", "grad_y_s0_x");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "0");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "0");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "0");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "(grad_y_s0_x + -1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "grad_y_s0_x");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "(grad_y_s0_x + 1)");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "(grad_y_s0_x + -1)");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "grad_y_s0_x");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "(grad_y_s0_x + 1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "(grad_y_s0_x + -1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "(grad_y_s0_x + 1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "grad_y_s0_x");
@@ -6674,8 +6104,8 @@ prog harris_sch7_bigtile() {
 
 //consuming grad_y.stencil
 ////producing lxy.stencil
-  auto lxy_s0_y = prg.add_loop("lxy_s0_y", -2, 124);
-  auto lxy_s0_x = lxy_s0_y->add_loop("lxy_s0_x", -2, 124);
+  auto lxy_s0_y = prg.add_loop("lxy_s0_y", -66, 60);
+  auto lxy_s0_x = lxy_s0_y->add_loop("lxy_s0_x", -66, 60);
 
 //store is: lxy.stencil(lxy_s0_x, lxy_s0_y) = ((grad_x.stencil(lxy_s0_x, lxy_s0_y)*grad_y.stencil(lxy_s0_x, lxy_s0_y))/(int16)64)
   auto hcompute_lxy_stencil = lxy_s0_x->add_op("op_hcompute_lxy_stencil");
@@ -6687,16 +6117,16 @@ prog harris_sch7_bigtile() {
 
 //consuming lxy.stencil
 ////producing lgxy.stencil
-  auto lgxy_s0_y = prg.add_loop("lgxy_s0_y", -1, 123);
-  auto lgxy_s0_x = lgxy_s0_y->add_loop("lgxy_s0_x", -1, 123);
+  auto lgxy_s0_y = prg.add_loop("lgxy_s0_y", -65, 59);
+  auto lgxy_s0_x = lgxy_s0_y->add_loop("lgxy_s0_x", -65, 59);
 
 //store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
   auto hcompute_lgxy_stencil = lgxy_s0_x->add_op("op_hcompute_lgxy_stencil");
   hcompute_lgxy_stencil->add_function("hcompute_lgxy_stencil");
   prg.buffer_port_widths["lgxy_stencil"] = 16;
   hcompute_lgxy_stencil->add_store("lgxy_stencil", "lgxy_s0_y", "lgxy_s0_x");
-  auto lgxy_s1_y = prg.add_loop("lgxy_s1_y", -1, 123);
-  auto lgxy_s1_x = lgxy_s1_y->add_loop("lgxy_s1_x", -1, 123);
+  auto lgxy_s1_y = prg.add_loop("lgxy_s1_y", -65, 59);
+  auto lgxy_s1_x = lgxy_s1_y->add_loop("lgxy_s1_x", -65, 59);
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + -1)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + -1), lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + 1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + 1)) + lxy.stencil(lgxy_s1_x, (lgxy_s1_y + 1)))))))))))
   auto hcompute_lgxy_stencil_1 = lgxy_s1_x->add_op("op_hcompute_lgxy_stencil_1");
@@ -6715,8 +6145,8 @@ prog harris_sch7_bigtile() {
 
 //consuming lgxy.stencil
 ////producing lyy.stencil
-  auto lyy_s0_y = prg.add_loop("lyy_s0_y", -2, 124);
-  auto lyy_s0_x = lyy_s0_y->add_loop("lyy_s0_x", -2, 124);
+  auto lyy_s0_y = prg.add_loop("lyy_s0_y", -66, 60);
+  auto lyy_s0_x = lyy_s0_y->add_loop("lyy_s0_x", -66, 60);
 
 //store is: lyy.stencil(lyy_s0_x, lyy_s0_y) = ((grad_y.stencil(lyy_s0_x, lyy_s0_y)*grad_y.stencil(lyy_s0_x, lyy_s0_y))/(int16)64)
   auto hcompute_lyy_stencil = lyy_s0_x->add_op("op_hcompute_lyy_stencil");
@@ -6727,16 +6157,16 @@ prog harris_sch7_bigtile() {
 
 //consuming lyy.stencil
 ////producing lgyy.stencil
-  auto lgyy_s0_y = prg.add_loop("lgyy_s0_y", -1, 123);
-  auto lgyy_s0_x = lgyy_s0_y->add_loop("lgyy_s0_x", -1, 123);
+  auto lgyy_s0_y = prg.add_loop("lgyy_s0_y", -65, 59);
+  auto lgyy_s0_x = lgyy_s0_y->add_loop("lgyy_s0_x", -65, 59);
 
 //store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
   auto hcompute_lgyy_stencil = lgyy_s0_x->add_op("op_hcompute_lgyy_stencil");
   hcompute_lgyy_stencil->add_function("hcompute_lgyy_stencil");
   prg.buffer_port_widths["lgyy_stencil"] = 16;
   hcompute_lgyy_stencil->add_store("lgyy_stencil", "lgyy_s0_y", "lgyy_s0_x");
-  auto lgyy_s1_y = prg.add_loop("lgyy_s1_y", -1, 123);
-  auto lgyy_s1_x = lgyy_s1_y->add_loop("lgyy_s1_x", -1, 123);
+  auto lgyy_s1_y = prg.add_loop("lgyy_s1_y", -65, 59);
+  auto lgyy_s1_x = lgyy_s1_y->add_loop("lgyy_s1_x", -65, 59);
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + -1)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + -1), lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + 1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + 1)) + lyy.stencil(lgyy_s1_x, (lgyy_s1_y + 1)))))))))))
   auto hcompute_lgyy_stencil_1 = lgyy_s1_x->add_op("op_hcompute_lgyy_stencil_1");
@@ -6755,8 +6185,8 @@ prog harris_sch7_bigtile() {
 
 //consuming lgyy.stencil
 ////producing cim.stencil
-  auto cim_s0_y = prg.add_loop("cim_s0_y", -1, 123);
-  auto cim_s0_x = cim_s0_y->add_loop("cim_s0_x", -1, 123);
+  auto cim_s0_y = prg.add_loop("cim_s0_y", -65, 59);
+  auto cim_s0_x = cim_s0_y->add_loop("cim_s0_x", -65, 59);
 
 //store is: cim.stencil(cim_s0_x, cim_s0_y) = ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)) - ((lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64))) - ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64))*((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)))/(int16)16))
   auto hcompute_cim_stencil = cim_s0_x->add_op("op_hcompute_cim_stencil");
@@ -6769,8 +6199,8 @@ prog harris_sch7_bigtile() {
 
 //consuming cim.stencil
 ////producing cim_output.stencil
-  auto cim_output_s0_y = prg.add_loop("cim_output_s0_y", 0, 122);
-  auto cim_output_s0_x = cim_output_s0_y->add_loop("cim_output_s0_x", 0, 122);
+  auto cim_output_s0_y = prg.add_loop("cim_output_s0_y", -64, 58);
+  auto cim_output_s0_x = cim_output_s0_y->add_loop("cim_output_s0_x", -64, 58);
 
 //store is: cim_output.stencil(cim_output_s0_x, cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y)) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && ((int16)1 <= cim.stencil(cim_output_s0_x, cim_output_s0_y))), 255, 0))
   auto hcompute_cim_output_stencil = cim_output_s0_x->add_op("op_hcompute_cim_output_stencil");
@@ -6791,11 +6221,11 @@ prog harris_sch7_bigtile() {
   auto hw_output_s0_y_yi = prg.add_loop("hw_output_s0_y_yi", 0, 122);
   auto hw_output_s0_x_xi = hw_output_s0_y_yi->add_loop("hw_output_s0_x_xi", 0, 122);
 
-//store is: hw_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi) = cim_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi)
+//store is: hw_output.stencil((hw_output_s0_x_xi + -64), (hw_output_s0_y_yi + -64)) = cim_output.stencil((hw_output_s0_x_xi + -64), (hw_output_s0_y_yi + -64))
   auto hcompute_hw_output_stencil = hw_output_s0_x_xi->add_op("op_hcompute_hw_output_stencil");
   hcompute_hw_output_stencil->add_function("hcompute_hw_output_stencil");
-  hcompute_hw_output_stencil->add_load("cim_output_stencil", "hw_output_s0_y_yi", "hw_output_s0_x_xi");
-  hcompute_hw_output_stencil->add_store("hw_output_stencil", "hw_output_s0_y_yi", "hw_output_s0_x_xi");
+  hcompute_hw_output_stencil->add_load("cim_output_stencil", "(hw_output_s0_y_yi + -64)", "(hw_output_s0_x_xi + -64)");
+  hcompute_hw_output_stencil->add_store("hw_output_stencil", "(hw_output_s0_y_yi + -64)", "(hw_output_s0_x_xi + -64)");
 
   return prg;
 }
@@ -6812,85 +6242,6 @@ prog harris_sch8_endcim() {
   prg.add_output("cim_stencil");
   prg.buffer_port_widths["cim_stencil"] = 16;
 
-////producing kernel_x.stencil
-
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil = prg.add_op("op_hcompute_kernel_x_stencil");
-  hcompute_kernel_x_stencil->add_function("hcompute_kernel_x_stencil");
-  prg.buffer_port_widths["kernel_x_stencil"] = 16;
-  hcompute_kernel_x_stencil->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_1 = prg.add_op("op_hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_function("hcompute_kernel_x_stencil_1");
-  hcompute_kernel_x_stencil_1->add_store("kernel_x_stencil", "-1", "0");
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_x_stencil_2 = prg.add_op("op_hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_function("hcompute_kernel_x_stencil_2");
-  hcompute_kernel_x_stencil_2->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_3 = prg.add_op("op_hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_function("hcompute_kernel_x_stencil_3");
-  hcompute_kernel_x_stencil_3->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_4 = prg.add_op("op_hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_function("hcompute_kernel_x_stencil_4");
-  hcompute_kernel_x_stencil_4->add_store("kernel_x_stencil", "0", "0");
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_x_stencil_5 = prg.add_op("op_hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_function("hcompute_kernel_x_stencil_5");
-  hcompute_kernel_x_stencil_5->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_6 = prg.add_op("op_hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_function("hcompute_kernel_x_stencil_6");
-  hcompute_kernel_x_stencil_6->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_7 = prg.add_op("op_hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_function("hcompute_kernel_x_stencil_7");
-  hcompute_kernel_x_stencil_7->add_store("kernel_x_stencil", "1", "0");
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_x_stencil_8 = prg.add_op("op_hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_function("hcompute_kernel_x_stencil_8");
-  hcompute_kernel_x_stencil_8->add_store("kernel_x_stencil", "1", "1");
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_x_stencil_9 = prg.add_op("op_hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_function("hcompute_kernel_x_stencil_9");
-  hcompute_kernel_x_stencil_9->add_store("kernel_x_stencil", "-1", "-1");
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-  auto hcompute_kernel_x_stencil_10 = prg.add_op("op_hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_function("hcompute_kernel_x_stencil_10");
-  hcompute_kernel_x_stencil_10->add_store("kernel_x_stencil", "0", "-1");
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-  auto hcompute_kernel_x_stencil_11 = prg.add_op("op_hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_function("hcompute_kernel_x_stencil_11");
-  hcompute_kernel_x_stencil_11->add_store("kernel_x_stencil", "1", "-1");
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-  auto hcompute_kernel_x_stencil_12 = prg.add_op("op_hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_function("hcompute_kernel_x_stencil_12");
-  hcompute_kernel_x_stencil_12->add_store("kernel_x_stencil", "-1", "1");
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-  auto hcompute_kernel_x_stencil_13 = prg.add_op("op_hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_function("hcompute_kernel_x_stencil_13");
-  hcompute_kernel_x_stencil_13->add_store("kernel_x_stencil", "0", "1");
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_x_stencil_14 = prg.add_op("op_hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_function("hcompute_kernel_x_stencil_14");
-  hcompute_kernel_x_stencil_14->add_store("kernel_x_stencil", "1", "1");
-
-//consuming kernel_x.stencil
 ////producing padded16_global_wrapper.stencil
   auto padded16_global_wrapper_s0_y = prg.add_loop("padded16_global_wrapper_s0_y", -3, 61);
   auto padded16_global_wrapper_s0_x = padded16_global_wrapper_s0_y->add_loop("padded16_global_wrapper_s0_x", -3, 61);
@@ -6914,28 +6265,16 @@ prog harris_sch8_endcim() {
   prg.buffer_port_widths["grad_x_unclamp_stencil"] = 16;
   hcompute_grad_x_unclamp_stencil->add_store("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
 
-//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + ((padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_x_s0_x, grad_x_s0_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + 1))*kernel_x.stencil(0, 1)))))))))))
+//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((((grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1)))
   auto hcompute_grad_x_unclamp_stencil_1 = grad_x_s0_x->add_op("op_hcompute_grad_x_unclamp_stencil_1");
   hcompute_grad_x_unclamp_stencil_1->add_function("hcompute_grad_x_unclamp_stencil_1");
   hcompute_grad_x_unclamp_stencil_1->add_load("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "-1", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "0", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "-1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "1");
-  hcompute_grad_x_unclamp_stencil_1->add_load("kernel_x_stencil", "1", "0");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + -1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "grad_x_s0_x");
   hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + -1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "grad_x_s0_x");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + -1)");
   hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + 1)");
-  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "grad_x_s0_x");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + 1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + -1)", "(grad_x_s0_x + -1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_x_s0_y", "(grad_x_s0_x + -1)");
+  hcompute_grad_x_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_x_s0_y + 1)", "(grad_x_s0_x + -1)");
   hcompute_grad_x_unclamp_stencil_1->add_store("grad_x_unclamp_stencil", "grad_x_s0_y", "grad_x_s0_x");
 
 //consuming grad_x_unclamp.stencil
@@ -6988,85 +6327,6 @@ prog harris_sch8_endcim() {
   hcompute_lgxx_stencil_1->add_store("lgxx_stencil", "lgxx_s1_y", "lgxx_s1_x");
 
 //consuming lgxx.stencil
-////producing kernel_y.stencil
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil = prg.add_op("op_hcompute_kernel_y_stencil");
-  hcompute_kernel_y_stencil->add_function("hcompute_kernel_y_stencil");
-  prg.buffer_port_widths["kernel_y_stencil"] = 16;
-  hcompute_kernel_y_stencil->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_1 = prg.add_op("op_hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_function("hcompute_kernel_y_stencil_1");
-  hcompute_kernel_y_stencil_1->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-  auto hcompute_kernel_y_stencil_2 = prg.add_op("op_hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_function("hcompute_kernel_y_stencil_2");
-  hcompute_kernel_y_stencil_2->add_store("kernel_y_stencil", "-1", "1");
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_3 = prg.add_op("op_hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_function("hcompute_kernel_y_stencil_3");
-  hcompute_kernel_y_stencil_3->add_store("kernel_y_stencil", "0", "-1");
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_4 = prg.add_op("op_hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_function("hcompute_kernel_y_stencil_4");
-  hcompute_kernel_y_stencil_4->add_store("kernel_y_stencil", "0", "0");
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-  auto hcompute_kernel_y_stencil_5 = prg.add_op("op_hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_function("hcompute_kernel_y_stencil_5");
-  hcompute_kernel_y_stencil_5->add_store("kernel_y_stencil", "0", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_6 = prg.add_op("op_hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_function("hcompute_kernel_y_stencil_6");
-  hcompute_kernel_y_stencil_6->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_7 = prg.add_op("op_hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_function("hcompute_kernel_y_stencil_7");
-  hcompute_kernel_y_stencil_7->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-  auto hcompute_kernel_y_stencil_8 = prg.add_op("op_hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_function("hcompute_kernel_y_stencil_8");
-  hcompute_kernel_y_stencil_8->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_9 = prg.add_op("op_hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_function("hcompute_kernel_y_stencil_9");
-  hcompute_kernel_y_stencil_9->add_store("kernel_y_stencil", "1", "-1");
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-  auto hcompute_kernel_y_stencil_10 = prg.add_op("op_hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_function("hcompute_kernel_y_stencil_10");
-  hcompute_kernel_y_stencil_10->add_store("kernel_y_stencil", "1", "0");
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-  auto hcompute_kernel_y_stencil_11 = prg.add_op("op_hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_function("hcompute_kernel_y_stencil_11");
-  hcompute_kernel_y_stencil_11->add_store("kernel_y_stencil", "1", "1");
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_12 = prg.add_op("op_hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_function("hcompute_kernel_y_stencil_12");
-  hcompute_kernel_y_stencil_12->add_store("kernel_y_stencil", "-1", "-1");
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-  auto hcompute_kernel_y_stencil_13 = prg.add_op("op_hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_function("hcompute_kernel_y_stencil_13");
-  hcompute_kernel_y_stencil_13->add_store("kernel_y_stencil", "-1", "0");
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-  auto hcompute_kernel_y_stencil_14 = prg.add_op("op_hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_function("hcompute_kernel_y_stencil_14");
-  hcompute_kernel_y_stencil_14->add_store("kernel_y_stencil", "-1", "1");
-
-//consuming kernel_y.stencil
 ////producing grad_y.stencil
   auto grad_y_s0_y = prg.add_loop("grad_y_s0_y", -2, 60);
   auto grad_y_s0_x = grad_y_s0_y->add_loop("grad_y_s0_x", -2, 60);
@@ -7078,25 +6338,13 @@ prog harris_sch8_endcim() {
   prg.buffer_port_widths["grad_y_unclamp_stencil"] = 16;
   hcompute_grad_y_unclamp_stencil->add_store("grad_y_unclamp_stencil", "grad_y_s0_y", "grad_y_s0_x");
 
-//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + ((padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), grad_y_s0_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_y_s0_x, grad_y_s0_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), grad_y_s0_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*kernel_y.stencil(0, 1)))))))))))
+//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((((grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))) - (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1)))
   auto hcompute_grad_y_unclamp_stencil_1 = grad_y_s0_x->add_op("op_hcompute_grad_y_unclamp_stencil_1");
   hcompute_grad_y_unclamp_stencil_1->add_function("hcompute_grad_y_unclamp_stencil_1");
   hcompute_grad_y_unclamp_stencil_1->add_load("grad_y_unclamp_stencil", "grad_y_s0_y", "grad_y_s0_x");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "0");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "-1", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "0");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "0", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "-1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "1");
-  hcompute_grad_y_unclamp_stencil_1->add_load("kernel_y_stencil", "1", "0");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "(grad_y_s0_x + -1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "grad_y_s0_x");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + -1)", "(grad_y_s0_x + 1)");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "(grad_y_s0_x + -1)");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "grad_y_s0_x");
-  hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "grad_y_s0_y", "(grad_y_s0_x + 1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "(grad_y_s0_x + -1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "(grad_y_s0_x + 1)");
   hcompute_grad_y_unclamp_stencil_1->add_load("padded16_global_wrapper_stencil", "(grad_y_s0_y + 1)", "grad_y_s0_x");

--- a/harris_sch5_1ppc_compute.h
+++ b/harris_sch5_1ppc_compute.h
@@ -3,96 +3,6 @@
 #include "clockwork_standard_compute_units.h"
 
 
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil() {
-  int16_t _260 = (int16_t)(0);
-  return _260;
-}
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_1() {
-  int16_t _263 = (int16_t)(0);
-  return _263;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_2() {
-  int16_t _266 = (int16_t)(0);
-  return _266;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_3() {
-  int16_t _269 = (int16_t)(0);
-  return _269;
-}
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_4() {
-  int16_t _272 = (int16_t)(0);
-  return _272;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_5() {
-  int16_t _275 = (int16_t)(0);
-  return _275;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_6() {
-  int16_t _278 = (int16_t)(0);
-  return _278;
-}
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_7() {
-  int16_t _281 = (int16_t)(0);
-  return _281;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_8() {
-  int16_t _284 = (int16_t)(0);
-  return _284;
-}
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_9() {
-  int16_t _287 = (int16_t)(-1);
-  return _287;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-hw_uint<16> hcompute_kernel_x_stencil_10() {
-  int16_t _290 = (int16_t)(-2);
-  return _290;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_11() {
-  int16_t _293 = (int16_t)(-1);
-  return _293;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_12() {
-  int16_t _296 = (int16_t)(1);
-  return _296;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-hw_uint<16> hcompute_kernel_x_stencil_13() {
-  int16_t _299 = (int16_t)(2);
-  return _299;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_14() {
-  int16_t _302 = (int16_t)(1);
-  return _302;
-}
-
 //store is: padded16_global_wrapper.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y) = padded16.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y)
 hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stencil) {
   int16_t _padded16_stencil_1 = (int16_t) padded16_stencil.extract<0, 15>();
@@ -102,23 +12,13 @@ hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stenc
 
 //store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_x_unclamp_stencil() {
-  int16_t _306 = (int16_t)(0);
-  return _306;
+  int16_t _261 = (int16_t)(0);
+  return _261;
 }
 
-//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + ((padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_x_s0_x, grad_x_s0_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + 1))*kernel_x.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<144>& kernel_x_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((((grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1)))
+hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_1 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_x_stencil_1 = (int16_t) kernel_x_stencil.extract<0, 15>();
-  int16_t _kernel_x_stencil_2 = (int16_t) kernel_x_stencil.extract<16, 31>();
-  int16_t _kernel_x_stencil_3 = (int16_t) kernel_x_stencil.extract<32, 47>();
-  int16_t _kernel_x_stencil_4 = (int16_t) kernel_x_stencil.extract<48, 63>();
-  int16_t _kernel_x_stencil_5 = (int16_t) kernel_x_stencil.extract<64, 79>();
-  int16_t _kernel_x_stencil_6 = (int16_t) kernel_x_stencil.extract<80, 95>();
-  int16_t _kernel_x_stencil_7 = (int16_t) kernel_x_stencil.extract<96, 111>();
-  int16_t _kernel_x_stencil_8 = (int16_t) kernel_x_stencil.extract<112, 127>();
-  int16_t _kernel_x_stencil_9 = (int16_t) kernel_x_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_1 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_2 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
@@ -126,56 +26,44 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stenci
   int16_t _padded16_global_wrapper_stencil_4 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
   int16_t _padded16_global_wrapper_stencil_5 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
   int16_t _padded16_global_wrapper_stencil_6 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
 
-  int16_t _309 = _padded16_global_wrapper_stencil_1 * _kernel_x_stencil_1;
-  int16_t _310 = _padded16_global_wrapper_stencil_2 * _kernel_x_stencil_2;
-  int16_t _311 = _padded16_global_wrapper_stencil_3 * _kernel_x_stencil_3;
-  int16_t _312 = _padded16_global_wrapper_stencil_4 * _kernel_x_stencil_4;
-  int16_t _313 = _padded16_global_wrapper_stencil_5 * _kernel_x_stencil_5;
-  int16_t _314 = _padded16_global_wrapper_stencil_6 * _kernel_x_stencil_6;
-  int16_t _315 = _padded16_global_wrapper_stencil_7 * _kernel_x_stencil_7;
-  int16_t _316 = _padded16_global_wrapper_stencil_8 * _kernel_x_stencil_8;
-  int16_t _317 = _padded16_global_wrapper_stencil_9 * _kernel_x_stencil_9;
-  int16_t _318 = _316 + _317;
-  int16_t _319 = _315 + _318;
-  int16_t _320 = _314 + _319;
-  int16_t _321 = _313 + _320;
-  int16_t _322 = _312 + _321;
-  int16_t _323 = _311 + _322;
-  int16_t _324 = _310 + _323;
-  int16_t _325 = _grad_x_unclamp_stencil_1 + _324;
-  int16_t _326 = _309 + _325;
-  return _326;
+  int16_t _264 = (int16_t)(2);
+  int16_t _265 = _padded16_global_wrapper_stencil_3 * _264;
+  int16_t _266 = _padded16_global_wrapper_stencil_2 + _265;
+  int16_t _267 = _padded16_global_wrapper_stencil_1 + _266;
+  int16_t _268 = _grad_x_unclamp_stencil_1 + _267;
+  int16_t _269 = _268 - _padded16_global_wrapper_stencil_4;
+  int16_t _270 = _padded16_global_wrapper_stencil_5 * _264;
+  int16_t _271 = _269 - _270;
+  int16_t _272 = _271 - _padded16_global_wrapper_stencil_6;
+  return _272;
 }
 
 //store is: grad_x.stencil(grad_x_s0_x, grad_x_s0_y) = max(min(grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y), (int16)180), (int16)-180)
 hw_uint<16> hcompute_grad_x_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _386 = (int16_t)(180);
-  int16_t _387 = min(_grad_x_unclamp_stencil_2, _386);
-  int16_t _388 = (int16_t)(-180);
-  int16_t _389 = max(_387, _388);
-  return _389;
+  int16_t _302 = (int16_t)(180);
+  int16_t _303 = min(_grad_x_unclamp_stencil_2, _302);
+  int16_t _304 = (int16_t)(-180);
+  int16_t _305 = max(_303, _304);
+  return _305;
 }
 
 //store is: lxx.stencil(lxx_s0_x, lxx_s0_y) = ((grad_x.stencil(lxx_s0_x, lxx_s0_y)*grad_x.stencil(lxx_s0_x, lxx_s0_y))/(int16)64)
 hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_stencil) {
   int16_t _grad_x_stencil_1 = (int16_t) grad_x_stencil.extract<0, 15>();
 
-  int16_t _399 = _grad_x_stencil_1 * _grad_x_stencil_1;
-  int16_t _400 = (int16_t)(6);
-  int16_t _401 = _399 >> _400;
-  return _401;
+  int16_t _315 = _grad_x_stencil_1 * _grad_x_stencil_1;
+  int16_t _316 = (int16_t)(6);
+  int16_t _317 = _315 >> _316;
+  return _317;
 }
 
 //store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _409 = (int16_t)(0);
-  return _409;
+  int16_t _325 = (int16_t)(0);
+  return _325;
 }
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + -1)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + -1), lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + 1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + 1)) + lxx.stencil(lgxx_s1_x, (lgxx_s1_y + 1)))))))))))
@@ -192,168 +80,56 @@ hw_uint<16> hcompute_lgxx_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx
   int16_t _lxx_stencil_8 = (int16_t) lxx_stencil.extract<112, 127>();
   int16_t _lxx_stencil_9 = (int16_t) lxx_stencil.extract<128, 143>();
 
-  int16_t _412 = _lxx_stencil_8 + _lxx_stencil_9;
-  int16_t _413 = _lxx_stencil_7 + _412;
-  int16_t _414 = _lxx_stencil_6 + _413;
-  int16_t _415 = _lxx_stencil_5 + _414;
-  int16_t _416 = _lxx_stencil_4 + _415;
-  int16_t _417 = _lxx_stencil_3 + _416;
-  int16_t _418 = _lxx_stencil_2 + _417;
-  int16_t _419 = _lgxx_stencil_1 + _418;
-  int16_t _420 = _lxx_stencil_1 + _419;
-  return _420;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil() {
-  int16_t _453 = (int16_t)(0);
-  return _453;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_1() {
-  int16_t _456 = (int16_t)(0);
-  return _456;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_2() {
-  int16_t _459 = (int16_t)(0);
-  return _459;
-}
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_3() {
-  int16_t _462 = (int16_t)(0);
-  return _462;
-}
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_4() {
-  int16_t _465 = (int16_t)(0);
-  return _465;
-}
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_5() {
-  int16_t _468 = (int16_t)(0);
-  return _468;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_6() {
-  int16_t _471 = (int16_t)(0);
-  return _471;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_7() {
-  int16_t _474 = (int16_t)(0);
-  return _474;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_8() {
-  int16_t _477 = (int16_t)(0);
-  return _477;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_9() {
-  int16_t _480 = (int16_t)(1);
-  return _480;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-hw_uint<16> hcompute_kernel_y_stencil_10() {
-  int16_t _483 = (int16_t)(2);
-  return _483;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_11() {
-  int16_t _486 = (int16_t)(1);
-  return _486;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_12() {
-  int16_t _489 = (int16_t)(-1);
-  return _489;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-hw_uint<16> hcompute_kernel_y_stencil_13() {
-  int16_t _492 = (int16_t)(-2);
-  return _492;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_14() {
-  int16_t _495 = (int16_t)(-1);
-  return _495;
+  int16_t _328 = _lxx_stencil_8 + _lxx_stencil_9;
+  int16_t _329 = _lxx_stencil_7 + _328;
+  int16_t _330 = _lxx_stencil_6 + _329;
+  int16_t _331 = _lxx_stencil_5 + _330;
+  int16_t _332 = _lxx_stencil_4 + _331;
+  int16_t _333 = _lxx_stencil_3 + _332;
+  int16_t _334 = _lxx_stencil_2 + _333;
+  int16_t _335 = _lgxx_stencil_1 + _334;
+  int16_t _336 = _lxx_stencil_1 + _335;
+  return _336;
 }
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil() {
-  int16_t _498 = (int16_t)(0);
-  return _498;
+  int16_t _369 = (int16_t)(0);
+  return _369;
 }
 
-//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + ((padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), grad_y_s0_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_y_s0_x, grad_y_s0_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), grad_y_s0_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*kernel_y.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<144>& kernel_y_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((((grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))) - (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1)))
+hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_y_unclamp_stencil_1 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_y_stencil_1 = (int16_t) kernel_y_stencil.extract<0, 15>();
-  int16_t _kernel_y_stencil_2 = (int16_t) kernel_y_stencil.extract<16, 31>();
-  int16_t _kernel_y_stencil_3 = (int16_t) kernel_y_stencil.extract<32, 47>();
-  int16_t _kernel_y_stencil_4 = (int16_t) kernel_y_stencil.extract<48, 63>();
-  int16_t _kernel_y_stencil_5 = (int16_t) kernel_y_stencil.extract<64, 79>();
-  int16_t _kernel_y_stencil_6 = (int16_t) kernel_y_stencil.extract<80, 95>();
-  int16_t _kernel_y_stencil_7 = (int16_t) kernel_y_stencil.extract<96, 111>();
-  int16_t _kernel_y_stencil_8 = (int16_t) kernel_y_stencil.extract<112, 127>();
-  int16_t _kernel_y_stencil_9 = (int16_t) kernel_y_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
   int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_13 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_14 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_15 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_16 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_17 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_18 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
+  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
 
-  int16_t _501 = _padded16_global_wrapper_stencil_10 * _kernel_y_stencil_1;
-  int16_t _502 = _padded16_global_wrapper_stencil_11 * _kernel_y_stencil_2;
-  int16_t _503 = _padded16_global_wrapper_stencil_12 * _kernel_y_stencil_3;
-  int16_t _504 = _padded16_global_wrapper_stencil_13 * _kernel_y_stencil_4;
-  int16_t _505 = _padded16_global_wrapper_stencil_14 * _kernel_y_stencil_5;
-  int16_t _506 = _padded16_global_wrapper_stencil_15 * _kernel_y_stencil_6;
-  int16_t _507 = _padded16_global_wrapper_stencil_16 * _kernel_y_stencil_7;
-  int16_t _508 = _padded16_global_wrapper_stencil_17 * _kernel_y_stencil_8;
-  int16_t _509 = _padded16_global_wrapper_stencil_18 * _kernel_y_stencil_9;
-  int16_t _510 = _508 + _509;
-  int16_t _511 = _507 + _510;
-  int16_t _512 = _506 + _511;
-  int16_t _513 = _505 + _512;
-  int16_t _514 = _504 + _513;
-  int16_t _515 = _503 + _514;
-  int16_t _516 = _502 + _515;
-  int16_t _517 = _grad_y_unclamp_stencil_1 + _516;
-  int16_t _518 = _501 + _517;
-  return _518;
+  int16_t _372 = (int16_t)(2);
+  int16_t _373 = _padded16_global_wrapper_stencil_9 * _372;
+  int16_t _374 = _padded16_global_wrapper_stencil_8 + _373;
+  int16_t _375 = _padded16_global_wrapper_stencil_7 + _374;
+  int16_t _376 = _grad_y_unclamp_stencil_1 + _375;
+  int16_t _377 = _376 - _padded16_global_wrapper_stencil_10;
+  int16_t _378 = _padded16_global_wrapper_stencil_11 * _372;
+  int16_t _379 = _377 - _378;
+  int16_t _380 = _379 - _padded16_global_wrapper_stencil_12;
+  return _380;
 }
 
 //store is: grad_y.stencil(grad_y_s0_x, grad_y_s0_y) = max(min(grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y), (int16)180), (int16)-180)
 hw_uint<16> hcompute_grad_y_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _578 = (int16_t)(180);
-  int16_t _579 = min(_grad_y_unclamp_stencil_2, _578);
-  int16_t _580 = (int16_t)(-180);
-  int16_t _581 = max(_579, _580);
-  return _581;
+  int16_t _410 = (int16_t)(180);
+  int16_t _411 = min(_grad_y_unclamp_stencil_2, _410);
+  int16_t _412 = (int16_t)(-180);
+  int16_t _413 = max(_411, _412);
+  return _413;
 }
 
 //store is: lxy.stencil(lxy_s0_x, lxy_s0_y) = ((grad_x.stencil(lxy_s0_x, lxy_s0_y)*grad_y.stencil(lxy_s0_x, lxy_s0_y))/(int16)64)
@@ -362,16 +138,16 @@ hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_stencil, hw_uint<16>& grad_
 
   int16_t _grad_y_stencil_1 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _591 = _grad_x_stencil_2 * _grad_y_stencil_1;
-  int16_t _592 = (int16_t)(6);
-  int16_t _593 = _591 >> _592;
-  return _593;
+  int16_t _423 = _grad_x_stencil_2 * _grad_y_stencil_1;
+  int16_t _424 = (int16_t)(6);
+  int16_t _425 = _423 >> _424;
+  return _425;
 }
 
 //store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _602 = (int16_t)(0);
-  return _602;
+  int16_t _434 = (int16_t)(0);
+  return _434;
 }
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + -1)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + -1), lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + 1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + 1)) + lxy.stencil(lgxy_s1_x, (lgxy_s1_y + 1)))))))))))
@@ -388,32 +164,32 @@ hw_uint<16> hcompute_lgxy_stencil_1(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy
   int16_t _lxy_stencil_8 = (int16_t) lxy_stencil.extract<112, 127>();
   int16_t _lxy_stencil_9 = (int16_t) lxy_stencil.extract<128, 143>();
 
-  int16_t _605 = _lxy_stencil_8 + _lxy_stencil_9;
-  int16_t _606 = _lxy_stencil_7 + _605;
-  int16_t _607 = _lxy_stencil_6 + _606;
-  int16_t _608 = _lxy_stencil_5 + _607;
-  int16_t _609 = _lxy_stencil_4 + _608;
-  int16_t _610 = _lxy_stencil_3 + _609;
-  int16_t _611 = _lxy_stencil_2 + _610;
-  int16_t _612 = _lgxy_stencil_1 + _611;
-  int16_t _613 = _lxy_stencil_1 + _612;
-  return _613;
+  int16_t _437 = _lxy_stencil_8 + _lxy_stencil_9;
+  int16_t _438 = _lxy_stencil_7 + _437;
+  int16_t _439 = _lxy_stencil_6 + _438;
+  int16_t _440 = _lxy_stencil_5 + _439;
+  int16_t _441 = _lxy_stencil_4 + _440;
+  int16_t _442 = _lxy_stencil_3 + _441;
+  int16_t _443 = _lxy_stencil_2 + _442;
+  int16_t _444 = _lgxy_stencil_1 + _443;
+  int16_t _445 = _lxy_stencil_1 + _444;
+  return _445;
 }
 
 //store is: lyy.stencil(lyy_s0_x, lyy_s0_y) = ((grad_y.stencil(lyy_s0_x, lyy_s0_y)*grad_y.stencil(lyy_s0_x, lyy_s0_y))/(int16)64)
 hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_stencil) {
   int16_t _grad_y_stencil_2 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _646 = _grad_y_stencil_2 * _grad_y_stencil_2;
-  int16_t _647 = (int16_t)(6);
-  int16_t _648 = _646 >> _647;
-  return _648;
+  int16_t _478 = _grad_y_stencil_2 * _grad_y_stencil_2;
+  int16_t _479 = (int16_t)(6);
+  int16_t _480 = _478 >> _479;
+  return _480;
 }
 
 //store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _656 = (int16_t)(0);
-  return _656;
+  int16_t _488 = (int16_t)(0);
+  return _488;
 }
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + -1)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + -1), lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + 1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + 1)) + lyy.stencil(lgyy_s1_x, (lgyy_s1_y + 1)))))))))))
@@ -430,16 +206,16 @@ hw_uint<16> hcompute_lgyy_stencil_1(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy
   int16_t _lyy_stencil_8 = (int16_t) lyy_stencil.extract<112, 127>();
   int16_t _lyy_stencil_9 = (int16_t) lyy_stencil.extract<128, 143>();
 
-  int16_t _659 = _lyy_stencil_8 + _lyy_stencil_9;
-  int16_t _660 = _lyy_stencil_7 + _659;
-  int16_t _661 = _lyy_stencil_6 + _660;
-  int16_t _662 = _lyy_stencil_5 + _661;
-  int16_t _663 = _lyy_stencil_4 + _662;
-  int16_t _664 = _lyy_stencil_3 + _663;
-  int16_t _665 = _lyy_stencil_2 + _664;
-  int16_t _666 = _lgyy_stencil_1 + _665;
-  int16_t _667 = _lyy_stencil_1 + _666;
-  return _667;
+  int16_t _491 = _lyy_stencil_8 + _lyy_stencil_9;
+  int16_t _492 = _lyy_stencil_7 + _491;
+  int16_t _493 = _lyy_stencil_6 + _492;
+  int16_t _494 = _lyy_stencil_5 + _493;
+  int16_t _495 = _lyy_stencil_4 + _494;
+  int16_t _496 = _lyy_stencil_3 + _495;
+  int16_t _497 = _lyy_stencil_2 + _496;
+  int16_t _498 = _lgyy_stencil_1 + _497;
+  int16_t _499 = _lyy_stencil_1 + _498;
+  return _499;
 }
 
 //store is: cim.stencil(cim_s0_x, cim_s0_y) = ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)) - ((lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64))) - ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64))*((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)))/(int16)16))
@@ -450,19 +226,19 @@ hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_st
 
   int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _700 = (int16_t)(6);
-  int16_t _701 = _lgxx_stencil_2 >> _700;
-  int16_t _702 = _lgyy_stencil_2 >> _700;
-  int16_t _703 = _701 * _702;
-  int16_t _704 = _lgxy_stencil_2 >> _700;
-  int16_t _705 = _704 * _704;
-  int16_t _706 = _703 - _705;
-  int16_t _707 = _701 + _702;
-  int16_t _708 = _707 * _707;
-  int16_t _709 = (int16_t)(4);
-  int16_t _710 = _708 >> _709;
-  int16_t _711 = _706 - _710;
-  return _711;
+  int16_t _532 = (int16_t)(6);
+  int16_t _533 = _lgxx_stencil_2 >> _532;
+  int16_t _534 = _lgyy_stencil_2 >> _532;
+  int16_t _535 = _533 * _534;
+  int16_t _536 = _lgxy_stencil_2 >> _532;
+  int16_t _537 = _536 * _536;
+  int16_t _538 = _535 - _537;
+  int16_t _539 = _533 + _534;
+  int16_t _540 = _539 * _539;
+  int16_t _541 = (int16_t)(4);
+  int16_t _542 = _540 >> _541;
+  int16_t _543 = _538 - _542;
+  return _543;
 }
 
 //store is: cim_output.stencil(cim_output_s0_x, cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y)) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && ((int16)1 <= cim.stencil(cim_output_s0_x, cim_output_s0_y))), 255, 0))
@@ -477,27 +253,27 @@ hw_uint<16> hcompute_cim_output_stencil(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_8 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_9 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _739 = _cim_stencil_1 < _cim_stencil_2;
-  bool _740 = _cim_stencil_3 < _cim_stencil_2;
-  bool _741 = _739 && _740;
-  bool _742 = _cim_stencil_4 < _cim_stencil_2;
-  bool _743 = _741 && _742;
-  bool _744 = _cim_stencil_5 < _cim_stencil_2;
-  bool _745 = _743 && _744;
-  bool _746 = _cim_stencil_6 < _cim_stencil_2;
-  bool _747 = _745 && _746;
-  bool _748 = _cim_stencil_7 < _cim_stencil_2;
-  bool _749 = _747 && _748;
-  bool _750 = _cim_stencil_8 < _cim_stencil_2;
-  bool _751 = _749 && _750;
-  bool _752 = _cim_stencil_9 < _cim_stencil_2;
-  bool _753 = _751 && _752;
-  int16_t _754 = (int16_t)(1);
-  bool _755 = _754 <= _cim_stencil_2;
-  bool _756 = _753 && _755;
-  int32_t _757 = (int32_t)(_756 ? 255 : 0);
-  int16_t _758 = (int16_t)(_757);
-  return _758;
+  bool _571 = _cim_stencil_1 < _cim_stencil_2;
+  bool _572 = _cim_stencil_3 < _cim_stencil_2;
+  bool _573 = _571 && _572;
+  bool _574 = _cim_stencil_4 < _cim_stencil_2;
+  bool _575 = _573 && _574;
+  bool _576 = _cim_stencil_5 < _cim_stencil_2;
+  bool _577 = _575 && _576;
+  bool _578 = _cim_stencil_6 < _cim_stencil_2;
+  bool _579 = _577 && _578;
+  bool _580 = _cim_stencil_7 < _cim_stencil_2;
+  bool _581 = _579 && _580;
+  bool _582 = _cim_stencil_8 < _cim_stencil_2;
+  bool _583 = _581 && _582;
+  bool _584 = _cim_stencil_9 < _cim_stencil_2;
+  bool _585 = _583 && _584;
+  int16_t _586 = (int16_t)(1);
+  bool _587 = _586 <= _cim_stencil_2;
+  bool _588 = _585 && _587;
+  int32_t _589 = (int32_t)(_588 ? 255 : 0);
+  int16_t _590 = (int16_t)(_589);
+  return _590;
 }
 
 //store is: hw_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi) = cim_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi)

--- a/harris_sch6_2ppc_compute.h
+++ b/harris_sch6_2ppc_compute.h
@@ -3,96 +3,6 @@
 #include "clockwork_standard_compute_units.h"
 
 
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil() {
-  int16_t _260 = (int16_t)(0);
-  return _260;
-}
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_1() {
-  int16_t _263 = (int16_t)(0);
-  return _263;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_2() {
-  int16_t _266 = (int16_t)(0);
-  return _266;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_3() {
-  int16_t _269 = (int16_t)(0);
-  return _269;
-}
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_4() {
-  int16_t _272 = (int16_t)(0);
-  return _272;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_5() {
-  int16_t _275 = (int16_t)(0);
-  return _275;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_6() {
-  int16_t _278 = (int16_t)(0);
-  return _278;
-}
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_7() {
-  int16_t _281 = (int16_t)(0);
-  return _281;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_8() {
-  int16_t _284 = (int16_t)(0);
-  return _284;
-}
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_9() {
-  int16_t _287 = (int16_t)(-1);
-  return _287;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-hw_uint<16> hcompute_kernel_x_stencil_10() {
-  int16_t _290 = (int16_t)(-2);
-  return _290;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_11() {
-  int16_t _293 = (int16_t)(-1);
-  return _293;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_12() {
-  int16_t _296 = (int16_t)(1);
-  return _296;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-hw_uint<16> hcompute_kernel_x_stencil_13() {
-  int16_t _299 = (int16_t)(2);
-  return _299;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_14() {
-  int16_t _302 = (int16_t)(1);
-  return _302;
-}
-
 //store is: padded16_global_wrapper.stencil(((padded16_global_wrapper_s0_x_x*2) + -3), padded16_global_wrapper_s0_y) = padded16.stencil(((padded16_global_wrapper_s0_x_x*2) + -3), padded16_global_wrapper_s0_y)
 hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stencil) {
   int16_t _padded16_stencil_1 = (int16_t) padded16_stencil.extract<0, 15>();
@@ -109,29 +19,19 @@ hw_uint<16> hcompute_padded16_global_wrapper_stencil_1(hw_uint<16>& padded16_ste
 
 //store is: grad_x_unclamp.stencil(((grad_x_unclamp_s0_x_x*2) + -2), grad_x_unclamp_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_x_unclamp_stencil() {
-  int16_t _311 = (int16_t)(0);
-  return _311;
+  int16_t _266 = (int16_t)(0);
+  return _266;
 }
 
 //store is: grad_x_unclamp.stencil(((grad_x_unclamp_s0_x_x*2) + -1), grad_x_unclamp_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_x_unclamp_stencil_1() {
-  int16_t _316 = (int16_t)(0);
-  return _316;
+  int16_t _271 = (int16_t)(0);
+  return _271;
 }
 
-//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), grad_x_unclamp_s1_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_x_unclamp_stencil_2(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<144>& kernel_x_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -3), (grad_x_unclamp_s1_y + 1)))
+hw_uint<16> hcompute_grad_x_unclamp_stencil_2(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_1 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_x_stencil_1 = (int16_t) kernel_x_stencil.extract<0, 15>();
-  int16_t _kernel_x_stencil_2 = (int16_t) kernel_x_stencil.extract<16, 31>();
-  int16_t _kernel_x_stencil_3 = (int16_t) kernel_x_stencil.extract<32, 47>();
-  int16_t _kernel_x_stencil_4 = (int16_t) kernel_x_stencil.extract<48, 63>();
-  int16_t _kernel_x_stencil_5 = (int16_t) kernel_x_stencil.extract<64, 79>();
-  int16_t _kernel_x_stencil_6 = (int16_t) kernel_x_stencil.extract<80, 95>();
-  int16_t _kernel_x_stencil_7 = (int16_t) kernel_x_stencil.extract<96, 111>();
-  int16_t _kernel_x_stencil_8 = (int16_t) kernel_x_stencil.extract<112, 127>();
-  int16_t _kernel_x_stencil_9 = (int16_t) kernel_x_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_1 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_2 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
@@ -139,114 +39,80 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_2(hw_uint<16>& grad_x_unclamp_stenci
   int16_t _padded16_global_wrapper_stencil_4 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
   int16_t _padded16_global_wrapper_stencil_5 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
   int16_t _padded16_global_wrapper_stencil_6 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
 
-  int16_t _321 = _padded16_global_wrapper_stencil_1 * _kernel_x_stencil_1;
-  int16_t _322 = _padded16_global_wrapper_stencil_2 * _kernel_x_stencil_2;
-  int16_t _323 = _padded16_global_wrapper_stencil_3 * _kernel_x_stencil_3;
-  int16_t _324 = _padded16_global_wrapper_stencil_4 * _kernel_x_stencil_4;
-  int16_t _325 = _padded16_global_wrapper_stencil_5 * _kernel_x_stencil_5;
-  int16_t _326 = _padded16_global_wrapper_stencil_6 * _kernel_x_stencil_6;
-  int16_t _327 = _padded16_global_wrapper_stencil_7 * _kernel_x_stencil_7;
-  int16_t _328 = _padded16_global_wrapper_stencil_8 * _kernel_x_stencil_8;
-  int16_t _329 = _padded16_global_wrapper_stencil_9 * _kernel_x_stencil_9;
-  int16_t _330 = _328 + _329;
-  int16_t _331 = _327 + _330;
-  int16_t _332 = _326 + _331;
-  int16_t _333 = _325 + _332;
-  int16_t _334 = _324 + _333;
-  int16_t _335 = _323 + _334;
-  int16_t _336 = _322 + _335;
-  int16_t _337 = _grad_x_unclamp_stencil_1 + _336;
-  int16_t _338 = _321 + _337;
-  return _338;
+  int16_t _276 = (int16_t)(2);
+  int16_t _277 = _padded16_global_wrapper_stencil_3 * _276;
+  int16_t _278 = _padded16_global_wrapper_stencil_2 + _277;
+  int16_t _279 = _padded16_global_wrapper_stencil_1 + _278;
+  int16_t _280 = _grad_x_unclamp_stencil_1 + _279;
+  int16_t _281 = _280 - _padded16_global_wrapper_stencil_4;
+  int16_t _282 = _padded16_global_wrapper_stencil_5 * _276;
+  int16_t _283 = _281 - _282;
+  int16_t _284 = _283 - _padded16_global_wrapper_stencil_6;
+  return _284;
 }
 
-//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), grad_x_unclamp_s1_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -1), (grad_x_unclamp_s1_y + 1))*kernel_x.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_x_unclamp_stencil_3(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<144>& kernel_x_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) = ((((grad_x_unclamp.stencil(((grad_x_unclamp_s1_x_x*2) + -1), grad_x_unclamp_s1_y) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + -1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), (grad_x_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_x_unclamp_s1_x_x*2), grad_x_unclamp_s1_y)*(int16)2)))) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), grad_x_unclamp_s1_y)*(int16)2)) - padded16_global_wrapper.stencil(((grad_x_unclamp_s1_x_x*2) + -2), (grad_x_unclamp_s1_y + 1)))
+hw_uint<16> hcompute_grad_x_unclamp_stencil_3(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_x_stencil_10 = (int16_t) kernel_x_stencil.extract<0, 15>();
-  int16_t _kernel_x_stencil_11 = (int16_t) kernel_x_stencil.extract<16, 31>();
-  int16_t _kernel_x_stencil_12 = (int16_t) kernel_x_stencil.extract<32, 47>();
-  int16_t _kernel_x_stencil_13 = (int16_t) kernel_x_stencil.extract<48, 63>();
-  int16_t _kernel_x_stencil_14 = (int16_t) kernel_x_stencil.extract<64, 79>();
-  int16_t _kernel_x_stencil_15 = (int16_t) kernel_x_stencil.extract<80, 95>();
-  int16_t _kernel_x_stencil_16 = (int16_t) kernel_x_stencil.extract<96, 111>();
-  int16_t _kernel_x_stencil_17 = (int16_t) kernel_x_stencil.extract<112, 127>();
-  int16_t _kernel_x_stencil_18 = (int16_t) kernel_x_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
   int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_13 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_14 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_15 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_16 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_17 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_18 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
+  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
 
-  int16_t _400 = _padded16_global_wrapper_stencil_10 * _kernel_x_stencil_10;
-  int16_t _401 = _padded16_global_wrapper_stencil_11 * _kernel_x_stencil_11;
-  int16_t _402 = _padded16_global_wrapper_stencil_12 * _kernel_x_stencil_12;
-  int16_t _403 = _padded16_global_wrapper_stencil_13 * _kernel_x_stencil_13;
-  int16_t _404 = _padded16_global_wrapper_stencil_14 * _kernel_x_stencil_14;
-  int16_t _405 = _padded16_global_wrapper_stencil_15 * _kernel_x_stencil_15;
-  int16_t _406 = _padded16_global_wrapper_stencil_16 * _kernel_x_stencil_16;
-  int16_t _407 = _padded16_global_wrapper_stencil_17 * _kernel_x_stencil_17;
-  int16_t _408 = _padded16_global_wrapper_stencil_18 * _kernel_x_stencil_18;
-  int16_t _409 = _407 + _408;
-  int16_t _410 = _406 + _409;
-  int16_t _411 = _405 + _410;
-  int16_t _412 = _404 + _411;
-  int16_t _413 = _403 + _412;
-  int16_t _414 = _402 + _413;
-  int16_t _415 = _401 + _414;
-  int16_t _416 = _grad_x_unclamp_stencil_2 + _415;
-  int16_t _417 = _400 + _416;
-  return _417;
+  int16_t _316 = (int16_t)(2);
+  int16_t _317 = _padded16_global_wrapper_stencil_9 * _316;
+  int16_t _318 = _padded16_global_wrapper_stencil_8 + _317;
+  int16_t _319 = _padded16_global_wrapper_stencil_7 + _318;
+  int16_t _320 = _grad_x_unclamp_stencil_2 + _319;
+  int16_t _321 = _320 - _padded16_global_wrapper_stencil_10;
+  int16_t _322 = _padded16_global_wrapper_stencil_11 * _316;
+  int16_t _323 = _321 - _322;
+  int16_t _324 = _323 - _padded16_global_wrapper_stencil_12;
+  return _324;
 }
 
 //store is: lxx.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)180), (int16)-180)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -2), lxx_s0_y), (int16)180), (int16)-180))/(int16)64)
 hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_3 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _478 = (int16_t)(180);
-  int16_t _479 = min(_grad_x_unclamp_stencil_3, _478);
-  int16_t _480 = (int16_t)(-180);
-  int16_t _481 = max(_479, _480);
-  int16_t _482 = _481 * _481;
-  int16_t _483 = (int16_t)(6);
-  int16_t _484 = _482 >> _483;
-  return _484;
+  int16_t _355 = (int16_t)(180);
+  int16_t _356 = min(_grad_x_unclamp_stencil_3, _355);
+  int16_t _357 = (int16_t)(-180);
+  int16_t _358 = max(_356, _357);
+  int16_t _359 = _358 * _358;
+  int16_t _360 = (int16_t)(6);
+  int16_t _361 = _359 >> _360;
+  return _361;
 }
 
 //store is: lxx.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)180), (int16)-180)*max(min(grad_x_unclamp.stencil(((lxx_s0_x_x*2) + -1), lxx_s0_y), (int16)180), (int16)-180))/(int16)64)
 hw_uint<16> hcompute_lxx_stencil_1(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_4 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _502 = (int16_t)(180);
-  int16_t _503 = min(_grad_x_unclamp_stencil_4, _502);
-  int16_t _504 = (int16_t)(-180);
-  int16_t _505 = max(_503, _504);
-  int16_t _506 = _505 * _505;
-  int16_t _507 = (int16_t)(6);
-  int16_t _508 = _506 >> _507;
-  return _508;
+  int16_t _379 = (int16_t)(180);
+  int16_t _380 = min(_grad_x_unclamp_stencil_4, _379);
+  int16_t _381 = (int16_t)(-180);
+  int16_t _382 = max(_380, _381);
+  int16_t _383 = _382 * _382;
+  int16_t _384 = (int16_t)(6);
+  int16_t _385 = _383 >> _384;
+  return _385;
 }
 
 //store is: lgxx.stencil(((lgxx_s0_x_x*2) + -1), lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _526 = (int16_t)(0);
-  return _526;
+  int16_t _403 = (int16_t)(0);
+  return _403;
 }
 
 //store is: lgxx.stencil((lgxx_s0_x_x*2), lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil_1() {
-  int16_t _531 = (int16_t)(0);
-  return _531;
+  int16_t _408 = (int16_t)(0);
+  return _408;
 }
 
 //store is: lgxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) = (lxx.stencil(((lgxx_s1_x_x*2) + -2), (lgxx_s1_y + -1)) + (lgxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + -2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -2), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + 1)) + lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + 1)))))))))))
@@ -263,16 +129,16 @@ hw_uint<16> hcompute_lgxx_stencil_2(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx
   int16_t _lxx_stencil_8 = (int16_t) lxx_stencil.extract<112, 127>();
   int16_t _lxx_stencil_9 = (int16_t) lxx_stencil.extract<128, 143>();
 
-  int16_t _535 = _lxx_stencil_8 + _lxx_stencil_9;
-  int16_t _536 = _lxx_stencil_7 + _535;
-  int16_t _537 = _lxx_stencil_6 + _536;
-  int16_t _538 = _lxx_stencil_5 + _537;
-  int16_t _539 = _lxx_stencil_4 + _538;
-  int16_t _540 = _lxx_stencil_3 + _539;
-  int16_t _541 = _lxx_stencil_2 + _540;
-  int16_t _542 = _lgxx_stencil_1 + _541;
-  int16_t _543 = _lxx_stencil_1 + _542;
-  return _543;
+  int16_t _412 = _lxx_stencil_8 + _lxx_stencil_9;
+  int16_t _413 = _lxx_stencil_7 + _412;
+  int16_t _414 = _lxx_stencil_6 + _413;
+  int16_t _415 = _lxx_stencil_5 + _414;
+  int16_t _416 = _lxx_stencil_4 + _415;
+  int16_t _417 = _lxx_stencil_3 + _416;
+  int16_t _418 = _lxx_stencil_2 + _417;
+  int16_t _419 = _lgxx_stencil_1 + _418;
+  int16_t _420 = _lxx_stencil_1 + _419;
+  return _420;
 }
 
 //store is: lgxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) = (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + -1)) + (lgxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), (lgxx_s1_y + -1)) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x_x*2), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), lgxx_s1_y) + (lxx.stencil(((lgxx_s1_x_x*2) + -1), (lgxx_s1_y + 1)) + (lxx.stencil(((lgxx_s1_x_x*2) + 1), (lgxx_s1_y + 1)) + lxx.stencil((lgxx_s1_x_x*2), (lgxx_s1_y + 1)))))))))))
@@ -289,133 +155,56 @@ hw_uint<16> hcompute_lgxx_stencil_3(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx
   int16_t _lxx_stencil_17 = (int16_t) lxx_stencil.extract<112, 127>();
   int16_t _lxx_stencil_18 = (int16_t) lxx_stencil.extract<128, 143>();
 
-  int16_t _577 = _lxx_stencil_17 + _lxx_stencil_18;
-  int16_t _578 = _lxx_stencil_16 + _577;
-  int16_t _579 = _lxx_stencil_15 + _578;
-  int16_t _580 = _lxx_stencil_14 + _579;
-  int16_t _581 = _lxx_stencil_13 + _580;
-  int16_t _582 = _lxx_stencil_12 + _581;
-  int16_t _583 = _lxx_stencil_11 + _582;
-  int16_t _584 = _lgxx_stencil_2 + _583;
-  int16_t _585 = _lxx_stencil_10 + _584;
-  return _585;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil() {
-  int16_t _619 = (int16_t)(0);
-  return _619;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_1() {
-  int16_t _622 = (int16_t)(0);
-  return _622;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_2() {
-  int16_t _625 = (int16_t)(0);
-  return _625;
-}
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_3() {
-  int16_t _628 = (int16_t)(0);
-  return _628;
-}
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_4() {
-  int16_t _631 = (int16_t)(0);
-  return _631;
-}
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_5() {
-  int16_t _634 = (int16_t)(0);
-  return _634;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_6() {
-  int16_t _637 = (int16_t)(0);
-  return _637;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_7() {
-  int16_t _640 = (int16_t)(0);
-  return _640;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_8() {
-  int16_t _643 = (int16_t)(0);
-  return _643;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_9() {
-  int16_t _646 = (int16_t)(1);
-  return _646;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-hw_uint<16> hcompute_kernel_y_stencil_10() {
-  int16_t _649 = (int16_t)(2);
-  return _649;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_11() {
-  int16_t _652 = (int16_t)(1);
-  return _652;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_12() {
-  int16_t _655 = (int16_t)(-1);
-  return _655;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-hw_uint<16> hcompute_kernel_y_stencil_13() {
-  int16_t _658 = (int16_t)(-2);
-  return _658;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_14() {
-  int16_t _661 = (int16_t)(-1);
-  return _661;
+  int16_t _454 = _lxx_stencil_17 + _lxx_stencil_18;
+  int16_t _455 = _lxx_stencil_16 + _454;
+  int16_t _456 = _lxx_stencil_15 + _455;
+  int16_t _457 = _lxx_stencil_14 + _456;
+  int16_t _458 = _lxx_stencil_13 + _457;
+  int16_t _459 = _lxx_stencil_12 + _458;
+  int16_t _460 = _lxx_stencil_11 + _459;
+  int16_t _461 = _lgxx_stencil_2 + _460;
+  int16_t _462 = _lxx_stencil_10 + _461;
+  return _462;
 }
 
 //store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -2), grad_y_unclamp_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil() {
-  int16_t _664 = (int16_t)(0);
-  return _664;
+  int16_t _496 = (int16_t)(0);
+  return _496;
 }
 
 //store is: grad_y_unclamp.stencil(((grad_y_unclamp_s0_x_x*2) + -1), grad_y_unclamp_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil_1() {
-  int16_t _669 = (int16_t)(0);
-  return _669;
+  int16_t _501 = (int16_t)(0);
+  return _501;
 }
 
-//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), grad_y_unclamp_s1_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_y_unclamp_stencil_2(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<144>& kernel_y_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -3), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1)))
+hw_uint<16> hcompute_grad_y_unclamp_stencil_2(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_y_unclamp_stencil_1 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _kernel_y_stencil_1 = (int16_t) kernel_y_stencil.extract<0, 15>();
-  int16_t _kernel_y_stencil_2 = (int16_t) kernel_y_stencil.extract<16, 31>();
-  int16_t _kernel_y_stencil_3 = (int16_t) kernel_y_stencil.extract<32, 47>();
-  int16_t _kernel_y_stencil_4 = (int16_t) kernel_y_stencil.extract<48, 63>();
-  int16_t _kernel_y_stencil_5 = (int16_t) kernel_y_stencil.extract<64, 79>();
-  int16_t _kernel_y_stencil_6 = (int16_t) kernel_y_stencil.extract<80, 95>();
-  int16_t _kernel_y_stencil_7 = (int16_t) kernel_y_stencil.extract<96, 111>();
-  int16_t _kernel_y_stencil_8 = (int16_t) kernel_y_stencil.extract<112, 127>();
-  int16_t _kernel_y_stencil_9 = (int16_t) kernel_y_stencil.extract<128, 143>();
+  int16_t _padded16_global_wrapper_stencil_13 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
+  int16_t _padded16_global_wrapper_stencil_14 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
+  int16_t _padded16_global_wrapper_stencil_15 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
+  int16_t _padded16_global_wrapper_stencil_16 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_17 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_18 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
+
+  int16_t _506 = (int16_t)(2);
+  int16_t _507 = _padded16_global_wrapper_stencil_15 * _506;
+  int16_t _508 = _padded16_global_wrapper_stencil_14 + _507;
+  int16_t _509 = _padded16_global_wrapper_stencil_13 + _508;
+  int16_t _510 = _grad_y_unclamp_stencil_1 + _509;
+  int16_t _511 = _510 - _padded16_global_wrapper_stencil_16;
+  int16_t _512 = _padded16_global_wrapper_stencil_17 * _506;
+  int16_t _513 = _511 - _512;
+  int16_t _514 = _513 - _padded16_global_wrapper_stencil_18;
+  return _514;
+}
+
+//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) = ((((grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))) - (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + -1)))
+hw_uint<16> hcompute_grad_y_unclamp_stencil_3(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
+  int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
   int16_t _padded16_global_wrapper_stencil_19 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_20 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
@@ -423,74 +212,17 @@ hw_uint<16> hcompute_grad_y_unclamp_stencil_2(hw_uint<16>& grad_y_unclamp_stenci
   int16_t _padded16_global_wrapper_stencil_22 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
   int16_t _padded16_global_wrapper_stencil_23 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
   int16_t _padded16_global_wrapper_stencil_24 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_25 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_26 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_27 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
 
-  int16_t _674 = _padded16_global_wrapper_stencil_19 * _kernel_y_stencil_1;
-  int16_t _675 = _padded16_global_wrapper_stencil_20 * _kernel_y_stencil_2;
-  int16_t _676 = _padded16_global_wrapper_stencil_21 * _kernel_y_stencil_3;
-  int16_t _677 = _padded16_global_wrapper_stencil_22 * _kernel_y_stencil_4;
-  int16_t _678 = _padded16_global_wrapper_stencil_23 * _kernel_y_stencil_5;
-  int16_t _679 = _padded16_global_wrapper_stencil_24 * _kernel_y_stencil_6;
-  int16_t _680 = _padded16_global_wrapper_stencil_25 * _kernel_y_stencil_7;
-  int16_t _681 = _padded16_global_wrapper_stencil_26 * _kernel_y_stencil_8;
-  int16_t _682 = _padded16_global_wrapper_stencil_27 * _kernel_y_stencil_9;
-  int16_t _683 = _681 + _682;
-  int16_t _684 = _680 + _683;
-  int16_t _685 = _679 + _684;
-  int16_t _686 = _678 + _685;
-  int16_t _687 = _677 + _686;
-  int16_t _688 = _676 + _687;
-  int16_t _689 = _675 + _688;
-  int16_t _690 = _grad_y_unclamp_stencil_1 + _689;
-  int16_t _691 = _674 + _690;
-  return _691;
-}
-
-//store is: grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) = ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), grad_y_unclamp_s1_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), grad_y_unclamp_s1_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), grad_y_unclamp_s1_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -2), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_unclamp_s1_x_x*2), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(((grad_y_unclamp_s1_x_x*2) + -1), (grad_y_unclamp_s1_y + 1))*kernel_y.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_y_unclamp_stencil_3(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<144>& kernel_y_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
-  int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_y_stencil_10 = (int16_t) kernel_y_stencil.extract<0, 15>();
-  int16_t _kernel_y_stencil_11 = (int16_t) kernel_y_stencil.extract<16, 31>();
-  int16_t _kernel_y_stencil_12 = (int16_t) kernel_y_stencil.extract<32, 47>();
-  int16_t _kernel_y_stencil_13 = (int16_t) kernel_y_stencil.extract<48, 63>();
-  int16_t _kernel_y_stencil_14 = (int16_t) kernel_y_stencil.extract<64, 79>();
-  int16_t _kernel_y_stencil_15 = (int16_t) kernel_y_stencil.extract<80, 95>();
-  int16_t _kernel_y_stencil_16 = (int16_t) kernel_y_stencil.extract<96, 111>();
-  int16_t _kernel_y_stencil_17 = (int16_t) kernel_y_stencil.extract<112, 127>();
-  int16_t _kernel_y_stencil_18 = (int16_t) kernel_y_stencil.extract<128, 143>();
-
-  int16_t _padded16_global_wrapper_stencil_28 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
-  int16_t _padded16_global_wrapper_stencil_29 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
-  int16_t _padded16_global_wrapper_stencil_30 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_31 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_32 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_33 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_34 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_35 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_36 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
-
-  int16_t _753 = _padded16_global_wrapper_stencil_28 * _kernel_y_stencil_10;
-  int16_t _754 = _padded16_global_wrapper_stencil_29 * _kernel_y_stencil_11;
-  int16_t _755 = _padded16_global_wrapper_stencil_30 * _kernel_y_stencil_12;
-  int16_t _756 = _padded16_global_wrapper_stencil_31 * _kernel_y_stencil_13;
-  int16_t _757 = _padded16_global_wrapper_stencil_32 * _kernel_y_stencil_14;
-  int16_t _758 = _padded16_global_wrapper_stencil_33 * _kernel_y_stencil_15;
-  int16_t _759 = _padded16_global_wrapper_stencil_34 * _kernel_y_stencil_16;
-  int16_t _760 = _padded16_global_wrapper_stencil_35 * _kernel_y_stencil_17;
-  int16_t _761 = _padded16_global_wrapper_stencil_36 * _kernel_y_stencil_18;
-  int16_t _762 = _760 + _761;
-  int16_t _763 = _759 + _762;
-  int16_t _764 = _758 + _763;
-  int16_t _765 = _757 + _764;
-  int16_t _766 = _756 + _765;
-  int16_t _767 = _755 + _766;
-  int16_t _768 = _754 + _767;
-  int16_t _769 = _grad_y_unclamp_stencil_2 + _768;
-  int16_t _770 = _753 + _769;
-  return _770;
+  int16_t _546 = (int16_t)(2);
+  int16_t _547 = _padded16_global_wrapper_stencil_21 * _546;
+  int16_t _548 = _padded16_global_wrapper_stencil_20 + _547;
+  int16_t _549 = _padded16_global_wrapper_stencil_19 + _548;
+  int16_t _550 = _grad_y_unclamp_stencil_2 + _549;
+  int16_t _551 = _550 - _padded16_global_wrapper_stencil_22;
+  int16_t _552 = _padded16_global_wrapper_stencil_23 * _546;
+  int16_t _553 = _551 - _552;
+  int16_t _554 = _553 - _padded16_global_wrapper_stencil_24;
+  return _554;
 }
 
 //store is: lxy.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)180), (int16)-180)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -2), lxy_s0_y), (int16)180), (int16)-180))/(int16)64)
@@ -499,16 +231,16 @@ hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<16
 
   int16_t _grad_y_unclamp_stencil_3 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _831 = (int16_t)(180);
-  int16_t _832 = min(_grad_x_unclamp_stencil_5, _831);
-  int16_t _833 = (int16_t)(-180);
-  int16_t _834 = max(_832, _833);
-  int16_t _835 = min(_grad_y_unclamp_stencil_3, _831);
-  int16_t _836 = max(_835, _833);
-  int16_t _837 = _834 * _836;
-  int16_t _838 = (int16_t)(6);
-  int16_t _839 = _837 >> _838;
-  return _839;
+  int16_t _585 = (int16_t)(180);
+  int16_t _586 = min(_grad_x_unclamp_stencil_5, _585);
+  int16_t _587 = (int16_t)(-180);
+  int16_t _588 = max(_586, _587);
+  int16_t _589 = min(_grad_y_unclamp_stencil_3, _585);
+  int16_t _590 = max(_589, _587);
+  int16_t _591 = _588 * _590;
+  int16_t _592 = (int16_t)(6);
+  int16_t _593 = _591 >> _592;
+  return _593;
 }
 
 //store is: lxy.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y) = ((max(min(grad_x_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)180), (int16)-180)*max(min(grad_y_unclamp.stencil(((lxy_s0_x_x*2) + -1), lxy_s0_y), (int16)180), (int16)-180))/(int16)64)
@@ -517,28 +249,28 @@ hw_uint<16> hcompute_lxy_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<
 
   int16_t _grad_y_unclamp_stencil_4 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _862 = (int16_t)(180);
-  int16_t _863 = min(_grad_x_unclamp_stencil_6, _862);
-  int16_t _864 = (int16_t)(-180);
-  int16_t _865 = max(_863, _864);
-  int16_t _866 = min(_grad_y_unclamp_stencil_4, _862);
-  int16_t _867 = max(_866, _864);
-  int16_t _868 = _865 * _867;
-  int16_t _869 = (int16_t)(6);
-  int16_t _870 = _868 >> _869;
-  return _870;
+  int16_t _616 = (int16_t)(180);
+  int16_t _617 = min(_grad_x_unclamp_stencil_6, _616);
+  int16_t _618 = (int16_t)(-180);
+  int16_t _619 = max(_617, _618);
+  int16_t _620 = min(_grad_y_unclamp_stencil_4, _616);
+  int16_t _621 = max(_620, _618);
+  int16_t _622 = _619 * _621;
+  int16_t _623 = (int16_t)(6);
+  int16_t _624 = _622 >> _623;
+  return _624;
 }
 
 //store is: lgxy.stencil(((lgxy_s0_x_x*2) + -1), lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _893 = (int16_t)(0);
-  return _893;
+  int16_t _647 = (int16_t)(0);
+  return _647;
 }
 
 //store is: lgxy.stencil((lgxy_s0_x_x*2), lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil_1() {
-  int16_t _898 = (int16_t)(0);
-  return _898;
+  int16_t _652 = (int16_t)(0);
+  return _652;
 }
 
 //store is: lgxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) = (lxy.stencil(((lgxy_s1_x_x*2) + -2), (lgxy_s1_y + -1)) + (lgxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + -2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -2), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + 1)) + lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + 1)))))))))))
@@ -555,16 +287,16 @@ hw_uint<16> hcompute_lgxy_stencil_2(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy
   int16_t _lxy_stencil_8 = (int16_t) lxy_stencil.extract<112, 127>();
   int16_t _lxy_stencil_9 = (int16_t) lxy_stencil.extract<128, 143>();
 
-  int16_t _902 = _lxy_stencil_8 + _lxy_stencil_9;
-  int16_t _903 = _lxy_stencil_7 + _902;
-  int16_t _904 = _lxy_stencil_6 + _903;
-  int16_t _905 = _lxy_stencil_5 + _904;
-  int16_t _906 = _lxy_stencil_4 + _905;
-  int16_t _907 = _lxy_stencil_3 + _906;
-  int16_t _908 = _lxy_stencil_2 + _907;
-  int16_t _909 = _lgxy_stencil_1 + _908;
-  int16_t _910 = _lxy_stencil_1 + _909;
-  return _910;
+  int16_t _656 = _lxy_stencil_8 + _lxy_stencil_9;
+  int16_t _657 = _lxy_stencil_7 + _656;
+  int16_t _658 = _lxy_stencil_6 + _657;
+  int16_t _659 = _lxy_stencil_5 + _658;
+  int16_t _660 = _lxy_stencil_4 + _659;
+  int16_t _661 = _lxy_stencil_3 + _660;
+  int16_t _662 = _lxy_stencil_2 + _661;
+  int16_t _663 = _lgxy_stencil_1 + _662;
+  int16_t _664 = _lxy_stencil_1 + _663;
+  return _664;
 }
 
 //store is: lgxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) = (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + -1)) + (lgxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), (lgxy_s1_y + -1)) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x_x*2), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), lgxy_s1_y) + (lxy.stencil(((lgxy_s1_x_x*2) + -1), (lgxy_s1_y + 1)) + (lxy.stencil(((lgxy_s1_x_x*2) + 1), (lgxy_s1_y + 1)) + lxy.stencil((lgxy_s1_x_x*2), (lgxy_s1_y + 1)))))))))))
@@ -581,56 +313,56 @@ hw_uint<16> hcompute_lgxy_stencil_3(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy
   int16_t _lxy_stencil_17 = (int16_t) lxy_stencil.extract<112, 127>();
   int16_t _lxy_stencil_18 = (int16_t) lxy_stencil.extract<128, 143>();
 
-  int16_t _944 = _lxy_stencil_17 + _lxy_stencil_18;
-  int16_t _945 = _lxy_stencil_16 + _944;
-  int16_t _946 = _lxy_stencil_15 + _945;
-  int16_t _947 = _lxy_stencil_14 + _946;
-  int16_t _948 = _lxy_stencil_13 + _947;
-  int16_t _949 = _lxy_stencil_12 + _948;
-  int16_t _950 = _lxy_stencil_11 + _949;
-  int16_t _951 = _lgxy_stencil_2 + _950;
-  int16_t _952 = _lxy_stencil_10 + _951;
-  return _952;
+  int16_t _698 = _lxy_stencil_17 + _lxy_stencil_18;
+  int16_t _699 = _lxy_stencil_16 + _698;
+  int16_t _700 = _lxy_stencil_15 + _699;
+  int16_t _701 = _lxy_stencil_14 + _700;
+  int16_t _702 = _lxy_stencil_13 + _701;
+  int16_t _703 = _lxy_stencil_12 + _702;
+  int16_t _704 = _lxy_stencil_11 + _703;
+  int16_t _705 = _lgxy_stencil_2 + _704;
+  int16_t _706 = _lxy_stencil_10 + _705;
+  return _706;
 }
 
 //store is: lyy.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)180), (int16)-180)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -2), lyy_s0_y), (int16)180), (int16)-180))/(int16)64)
 hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_y_unclamp_stencil_5 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _986 = (int16_t)(180);
-  int16_t _987 = min(_grad_y_unclamp_stencil_5, _986);
-  int16_t _988 = (int16_t)(-180);
-  int16_t _989 = max(_987, _988);
-  int16_t _990 = _989 * _989;
-  int16_t _991 = (int16_t)(6);
-  int16_t _992 = _990 >> _991;
-  return _992;
+  int16_t _740 = (int16_t)(180);
+  int16_t _741 = min(_grad_y_unclamp_stencil_5, _740);
+  int16_t _742 = (int16_t)(-180);
+  int16_t _743 = max(_741, _742);
+  int16_t _744 = _743 * _743;
+  int16_t _745 = (int16_t)(6);
+  int16_t _746 = _744 >> _745;
+  return _746;
 }
 
 //store is: lyy.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y) = ((max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)180), (int16)-180)*max(min(grad_y_unclamp.stencil(((lyy_s0_x_x*2) + -1), lyy_s0_y), (int16)180), (int16)-180))/(int16)64)
 hw_uint<16> hcompute_lyy_stencil_1(hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_y_unclamp_stencil_6 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _1010 = (int16_t)(180);
-  int16_t _1011 = min(_grad_y_unclamp_stencil_6, _1010);
-  int16_t _1012 = (int16_t)(-180);
-  int16_t _1013 = max(_1011, _1012);
-  int16_t _1014 = _1013 * _1013;
-  int16_t _1015 = (int16_t)(6);
-  int16_t _1016 = _1014 >> _1015;
-  return _1016;
+  int16_t _764 = (int16_t)(180);
+  int16_t _765 = min(_grad_y_unclamp_stencil_6, _764);
+  int16_t _766 = (int16_t)(-180);
+  int16_t _767 = max(_765, _766);
+  int16_t _768 = _767 * _767;
+  int16_t _769 = (int16_t)(6);
+  int16_t _770 = _768 >> _769;
+  return _770;
 }
 
 //store is: lgyy.stencil(((lgyy_s0_x_x*2) + -1), lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _1034 = (int16_t)(0);
-  return _1034;
+  int16_t _788 = (int16_t)(0);
+  return _788;
 }
 
 //store is: lgyy.stencil((lgyy_s0_x_x*2), lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil_1() {
-  int16_t _1039 = (int16_t)(0);
-  return _1039;
+  int16_t _793 = (int16_t)(0);
+  return _793;
 }
 
 //store is: lgyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) = (lyy.stencil(((lgyy_s1_x_x*2) + -2), (lgyy_s1_y + -1)) + (lgyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + -2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -2), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + 1)) + lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + 1)))))))))))
@@ -647,16 +379,16 @@ hw_uint<16> hcompute_lgyy_stencil_2(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy
   int16_t _lyy_stencil_8 = (int16_t) lyy_stencil.extract<112, 127>();
   int16_t _lyy_stencil_9 = (int16_t) lyy_stencil.extract<128, 143>();
 
-  int16_t _1043 = _lyy_stencil_8 + _lyy_stencil_9;
-  int16_t _1044 = _lyy_stencil_7 + _1043;
-  int16_t _1045 = _lyy_stencil_6 + _1044;
-  int16_t _1046 = _lyy_stencil_5 + _1045;
-  int16_t _1047 = _lyy_stencil_4 + _1046;
-  int16_t _1048 = _lyy_stencil_3 + _1047;
-  int16_t _1049 = _lyy_stencil_2 + _1048;
-  int16_t _1050 = _lgyy_stencil_1 + _1049;
-  int16_t _1051 = _lyy_stencil_1 + _1050;
-  return _1051;
+  int16_t _797 = _lyy_stencil_8 + _lyy_stencil_9;
+  int16_t _798 = _lyy_stencil_7 + _797;
+  int16_t _799 = _lyy_stencil_6 + _798;
+  int16_t _800 = _lyy_stencil_5 + _799;
+  int16_t _801 = _lyy_stencil_4 + _800;
+  int16_t _802 = _lyy_stencil_3 + _801;
+  int16_t _803 = _lyy_stencil_2 + _802;
+  int16_t _804 = _lgyy_stencil_1 + _803;
+  int16_t _805 = _lyy_stencil_1 + _804;
+  return _805;
 }
 
 //store is: lgyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) = (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + -1)) + (lgyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), (lgyy_s1_y + -1)) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x_x*2), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), lgyy_s1_y) + (lyy.stencil(((lgyy_s1_x_x*2) + -1), (lgyy_s1_y + 1)) + (lyy.stencil(((lgyy_s1_x_x*2) + 1), (lgyy_s1_y + 1)) + lyy.stencil((lgyy_s1_x_x*2), (lgyy_s1_y + 1)))))))))))
@@ -673,16 +405,16 @@ hw_uint<16> hcompute_lgyy_stencil_3(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy
   int16_t _lyy_stencil_17 = (int16_t) lyy_stencil.extract<112, 127>();
   int16_t _lyy_stencil_18 = (int16_t) lyy_stencil.extract<128, 143>();
 
-  int16_t _1085 = _lyy_stencil_17 + _lyy_stencil_18;
-  int16_t _1086 = _lyy_stencil_16 + _1085;
-  int16_t _1087 = _lyy_stencil_15 + _1086;
-  int16_t _1088 = _lyy_stencil_14 + _1087;
-  int16_t _1089 = _lyy_stencil_13 + _1088;
-  int16_t _1090 = _lyy_stencil_12 + _1089;
-  int16_t _1091 = _lyy_stencil_11 + _1090;
-  int16_t _1092 = _lgyy_stencil_2 + _1091;
-  int16_t _1093 = _lyy_stencil_10 + _1092;
-  return _1093;
+  int16_t _839 = _lyy_stencil_17 + _lyy_stencil_18;
+  int16_t _840 = _lyy_stencil_16 + _839;
+  int16_t _841 = _lyy_stencil_15 + _840;
+  int16_t _842 = _lyy_stencil_14 + _841;
+  int16_t _843 = _lyy_stencil_13 + _842;
+  int16_t _844 = _lyy_stencil_12 + _843;
+  int16_t _845 = _lyy_stencil_11 + _844;
+  int16_t _846 = _lgyy_stencil_2 + _845;
+  int16_t _847 = _lyy_stencil_10 + _846;
+  return _847;
 }
 
 //store is: cim.stencil(((cim_s0_x_x*2) + -1), cim_s0_y) = ((((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)*(lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)) - ((lgxy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)*(lgxy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64))) - ((((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64) + (lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64))*((lgxx.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64) + (lgyy.stencil(((cim_s0_x_x*2) + -1), cim_s0_y)/(int16)64)))/(int16)16))
@@ -693,19 +425,19 @@ hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_st
 
   int16_t _lgyy_stencil_3 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _1127 = (int16_t)(6);
-  int16_t _1128 = _lgxx_stencil_3 >> _1127;
-  int16_t _1129 = _lgyy_stencil_3 >> _1127;
-  int16_t _1130 = _1128 * _1129;
-  int16_t _1131 = _lgxy_stencil_3 >> _1127;
-  int16_t _1132 = _1131 * _1131;
-  int16_t _1133 = _1130 - _1132;
-  int16_t _1134 = _1128 + _1129;
-  int16_t _1135 = _1134 * _1134;
-  int16_t _1136 = (int16_t)(4);
-  int16_t _1137 = _1135 >> _1136;
-  int16_t _1138 = _1133 - _1137;
-  return _1138;
+  int16_t _881 = (int16_t)(6);
+  int16_t _882 = _lgxx_stencil_3 >> _881;
+  int16_t _883 = _lgyy_stencil_3 >> _881;
+  int16_t _884 = _882 * _883;
+  int16_t _885 = _lgxy_stencil_3 >> _881;
+  int16_t _886 = _885 * _885;
+  int16_t _887 = _884 - _886;
+  int16_t _888 = _882 + _883;
+  int16_t _889 = _888 * _888;
+  int16_t _890 = (int16_t)(4);
+  int16_t _891 = _889 >> _890;
+  int16_t _892 = _887 - _891;
+  return _892;
 }
 
 //store is: cim.stencil((cim_s0_x_x*2), cim_s0_y) = ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)) - ((lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)*(lgxy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))) - ((((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64))*((lgxx.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64) + (lgyy.stencil((cim_s0_x_x*2), cim_s0_y)/(int16)64)))/(int16)16))
@@ -716,19 +448,19 @@ hw_uint<16> hcompute_cim_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_
 
   int16_t _lgyy_stencil_4 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _1168 = (int16_t)(6);
-  int16_t _1169 = _lgxx_stencil_4 >> _1168;
-  int16_t _1170 = _lgyy_stencil_4 >> _1168;
-  int16_t _1171 = _1169 * _1170;
-  int16_t _1172 = _lgxy_stencil_4 >> _1168;
-  int16_t _1173 = _1172 * _1172;
-  int16_t _1174 = _1171 - _1173;
-  int16_t _1175 = _1169 + _1170;
-  int16_t _1176 = _1175 * _1175;
-  int16_t _1177 = (int16_t)(4);
-  int16_t _1178 = _1176 >> _1177;
-  int16_t _1179 = _1174 - _1178;
-  return _1179;
+  int16_t _922 = (int16_t)(6);
+  int16_t _923 = _lgxx_stencil_4 >> _922;
+  int16_t _924 = _lgyy_stencil_4 >> _922;
+  int16_t _925 = _923 * _924;
+  int16_t _926 = _lgxy_stencil_4 >> _922;
+  int16_t _927 = _926 * _926;
+  int16_t _928 = _925 - _927;
+  int16_t _929 = _923 + _924;
+  int16_t _930 = _929 * _929;
+  int16_t _931 = (int16_t)(4);
+  int16_t _932 = _930 >> _931;
+  int16_t _933 = _928 - _932;
+  return _933;
 }
 
 //store is: cim_output.stencil((cim_output_s0_x_x*2), cim_output_s0_y) = int16(select((((((((((cim.stencil(((cim_output_s0_x_x*2) + -1), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y)) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + -1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + -1), cim_output_s0_y) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + -1), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + 1)) < cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))) && ((int16)1 <= cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y))), 255, 0))
@@ -743,27 +475,27 @@ hw_uint<16> hcompute_cim_output_stencil(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_8 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_9 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _1208 = _cim_stencil_1 < _cim_stencil_2;
-  bool _1209 = _cim_stencil_3 < _cim_stencil_2;
-  bool _1210 = _1208 && _1209;
-  bool _1211 = _cim_stencil_4 < _cim_stencil_2;
-  bool _1212 = _1210 && _1211;
-  bool _1213 = _cim_stencil_5 < _cim_stencil_2;
-  bool _1214 = _1212 && _1213;
-  bool _1215 = _cim_stencil_6 < _cim_stencil_2;
-  bool _1216 = _1214 && _1215;
-  bool _1217 = _cim_stencil_7 < _cim_stencil_2;
-  bool _1218 = _1216 && _1217;
-  bool _1219 = _cim_stencil_8 < _cim_stencil_2;
-  bool _1220 = _1218 && _1219;
-  bool _1221 = _cim_stencil_9 < _cim_stencil_2;
-  bool _1222 = _1220 && _1221;
-  int16_t _1223 = (int16_t)(1);
-  bool _1224 = _1223 <= _cim_stencil_2;
-  bool _1225 = _1222 && _1224;
-  int32_t _1226 = (int32_t)(_1225 ? 255 : 0);
-  int16_t _1227 = (int16_t)(_1226);
-  return _1227;
+  bool _962 = _cim_stencil_1 < _cim_stencil_2;
+  bool _963 = _cim_stencil_3 < _cim_stencil_2;
+  bool _964 = _962 && _963;
+  bool _965 = _cim_stencil_4 < _cim_stencil_2;
+  bool _966 = _964 && _965;
+  bool _967 = _cim_stencil_5 < _cim_stencil_2;
+  bool _968 = _966 && _967;
+  bool _969 = _cim_stencil_6 < _cim_stencil_2;
+  bool _970 = _968 && _969;
+  bool _971 = _cim_stencil_7 < _cim_stencil_2;
+  bool _972 = _970 && _971;
+  bool _973 = _cim_stencil_8 < _cim_stencil_2;
+  bool _974 = _972 && _973;
+  bool _975 = _cim_stencil_9 < _cim_stencil_2;
+  bool _976 = _974 && _975;
+  int16_t _977 = (int16_t)(1);
+  bool _978 = _977 <= _cim_stencil_2;
+  bool _979 = _976 && _978;
+  int32_t _980 = (int32_t)(_979 ? 255 : 0);
+  int16_t _981 = (int16_t)(_980);
+  return _981;
 }
 
 //store is: cim_output.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y)) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), (cim_output_s0_y + -1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), cim_output_s0_y) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), cim_output_s0_y) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil((cim_output_s0_x_x*2), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 1), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && (cim.stencil(((cim_output_s0_x_x*2) + 2), (cim_output_s0_y + 1)) < cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))) && ((int16)1 <= cim.stencil(((cim_output_s0_x_x*2) + 1), cim_output_s0_y))), 255, 0))
@@ -778,27 +510,27 @@ hw_uint<16> hcompute_cim_output_stencil_1(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_17 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_18 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _1282 = _cim_stencil_10 < _cim_stencil_11;
-  bool _1283 = _cim_stencil_12 < _cim_stencil_11;
-  bool _1284 = _1282 && _1283;
-  bool _1285 = _cim_stencil_13 < _cim_stencil_11;
-  bool _1286 = _1284 && _1285;
-  bool _1287 = _cim_stencil_14 < _cim_stencil_11;
-  bool _1288 = _1286 && _1287;
-  bool _1289 = _cim_stencil_15 < _cim_stencil_11;
-  bool _1290 = _1288 && _1289;
-  bool _1291 = _cim_stencil_16 < _cim_stencil_11;
-  bool _1292 = _1290 && _1291;
-  bool _1293 = _cim_stencil_17 < _cim_stencil_11;
-  bool _1294 = _1292 && _1293;
-  bool _1295 = _cim_stencil_18 < _cim_stencil_11;
-  bool _1296 = _1294 && _1295;
-  int16_t _1297 = (int16_t)(1);
-  bool _1298 = _1297 <= _cim_stencil_11;
-  bool _1299 = _1296 && _1298;
-  int32_t _1300 = (int32_t)(_1299 ? 255 : 0);
-  int16_t _1301 = (int16_t)(_1300);
-  return _1301;
+  bool _1036 = _cim_stencil_10 < _cim_stencil_11;
+  bool _1037 = _cim_stencil_12 < _cim_stencil_11;
+  bool _1038 = _1036 && _1037;
+  bool _1039 = _cim_stencil_13 < _cim_stencil_11;
+  bool _1040 = _1038 && _1039;
+  bool _1041 = _cim_stencil_14 < _cim_stencil_11;
+  bool _1042 = _1040 && _1041;
+  bool _1043 = _cim_stencil_15 < _cim_stencil_11;
+  bool _1044 = _1042 && _1043;
+  bool _1045 = _cim_stencil_16 < _cim_stencil_11;
+  bool _1046 = _1044 && _1045;
+  bool _1047 = _cim_stencil_17 < _cim_stencil_11;
+  bool _1048 = _1046 && _1047;
+  bool _1049 = _cim_stencil_18 < _cim_stencil_11;
+  bool _1050 = _1048 && _1049;
+  int16_t _1051 = (int16_t)(1);
+  bool _1052 = _1051 <= _cim_stencil_11;
+  bool _1053 = _1050 && _1052;
+  int32_t _1054 = (int32_t)(_1053 ? 255 : 0);
+  int16_t _1055 = (int16_t)(_1054);
+  return _1055;
 }
 
 //store is: hw_output.stencil((hw_output_s0_x_xi_xi*2), hw_output_s0_y_yi) = cim_output.stencil((hw_output_s0_x_xi_xi*2), hw_output_s0_y_yi)

--- a/harris_sch7_bigtile_compute.h
+++ b/harris_sch7_bigtile_compute.h
@@ -3,96 +3,6 @@
 #include "clockwork_standard_compute_units.h"
 
 
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil() {
-  int16_t _260 = (int16_t)(0);
-  return _260;
-}
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_1() {
-  int16_t _263 = (int16_t)(0);
-  return _263;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_2() {
-  int16_t _266 = (int16_t)(0);
-  return _266;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_3() {
-  int16_t _269 = (int16_t)(0);
-  return _269;
-}
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_4() {
-  int16_t _272 = (int16_t)(0);
-  return _272;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_5() {
-  int16_t _275 = (int16_t)(0);
-  return _275;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_6() {
-  int16_t _278 = (int16_t)(0);
-  return _278;
-}
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_7() {
-  int16_t _281 = (int16_t)(0);
-  return _281;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_8() {
-  int16_t _284 = (int16_t)(0);
-  return _284;
-}
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_9() {
-  int16_t _287 = (int16_t)(-1);
-  return _287;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-hw_uint<16> hcompute_kernel_x_stencil_10() {
-  int16_t _290 = (int16_t)(-2);
-  return _290;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_11() {
-  int16_t _293 = (int16_t)(-1);
-  return _293;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_12() {
-  int16_t _296 = (int16_t)(1);
-  return _296;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-hw_uint<16> hcompute_kernel_x_stencil_13() {
-  int16_t _299 = (int16_t)(2);
-  return _299;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_14() {
-  int16_t _302 = (int16_t)(1);
-  return _302;
-}
-
 //store is: padded16_global_wrapper.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y) = padded16.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y)
 hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stencil) {
   int16_t _padded16_stencil_1 = (int16_t) padded16_stencil.extract<0, 15>();
@@ -102,23 +12,13 @@ hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stenc
 
 //store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_x_unclamp_stencil() {
-  int16_t _306 = (int16_t)(0);
-  return _306;
+  int16_t _261 = (int16_t)(0);
+  return _261;
 }
 
-//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + ((padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_x_s0_x, grad_x_s0_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + 1))*kernel_x.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<144>& kernel_x_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((((grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1)))
+hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_1 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_x_stencil_1 = (int16_t) kernel_x_stencil.extract<0, 15>();
-  int16_t _kernel_x_stencil_2 = (int16_t) kernel_x_stencil.extract<16, 31>();
-  int16_t _kernel_x_stencil_3 = (int16_t) kernel_x_stencil.extract<32, 47>();
-  int16_t _kernel_x_stencil_4 = (int16_t) kernel_x_stencil.extract<48, 63>();
-  int16_t _kernel_x_stencil_5 = (int16_t) kernel_x_stencil.extract<64, 79>();
-  int16_t _kernel_x_stencil_6 = (int16_t) kernel_x_stencil.extract<80, 95>();
-  int16_t _kernel_x_stencil_7 = (int16_t) kernel_x_stencil.extract<96, 111>();
-  int16_t _kernel_x_stencil_8 = (int16_t) kernel_x_stencil.extract<112, 127>();
-  int16_t _kernel_x_stencil_9 = (int16_t) kernel_x_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_1 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_2 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
@@ -126,56 +26,44 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stenci
   int16_t _padded16_global_wrapper_stencil_4 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
   int16_t _padded16_global_wrapper_stencil_5 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
   int16_t _padded16_global_wrapper_stencil_6 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
 
-  int16_t _309 = _padded16_global_wrapper_stencil_1 * _kernel_x_stencil_1;
-  int16_t _310 = _padded16_global_wrapper_stencil_2 * _kernel_x_stencil_2;
-  int16_t _311 = _padded16_global_wrapper_stencil_3 * _kernel_x_stencil_3;
-  int16_t _312 = _padded16_global_wrapper_stencil_4 * _kernel_x_stencil_4;
-  int16_t _313 = _padded16_global_wrapper_stencil_5 * _kernel_x_stencil_5;
-  int16_t _314 = _padded16_global_wrapper_stencil_6 * _kernel_x_stencil_6;
-  int16_t _315 = _padded16_global_wrapper_stencil_7 * _kernel_x_stencil_7;
-  int16_t _316 = _padded16_global_wrapper_stencil_8 * _kernel_x_stencil_8;
-  int16_t _317 = _padded16_global_wrapper_stencil_9 * _kernel_x_stencil_9;
-  int16_t _318 = _316 + _317;
-  int16_t _319 = _315 + _318;
-  int16_t _320 = _314 + _319;
-  int16_t _321 = _313 + _320;
-  int16_t _322 = _312 + _321;
-  int16_t _323 = _311 + _322;
-  int16_t _324 = _310 + _323;
-  int16_t _325 = _grad_x_unclamp_stencil_1 + _324;
-  int16_t _326 = _309 + _325;
-  return _326;
+  int16_t _264 = (int16_t)(2);
+  int16_t _265 = _padded16_global_wrapper_stencil_3 * _264;
+  int16_t _266 = _padded16_global_wrapper_stencil_2 + _265;
+  int16_t _267 = _padded16_global_wrapper_stencil_1 + _266;
+  int16_t _268 = _grad_x_unclamp_stencil_1 + _267;
+  int16_t _269 = _268 - _padded16_global_wrapper_stencil_4;
+  int16_t _270 = _padded16_global_wrapper_stencil_5 * _264;
+  int16_t _271 = _269 - _270;
+  int16_t _272 = _271 - _padded16_global_wrapper_stencil_6;
+  return _272;
 }
 
 //store is: grad_x.stencil(grad_x_s0_x, grad_x_s0_y) = max(min(grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y), (int16)180), (int16)-180)
 hw_uint<16> hcompute_grad_x_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _386 = (int16_t)(180);
-  int16_t _387 = min(_grad_x_unclamp_stencil_2, _386);
-  int16_t _388 = (int16_t)(-180);
-  int16_t _389 = max(_387, _388);
-  return _389;
+  int16_t _302 = (int16_t)(180);
+  int16_t _303 = min(_grad_x_unclamp_stencil_2, _302);
+  int16_t _304 = (int16_t)(-180);
+  int16_t _305 = max(_303, _304);
+  return _305;
 }
 
 //store is: lxx.stencil(lxx_s0_x, lxx_s0_y) = ((grad_x.stencil(lxx_s0_x, lxx_s0_y)*grad_x.stencil(lxx_s0_x, lxx_s0_y))/(int16)64)
 hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_stencil) {
   int16_t _grad_x_stencil_1 = (int16_t) grad_x_stencil.extract<0, 15>();
 
-  int16_t _399 = _grad_x_stencil_1 * _grad_x_stencil_1;
-  int16_t _400 = (int16_t)(6);
-  int16_t _401 = _399 >> _400;
-  return _401;
+  int16_t _315 = _grad_x_stencil_1 * _grad_x_stencil_1;
+  int16_t _316 = (int16_t)(6);
+  int16_t _317 = _315 >> _316;
+  return _317;
 }
 
 //store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _409 = (int16_t)(0);
-  return _409;
+  int16_t _325 = (int16_t)(0);
+  return _325;
 }
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + -1)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + -1), lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + 1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + 1)) + lxx.stencil(lgxx_s1_x, (lgxx_s1_y + 1)))))))))))
@@ -192,168 +80,56 @@ hw_uint<16> hcompute_lgxx_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx
   int16_t _lxx_stencil_8 = (int16_t) lxx_stencil.extract<112, 127>();
   int16_t _lxx_stencil_9 = (int16_t) lxx_stencil.extract<128, 143>();
 
-  int16_t _412 = _lxx_stencil_8 + _lxx_stencil_9;
-  int16_t _413 = _lxx_stencil_7 + _412;
-  int16_t _414 = _lxx_stencil_6 + _413;
-  int16_t _415 = _lxx_stencil_5 + _414;
-  int16_t _416 = _lxx_stencil_4 + _415;
-  int16_t _417 = _lxx_stencil_3 + _416;
-  int16_t _418 = _lxx_stencil_2 + _417;
-  int16_t _419 = _lgxx_stencil_1 + _418;
-  int16_t _420 = _lxx_stencil_1 + _419;
-  return _420;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil() {
-  int16_t _453 = (int16_t)(0);
-  return _453;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_1() {
-  int16_t _456 = (int16_t)(0);
-  return _456;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_2() {
-  int16_t _459 = (int16_t)(0);
-  return _459;
-}
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_3() {
-  int16_t _462 = (int16_t)(0);
-  return _462;
-}
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_4() {
-  int16_t _465 = (int16_t)(0);
-  return _465;
-}
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_5() {
-  int16_t _468 = (int16_t)(0);
-  return _468;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_6() {
-  int16_t _471 = (int16_t)(0);
-  return _471;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_7() {
-  int16_t _474 = (int16_t)(0);
-  return _474;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_8() {
-  int16_t _477 = (int16_t)(0);
-  return _477;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_9() {
-  int16_t _480 = (int16_t)(1);
-  return _480;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-hw_uint<16> hcompute_kernel_y_stencil_10() {
-  int16_t _483 = (int16_t)(2);
-  return _483;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_11() {
-  int16_t _486 = (int16_t)(1);
-  return _486;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_12() {
-  int16_t _489 = (int16_t)(-1);
-  return _489;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-hw_uint<16> hcompute_kernel_y_stencil_13() {
-  int16_t _492 = (int16_t)(-2);
-  return _492;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_14() {
-  int16_t _495 = (int16_t)(-1);
-  return _495;
+  int16_t _328 = _lxx_stencil_8 + _lxx_stencil_9;
+  int16_t _329 = _lxx_stencil_7 + _328;
+  int16_t _330 = _lxx_stencil_6 + _329;
+  int16_t _331 = _lxx_stencil_5 + _330;
+  int16_t _332 = _lxx_stencil_4 + _331;
+  int16_t _333 = _lxx_stencil_3 + _332;
+  int16_t _334 = _lxx_stencil_2 + _333;
+  int16_t _335 = _lgxx_stencil_1 + _334;
+  int16_t _336 = _lxx_stencil_1 + _335;
+  return _336;
 }
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil() {
-  int16_t _498 = (int16_t)(0);
-  return _498;
+  int16_t _369 = (int16_t)(0);
+  return _369;
 }
 
-//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + ((padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), grad_y_s0_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_y_s0_x, grad_y_s0_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), grad_y_s0_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*kernel_y.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<144>& kernel_y_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((((grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))) - (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1)))
+hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_y_unclamp_stencil_1 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_y_stencil_1 = (int16_t) kernel_y_stencil.extract<0, 15>();
-  int16_t _kernel_y_stencil_2 = (int16_t) kernel_y_stencil.extract<16, 31>();
-  int16_t _kernel_y_stencil_3 = (int16_t) kernel_y_stencil.extract<32, 47>();
-  int16_t _kernel_y_stencil_4 = (int16_t) kernel_y_stencil.extract<48, 63>();
-  int16_t _kernel_y_stencil_5 = (int16_t) kernel_y_stencil.extract<64, 79>();
-  int16_t _kernel_y_stencil_6 = (int16_t) kernel_y_stencil.extract<80, 95>();
-  int16_t _kernel_y_stencil_7 = (int16_t) kernel_y_stencil.extract<96, 111>();
-  int16_t _kernel_y_stencil_8 = (int16_t) kernel_y_stencil.extract<112, 127>();
-  int16_t _kernel_y_stencil_9 = (int16_t) kernel_y_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
   int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_13 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_14 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_15 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_16 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_17 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_18 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
+  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
 
-  int16_t _501 = _padded16_global_wrapper_stencil_10 * _kernel_y_stencil_1;
-  int16_t _502 = _padded16_global_wrapper_stencil_11 * _kernel_y_stencil_2;
-  int16_t _503 = _padded16_global_wrapper_stencil_12 * _kernel_y_stencil_3;
-  int16_t _504 = _padded16_global_wrapper_stencil_13 * _kernel_y_stencil_4;
-  int16_t _505 = _padded16_global_wrapper_stencil_14 * _kernel_y_stencil_5;
-  int16_t _506 = _padded16_global_wrapper_stencil_15 * _kernel_y_stencil_6;
-  int16_t _507 = _padded16_global_wrapper_stencil_16 * _kernel_y_stencil_7;
-  int16_t _508 = _padded16_global_wrapper_stencil_17 * _kernel_y_stencil_8;
-  int16_t _509 = _padded16_global_wrapper_stencil_18 * _kernel_y_stencil_9;
-  int16_t _510 = _508 + _509;
-  int16_t _511 = _507 + _510;
-  int16_t _512 = _506 + _511;
-  int16_t _513 = _505 + _512;
-  int16_t _514 = _504 + _513;
-  int16_t _515 = _503 + _514;
-  int16_t _516 = _502 + _515;
-  int16_t _517 = _grad_y_unclamp_stencil_1 + _516;
-  int16_t _518 = _501 + _517;
-  return _518;
+  int16_t _372 = (int16_t)(2);
+  int16_t _373 = _padded16_global_wrapper_stencil_9 * _372;
+  int16_t _374 = _padded16_global_wrapper_stencil_8 + _373;
+  int16_t _375 = _padded16_global_wrapper_stencil_7 + _374;
+  int16_t _376 = _grad_y_unclamp_stencil_1 + _375;
+  int16_t _377 = _376 - _padded16_global_wrapper_stencil_10;
+  int16_t _378 = _padded16_global_wrapper_stencil_11 * _372;
+  int16_t _379 = _377 - _378;
+  int16_t _380 = _379 - _padded16_global_wrapper_stencil_12;
+  return _380;
 }
 
 //store is: grad_y.stencil(grad_y_s0_x, grad_y_s0_y) = max(min(grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y), (int16)180), (int16)-180)
 hw_uint<16> hcompute_grad_y_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _578 = (int16_t)(180);
-  int16_t _579 = min(_grad_y_unclamp_stencil_2, _578);
-  int16_t _580 = (int16_t)(-180);
-  int16_t _581 = max(_579, _580);
-  return _581;
+  int16_t _410 = (int16_t)(180);
+  int16_t _411 = min(_grad_y_unclamp_stencil_2, _410);
+  int16_t _412 = (int16_t)(-180);
+  int16_t _413 = max(_411, _412);
+  return _413;
 }
 
 //store is: lxy.stencil(lxy_s0_x, lxy_s0_y) = ((grad_x.stencil(lxy_s0_x, lxy_s0_y)*grad_y.stencil(lxy_s0_x, lxy_s0_y))/(int16)64)
@@ -362,16 +138,16 @@ hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_stencil, hw_uint<16>& grad_
 
   int16_t _grad_y_stencil_1 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _591 = _grad_x_stencil_2 * _grad_y_stencil_1;
-  int16_t _592 = (int16_t)(6);
-  int16_t _593 = _591 >> _592;
-  return _593;
+  int16_t _423 = _grad_x_stencil_2 * _grad_y_stencil_1;
+  int16_t _424 = (int16_t)(6);
+  int16_t _425 = _423 >> _424;
+  return _425;
 }
 
 //store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _602 = (int16_t)(0);
-  return _602;
+  int16_t _434 = (int16_t)(0);
+  return _434;
 }
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + -1)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + -1), lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + 1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + 1)) + lxy.stencil(lgxy_s1_x, (lgxy_s1_y + 1)))))))))))
@@ -388,32 +164,32 @@ hw_uint<16> hcompute_lgxy_stencil_1(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy
   int16_t _lxy_stencil_8 = (int16_t) lxy_stencil.extract<112, 127>();
   int16_t _lxy_stencil_9 = (int16_t) lxy_stencil.extract<128, 143>();
 
-  int16_t _605 = _lxy_stencil_8 + _lxy_stencil_9;
-  int16_t _606 = _lxy_stencil_7 + _605;
-  int16_t _607 = _lxy_stencil_6 + _606;
-  int16_t _608 = _lxy_stencil_5 + _607;
-  int16_t _609 = _lxy_stencil_4 + _608;
-  int16_t _610 = _lxy_stencil_3 + _609;
-  int16_t _611 = _lxy_stencil_2 + _610;
-  int16_t _612 = _lgxy_stencil_1 + _611;
-  int16_t _613 = _lxy_stencil_1 + _612;
-  return _613;
+  int16_t _437 = _lxy_stencil_8 + _lxy_stencil_9;
+  int16_t _438 = _lxy_stencil_7 + _437;
+  int16_t _439 = _lxy_stencil_6 + _438;
+  int16_t _440 = _lxy_stencil_5 + _439;
+  int16_t _441 = _lxy_stencil_4 + _440;
+  int16_t _442 = _lxy_stencil_3 + _441;
+  int16_t _443 = _lxy_stencil_2 + _442;
+  int16_t _444 = _lgxy_stencil_1 + _443;
+  int16_t _445 = _lxy_stencil_1 + _444;
+  return _445;
 }
 
 //store is: lyy.stencil(lyy_s0_x, lyy_s0_y) = ((grad_y.stencil(lyy_s0_x, lyy_s0_y)*grad_y.stencil(lyy_s0_x, lyy_s0_y))/(int16)64)
 hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_stencil) {
   int16_t _grad_y_stencil_2 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _646 = _grad_y_stencil_2 * _grad_y_stencil_2;
-  int16_t _647 = (int16_t)(6);
-  int16_t _648 = _646 >> _647;
-  return _648;
+  int16_t _478 = _grad_y_stencil_2 * _grad_y_stencil_2;
+  int16_t _479 = (int16_t)(6);
+  int16_t _480 = _478 >> _479;
+  return _480;
 }
 
 //store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _656 = (int16_t)(0);
-  return _656;
+  int16_t _488 = (int16_t)(0);
+  return _488;
 }
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + -1)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + -1), lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + 1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + 1)) + lyy.stencil(lgyy_s1_x, (lgyy_s1_y + 1)))))))))))
@@ -430,16 +206,16 @@ hw_uint<16> hcompute_lgyy_stencil_1(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy
   int16_t _lyy_stencil_8 = (int16_t) lyy_stencil.extract<112, 127>();
   int16_t _lyy_stencil_9 = (int16_t) lyy_stencil.extract<128, 143>();
 
-  int16_t _659 = _lyy_stencil_8 + _lyy_stencil_9;
-  int16_t _660 = _lyy_stencil_7 + _659;
-  int16_t _661 = _lyy_stencil_6 + _660;
-  int16_t _662 = _lyy_stencil_5 + _661;
-  int16_t _663 = _lyy_stencil_4 + _662;
-  int16_t _664 = _lyy_stencil_3 + _663;
-  int16_t _665 = _lyy_stencil_2 + _664;
-  int16_t _666 = _lgyy_stencil_1 + _665;
-  int16_t _667 = _lyy_stencil_1 + _666;
-  return _667;
+  int16_t _491 = _lyy_stencil_8 + _lyy_stencil_9;
+  int16_t _492 = _lyy_stencil_7 + _491;
+  int16_t _493 = _lyy_stencil_6 + _492;
+  int16_t _494 = _lyy_stencil_5 + _493;
+  int16_t _495 = _lyy_stencil_4 + _494;
+  int16_t _496 = _lyy_stencil_3 + _495;
+  int16_t _497 = _lyy_stencil_2 + _496;
+  int16_t _498 = _lgyy_stencil_1 + _497;
+  int16_t _499 = _lyy_stencil_1 + _498;
+  return _499;
 }
 
 //store is: cim.stencil(cim_s0_x, cim_s0_y) = ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)) - ((lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64)*(lgxy.stencil(cim_s0_x, cim_s0_y)/(int16)64))) - ((((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64))*((lgxx.stencil(cim_s0_x, cim_s0_y)/(int16)64) + (lgyy.stencil(cim_s0_x, cim_s0_y)/(int16)64)))/(int16)16))
@@ -450,19 +226,19 @@ hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_st
 
   int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _700 = (int16_t)(6);
-  int16_t _701 = _lgxx_stencil_2 >> _700;
-  int16_t _702 = _lgyy_stencil_2 >> _700;
-  int16_t _703 = _701 * _702;
-  int16_t _704 = _lgxy_stencil_2 >> _700;
-  int16_t _705 = _704 * _704;
-  int16_t _706 = _703 - _705;
-  int16_t _707 = _701 + _702;
-  int16_t _708 = _707 * _707;
-  int16_t _709 = (int16_t)(4);
-  int16_t _710 = _708 >> _709;
-  int16_t _711 = _706 - _710;
-  return _711;
+  int16_t _532 = (int16_t)(6);
+  int16_t _533 = _lgxx_stencil_2 >> _532;
+  int16_t _534 = _lgyy_stencil_2 >> _532;
+  int16_t _535 = _533 * _534;
+  int16_t _536 = _lgxy_stencil_2 >> _532;
+  int16_t _537 = _536 * _536;
+  int16_t _538 = _535 - _537;
+  int16_t _539 = _533 + _534;
+  int16_t _540 = _539 * _539;
+  int16_t _541 = (int16_t)(4);
+  int16_t _542 = _540 >> _541;
+  int16_t _543 = _538 - _542;
+  return _543;
 }
 
 //store is: cim_output.stencil(cim_output_s0_x, cim_output_s0_y) = int16(select((((((((((cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y)) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + -1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), cim_output_s0_y) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + -1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil(cim_output_s0_x, (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && (cim.stencil((cim_output_s0_x + 1), (cim_output_s0_y + 1)) < cim.stencil(cim_output_s0_x, cim_output_s0_y))) && ((int16)1 <= cim.stencil(cim_output_s0_x, cim_output_s0_y))), 255, 0))
@@ -477,30 +253,30 @@ hw_uint<16> hcompute_cim_output_stencil(hw_uint<144>& cim_stencil) {
   int16_t _cim_stencil_8 = (int16_t) cim_stencil.extract<112, 127>();
   int16_t _cim_stencil_9 = (int16_t) cim_stencil.extract<128, 143>();
 
-  bool _739 = _cim_stencil_1 < _cim_stencil_2;
-  bool _740 = _cim_stencil_3 < _cim_stencil_2;
-  bool _741 = _739 && _740;
-  bool _742 = _cim_stencil_4 < _cim_stencil_2;
-  bool _743 = _741 && _742;
-  bool _744 = _cim_stencil_5 < _cim_stencil_2;
-  bool _745 = _743 && _744;
-  bool _746 = _cim_stencil_6 < _cim_stencil_2;
-  bool _747 = _745 && _746;
-  bool _748 = _cim_stencil_7 < _cim_stencil_2;
-  bool _749 = _747 && _748;
-  bool _750 = _cim_stencil_8 < _cim_stencil_2;
-  bool _751 = _749 && _750;
-  bool _752 = _cim_stencil_9 < _cim_stencil_2;
-  bool _753 = _751 && _752;
-  int16_t _754 = (int16_t)(1);
-  bool _755 = _754 <= _cim_stencil_2;
-  bool _756 = _753 && _755;
-  int32_t _757 = (int32_t)(_756 ? 255 : 0);
-  int16_t _758 = (int16_t)(_757);
-  return _758;
+  bool _571 = _cim_stencil_1 < _cim_stencil_2;
+  bool _572 = _cim_stencil_3 < _cim_stencil_2;
+  bool _573 = _571 && _572;
+  bool _574 = _cim_stencil_4 < _cim_stencil_2;
+  bool _575 = _573 && _574;
+  bool _576 = _cim_stencil_5 < _cim_stencil_2;
+  bool _577 = _575 && _576;
+  bool _578 = _cim_stencil_6 < _cim_stencil_2;
+  bool _579 = _577 && _578;
+  bool _580 = _cim_stencil_7 < _cim_stencil_2;
+  bool _581 = _579 && _580;
+  bool _582 = _cim_stencil_8 < _cim_stencil_2;
+  bool _583 = _581 && _582;
+  bool _584 = _cim_stencil_9 < _cim_stencil_2;
+  bool _585 = _583 && _584;
+  int16_t _586 = (int16_t)(1);
+  bool _587 = _586 <= _cim_stencil_2;
+  bool _588 = _585 && _587;
+  int32_t _589 = (int32_t)(_588 ? 255 : 0);
+  int16_t _590 = (int16_t)(_589);
+  return _590;
 }
 
-//store is: hw_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi) = cim_output.stencil(hw_output_s0_x_xi, hw_output_s0_y_yi)
+//store is: hw_output.stencil((hw_output_s0_x_xi + -64), (hw_output_s0_y_yi + -64)) = cim_output.stencil((hw_output_s0_x_xi + -64), (hw_output_s0_y_yi + -64))
 hw_uint<16> hcompute_hw_output_stencil(hw_uint<16>& cim_output_stencil) {
   int16_t _cim_output_stencil_1 = (int16_t) cim_output_stencil.extract<0, 15>();
 

--- a/harris_sch8_endcim_compute.h
+++ b/harris_sch8_endcim_compute.h
@@ -3,96 +3,6 @@
 #include "clockwork_standard_compute_units.h"
 
 
-//store is: kernel_x.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil() {
-  int16_t _260 = (int16_t)(0);
-  return _260;
-}
-
-//store is: kernel_x.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_1() {
-  int16_t _263 = (int16_t)(0);
-  return _263;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_2() {
-  int16_t _266 = (int16_t)(0);
-  return _266;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_3() {
-  int16_t _269 = (int16_t)(0);
-  return _269;
-}
-
-//store is: kernel_x.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_4() {
-  int16_t _272 = (int16_t)(0);
-  return _272;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_5() {
-  int16_t _275 = (int16_t)(0);
-  return _275;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_6() {
-  int16_t _278 = (int16_t)(0);
-  return _278;
-}
-
-//store is: kernel_x.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_7() {
-  int16_t _281 = (int16_t)(0);
-  return _281;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_x_stencil_8() {
-  int16_t _284 = (int16_t)(0);
-  return _284;
-}
-
-//store is: kernel_x.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_9() {
-  int16_t _287 = (int16_t)(-1);
-  return _287;
-}
-
-//store is: kernel_x.stencil(-1, 0) = (int16)-2
-hw_uint<16> hcompute_kernel_x_stencil_10() {
-  int16_t _290 = (int16_t)(-2);
-  return _290;
-}
-
-//store is: kernel_x.stencil(-1, 1) = (int16)-1
-hw_uint<16> hcompute_kernel_x_stencil_11() {
-  int16_t _293 = (int16_t)(-1);
-  return _293;
-}
-
-//store is: kernel_x.stencil(1, -1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_12() {
-  int16_t _296 = (int16_t)(1);
-  return _296;
-}
-
-//store is: kernel_x.stencil(1, 0) = (int16)2
-hw_uint<16> hcompute_kernel_x_stencil_13() {
-  int16_t _299 = (int16_t)(2);
-  return _299;
-}
-
-//store is: kernel_x.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_x_stencil_14() {
-  int16_t _302 = (int16_t)(1);
-  return _302;
-}
-
 //store is: padded16_global_wrapper.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y) = padded16.stencil(padded16_global_wrapper_s0_x, padded16_global_wrapper_s0_y)
 hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stencil) {
   int16_t _padded16_stencil_1 = (int16_t) padded16_stencil.extract<0, 15>();
@@ -102,23 +12,13 @@ hw_uint<16> hcompute_padded16_global_wrapper_stencil(hw_uint<16>& padded16_stenc
 
 //store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_x_unclamp_stencil() {
-  int16_t _306 = (int16_t)(0);
-  return _306;
+  int16_t _261 = (int16_t)(0);
+  return _261;
 }
 
-//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))*kernel_x.stencil(-1, -1)) + (grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + ((padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + -1))*kernel_x.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1))*kernel_x.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*kernel_x.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_x_s0_x, grad_x_s0_y)*kernel_x.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*kernel_x.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1))*kernel_x.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1))*kernel_x.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_x_s0_x, (grad_x_s0_y + 1))*kernel_x.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<144>& kernel_x_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) = ((((grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + -1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), (grad_x_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_x_s0_x + 1), grad_x_s0_y)*(int16)2)))) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + -1))) - (padded16_global_wrapper.stencil((grad_x_s0_x + -1), grad_x_s0_y)*(int16)2)) - padded16_global_wrapper.stencil((grad_x_s0_x + -1), (grad_x_s0_y + 1)))
+hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_x_unclamp_stencil_1 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_x_stencil_1 = (int16_t) kernel_x_stencil.extract<0, 15>();
-  int16_t _kernel_x_stencil_2 = (int16_t) kernel_x_stencil.extract<16, 31>();
-  int16_t _kernel_x_stencil_3 = (int16_t) kernel_x_stencil.extract<32, 47>();
-  int16_t _kernel_x_stencil_4 = (int16_t) kernel_x_stencil.extract<48, 63>();
-  int16_t _kernel_x_stencil_5 = (int16_t) kernel_x_stencil.extract<64, 79>();
-  int16_t _kernel_x_stencil_6 = (int16_t) kernel_x_stencil.extract<80, 95>();
-  int16_t _kernel_x_stencil_7 = (int16_t) kernel_x_stencil.extract<96, 111>();
-  int16_t _kernel_x_stencil_8 = (int16_t) kernel_x_stencil.extract<112, 127>();
-  int16_t _kernel_x_stencil_9 = (int16_t) kernel_x_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_1 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_2 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
@@ -126,56 +26,44 @@ hw_uint<16> hcompute_grad_x_unclamp_stencil_1(hw_uint<16>& grad_x_unclamp_stenci
   int16_t _padded16_global_wrapper_stencil_4 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
   int16_t _padded16_global_wrapper_stencil_5 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
   int16_t _padded16_global_wrapper_stencil_6 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
 
-  int16_t _309 = _padded16_global_wrapper_stencil_1 * _kernel_x_stencil_1;
-  int16_t _310 = _padded16_global_wrapper_stencil_2 * _kernel_x_stencil_2;
-  int16_t _311 = _padded16_global_wrapper_stencil_3 * _kernel_x_stencil_3;
-  int16_t _312 = _padded16_global_wrapper_stencil_4 * _kernel_x_stencil_4;
-  int16_t _313 = _padded16_global_wrapper_stencil_5 * _kernel_x_stencil_5;
-  int16_t _314 = _padded16_global_wrapper_stencil_6 * _kernel_x_stencil_6;
-  int16_t _315 = _padded16_global_wrapper_stencil_7 * _kernel_x_stencil_7;
-  int16_t _316 = _padded16_global_wrapper_stencil_8 * _kernel_x_stencil_8;
-  int16_t _317 = _padded16_global_wrapper_stencil_9 * _kernel_x_stencil_9;
-  int16_t _318 = _316 + _317;
-  int16_t _319 = _315 + _318;
-  int16_t _320 = _314 + _319;
-  int16_t _321 = _313 + _320;
-  int16_t _322 = _312 + _321;
-  int16_t _323 = _311 + _322;
-  int16_t _324 = _310 + _323;
-  int16_t _325 = _grad_x_unclamp_stencil_1 + _324;
-  int16_t _326 = _309 + _325;
-  return _326;
+  int16_t _264 = (int16_t)(2);
+  int16_t _265 = _padded16_global_wrapper_stencil_3 * _264;
+  int16_t _266 = _padded16_global_wrapper_stencil_2 + _265;
+  int16_t _267 = _padded16_global_wrapper_stencil_1 + _266;
+  int16_t _268 = _grad_x_unclamp_stencil_1 + _267;
+  int16_t _269 = _268 - _padded16_global_wrapper_stencil_4;
+  int16_t _270 = _padded16_global_wrapper_stencil_5 * _264;
+  int16_t _271 = _269 - _270;
+  int16_t _272 = _271 - _padded16_global_wrapper_stencil_6;
+  return _272;
 }
 
 //store is: grad_x.stencil(grad_x_s0_x, grad_x_s0_y) = max(min(grad_x_unclamp.stencil(grad_x_s0_x, grad_x_s0_y), (int16)180), (int16)-180)
 hw_uint<16> hcompute_grad_x_stencil(hw_uint<16>& grad_x_unclamp_stencil) {
   int16_t _grad_x_unclamp_stencil_2 = (int16_t) grad_x_unclamp_stencil.extract<0, 15>();
 
-  int16_t _386 = (int16_t)(180);
-  int16_t _387 = min(_grad_x_unclamp_stencil_2, _386);
-  int16_t _388 = (int16_t)(-180);
-  int16_t _389 = max(_387, _388);
-  return _389;
+  int16_t _302 = (int16_t)(180);
+  int16_t _303 = min(_grad_x_unclamp_stencil_2, _302);
+  int16_t _304 = (int16_t)(-180);
+  int16_t _305 = max(_303, _304);
+  return _305;
 }
 
 //store is: lxx.stencil(lxx_s0_x, lxx_s0_y) = ((grad_x.stencil(lxx_s0_x, lxx_s0_y)*grad_x.stencil(lxx_s0_x, lxx_s0_y))/(int16)64)
 hw_uint<16> hcompute_lxx_stencil(hw_uint<16>& grad_x_stencil) {
   int16_t _grad_x_stencil_1 = (int16_t) grad_x_stencil.extract<0, 15>();
 
-  int16_t _399 = _grad_x_stencil_1 * _grad_x_stencil_1;
-  int16_t _400 = (int16_t)(6);
-  int16_t _401 = _399 >> _400;
-  return _401;
+  int16_t _315 = _grad_x_stencil_1 * _grad_x_stencil_1;
+  int16_t _316 = (int16_t)(6);
+  int16_t _317 = _315 >> _316;
+  return _317;
 }
 
 //store is: lgxx.stencil(lgxx_s0_x, lgxx_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxx_stencil() {
-  int16_t _409 = (int16_t)(0);
-  return _409;
+  int16_t _325 = (int16_t)(0);
+  return _325;
 }
 
 //store is: lgxx.stencil(lgxx_s1_x, lgxx_s1_y) = (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + -1)) + (lgxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + -1)) + (lxx.stencil((lgxx_s1_x + -1), lgxx_s1_y) + (lxx.stencil(lgxx_s1_x, lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + 1), lgxx_s1_y) + (lxx.stencil((lgxx_s1_x + -1), (lgxx_s1_y + 1)) + (lxx.stencil((lgxx_s1_x + 1), (lgxx_s1_y + 1)) + lxx.stencil(lgxx_s1_x, (lgxx_s1_y + 1)))))))))))
@@ -192,168 +80,56 @@ hw_uint<16> hcompute_lgxx_stencil_1(hw_uint<16>& lgxx_stencil, hw_uint<144>& lxx
   int16_t _lxx_stencil_8 = (int16_t) lxx_stencil.extract<112, 127>();
   int16_t _lxx_stencil_9 = (int16_t) lxx_stencil.extract<128, 143>();
 
-  int16_t _412 = _lxx_stencil_8 + _lxx_stencil_9;
-  int16_t _413 = _lxx_stencil_7 + _412;
-  int16_t _414 = _lxx_stencil_6 + _413;
-  int16_t _415 = _lxx_stencil_5 + _414;
-  int16_t _416 = _lxx_stencil_4 + _415;
-  int16_t _417 = _lxx_stencil_3 + _416;
-  int16_t _418 = _lxx_stencil_2 + _417;
-  int16_t _419 = _lgxx_stencil_1 + _418;
-  int16_t _420 = _lxx_stencil_1 + _419;
-  return _420;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil() {
-  int16_t _453 = (int16_t)(0);
-  return _453;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_1() {
-  int16_t _456 = (int16_t)(0);
-  return _456;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_2() {
-  int16_t _459 = (int16_t)(0);
-  return _459;
-}
-
-//store is: kernel_y.stencil(-1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_3() {
-  int16_t _462 = (int16_t)(0);
-  return _462;
-}
-
-//store is: kernel_y.stencil(0, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_4() {
-  int16_t _465 = (int16_t)(0);
-  return _465;
-}
-
-//store is: kernel_y.stencil(1, 0) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_5() {
-  int16_t _468 = (int16_t)(0);
-  return _468;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_6() {
-  int16_t _471 = (int16_t)(0);
-  return _471;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_7() {
-  int16_t _474 = (int16_t)(0);
-  return _474;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)0
-hw_uint<16> hcompute_kernel_y_stencil_8() {
-  int16_t _477 = (int16_t)(0);
-  return _477;
-}
-
-//store is: kernel_y.stencil(-1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_9() {
-  int16_t _480 = (int16_t)(1);
-  return _480;
-}
-
-//store is: kernel_y.stencil(0, 1) = (int16)2
-hw_uint<16> hcompute_kernel_y_stencil_10() {
-  int16_t _483 = (int16_t)(2);
-  return _483;
-}
-
-//store is: kernel_y.stencil(1, 1) = (int16)1
-hw_uint<16> hcompute_kernel_y_stencil_11() {
-  int16_t _486 = (int16_t)(1);
-  return _486;
-}
-
-//store is: kernel_y.stencil(-1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_12() {
-  int16_t _489 = (int16_t)(-1);
-  return _489;
-}
-
-//store is: kernel_y.stencil(0, -1) = (int16)-2
-hw_uint<16> hcompute_kernel_y_stencil_13() {
-  int16_t _492 = (int16_t)(-2);
-  return _492;
-}
-
-//store is: kernel_y.stencil(1, -1) = (int16)-1
-hw_uint<16> hcompute_kernel_y_stencil_14() {
-  int16_t _495 = (int16_t)(-1);
-  return _495;
+  int16_t _328 = _lxx_stencil_8 + _lxx_stencil_9;
+  int16_t _329 = _lxx_stencil_7 + _328;
+  int16_t _330 = _lxx_stencil_6 + _329;
+  int16_t _331 = _lxx_stencil_5 + _330;
+  int16_t _332 = _lxx_stencil_4 + _331;
+  int16_t _333 = _lxx_stencil_3 + _332;
+  int16_t _334 = _lxx_stencil_2 + _333;
+  int16_t _335 = _lgxx_stencil_1 + _334;
+  int16_t _336 = _lxx_stencil_1 + _335;
+  return _336;
 }
 
 //store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = (int16)0
 hw_uint<16> hcompute_grad_y_unclamp_stencil() {
-  int16_t _498 = (int16_t)(0);
-  return _498;
+  int16_t _369 = (int16_t)(0);
+  return _369;
 }
 
-//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))*kernel_y.stencil(-1, -1)) + (grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + ((padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*kernel_y.stencil(0, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1))*kernel_y.stencil(1, -1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), grad_y_s0_y)*kernel_y.stencil(-1, 0)) + ((padded16_global_wrapper.stencil(grad_y_s0_x, grad_y_s0_y)*kernel_y.stencil(0, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), grad_y_s0_y)*kernel_y.stencil(1, 0)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1))*kernel_y.stencil(-1, 1)) + ((padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1))*kernel_y.stencil(1, 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*kernel_y.stencil(0, 1)))))))))))
-hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<144>& kernel_y_stencil, hw_uint<144>& padded16_global_wrapper_stencil) {
+//store is: grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) = ((((grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y) + (padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + 1)) + (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + 1))*(int16)2)))) - padded16_global_wrapper.stencil((grad_y_s0_x + -1), (grad_y_s0_y + -1))) - (padded16_global_wrapper.stencil(grad_y_s0_x, (grad_y_s0_y + -1))*(int16)2)) - padded16_global_wrapper.stencil((grad_y_s0_x + 1), (grad_y_s0_y + -1)))
+hw_uint<16> hcompute_grad_y_unclamp_stencil_1(hw_uint<16>& grad_y_unclamp_stencil, hw_uint<96>& padded16_global_wrapper_stencil) {
   int16_t _grad_y_unclamp_stencil_1 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
-
-  int16_t _kernel_y_stencil_1 = (int16_t) kernel_y_stencil.extract<0, 15>();
-  int16_t _kernel_y_stencil_2 = (int16_t) kernel_y_stencil.extract<16, 31>();
-  int16_t _kernel_y_stencil_3 = (int16_t) kernel_y_stencil.extract<32, 47>();
-  int16_t _kernel_y_stencil_4 = (int16_t) kernel_y_stencil.extract<48, 63>();
-  int16_t _kernel_y_stencil_5 = (int16_t) kernel_y_stencil.extract<64, 79>();
-  int16_t _kernel_y_stencil_6 = (int16_t) kernel_y_stencil.extract<80, 95>();
-  int16_t _kernel_y_stencil_7 = (int16_t) kernel_y_stencil.extract<96, 111>();
-  int16_t _kernel_y_stencil_8 = (int16_t) kernel_y_stencil.extract<112, 127>();
-  int16_t _kernel_y_stencil_9 = (int16_t) kernel_y_stencil.extract<128, 143>();
 
   int16_t _padded16_global_wrapper_stencil_10 = (int16_t) padded16_global_wrapper_stencil.extract<0, 15>();
   int16_t _padded16_global_wrapper_stencil_11 = (int16_t) padded16_global_wrapper_stencil.extract<16, 31>();
   int16_t _padded16_global_wrapper_stencil_12 = (int16_t) padded16_global_wrapper_stencil.extract<32, 47>();
-  int16_t _padded16_global_wrapper_stencil_13 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
-  int16_t _padded16_global_wrapper_stencil_14 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
-  int16_t _padded16_global_wrapper_stencil_15 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
-  int16_t _padded16_global_wrapper_stencil_16 = (int16_t) padded16_global_wrapper_stencil.extract<96, 111>();
-  int16_t _padded16_global_wrapper_stencil_17 = (int16_t) padded16_global_wrapper_stencil.extract<112, 127>();
-  int16_t _padded16_global_wrapper_stencil_18 = (int16_t) padded16_global_wrapper_stencil.extract<128, 143>();
+  int16_t _padded16_global_wrapper_stencil_7 = (int16_t) padded16_global_wrapper_stencil.extract<48, 63>();
+  int16_t _padded16_global_wrapper_stencil_8 = (int16_t) padded16_global_wrapper_stencil.extract<64, 79>();
+  int16_t _padded16_global_wrapper_stencil_9 = (int16_t) padded16_global_wrapper_stencil.extract<80, 95>();
 
-  int16_t _501 = _padded16_global_wrapper_stencil_10 * _kernel_y_stencil_1;
-  int16_t _502 = _padded16_global_wrapper_stencil_11 * _kernel_y_stencil_2;
-  int16_t _503 = _padded16_global_wrapper_stencil_12 * _kernel_y_stencil_3;
-  int16_t _504 = _padded16_global_wrapper_stencil_13 * _kernel_y_stencil_4;
-  int16_t _505 = _padded16_global_wrapper_stencil_14 * _kernel_y_stencil_5;
-  int16_t _506 = _padded16_global_wrapper_stencil_15 * _kernel_y_stencil_6;
-  int16_t _507 = _padded16_global_wrapper_stencil_16 * _kernel_y_stencil_7;
-  int16_t _508 = _padded16_global_wrapper_stencil_17 * _kernel_y_stencil_8;
-  int16_t _509 = _padded16_global_wrapper_stencil_18 * _kernel_y_stencil_9;
-  int16_t _510 = _508 + _509;
-  int16_t _511 = _507 + _510;
-  int16_t _512 = _506 + _511;
-  int16_t _513 = _505 + _512;
-  int16_t _514 = _504 + _513;
-  int16_t _515 = _503 + _514;
-  int16_t _516 = _502 + _515;
-  int16_t _517 = _grad_y_unclamp_stencil_1 + _516;
-  int16_t _518 = _501 + _517;
-  return _518;
+  int16_t _372 = (int16_t)(2);
+  int16_t _373 = _padded16_global_wrapper_stencil_9 * _372;
+  int16_t _374 = _padded16_global_wrapper_stencil_8 + _373;
+  int16_t _375 = _padded16_global_wrapper_stencil_7 + _374;
+  int16_t _376 = _grad_y_unclamp_stencil_1 + _375;
+  int16_t _377 = _376 - _padded16_global_wrapper_stencil_10;
+  int16_t _378 = _padded16_global_wrapper_stencil_11 * _372;
+  int16_t _379 = _377 - _378;
+  int16_t _380 = _379 - _padded16_global_wrapper_stencil_12;
+  return _380;
 }
 
 //store is: grad_y.stencil(grad_y_s0_x, grad_y_s0_y) = max(min(grad_y_unclamp.stencil(grad_y_s0_x, grad_y_s0_y), (int16)180), (int16)-180)
 hw_uint<16> hcompute_grad_y_stencil(hw_uint<16>& grad_y_unclamp_stencil) {
   int16_t _grad_y_unclamp_stencil_2 = (int16_t) grad_y_unclamp_stencil.extract<0, 15>();
 
-  int16_t _578 = (int16_t)(180);
-  int16_t _579 = min(_grad_y_unclamp_stencil_2, _578);
-  int16_t _580 = (int16_t)(-180);
-  int16_t _581 = max(_579, _580);
-  return _581;
+  int16_t _410 = (int16_t)(180);
+  int16_t _411 = min(_grad_y_unclamp_stencil_2, _410);
+  int16_t _412 = (int16_t)(-180);
+  int16_t _413 = max(_411, _412);
+  return _413;
 }
 
 //store is: lxy.stencil(lxy_s0_x, lxy_s0_y) = ((grad_x.stencil(lxy_s0_x, lxy_s0_y)*grad_y.stencil(lxy_s0_x, lxy_s0_y))/(int16)64)
@@ -362,16 +138,16 @@ hw_uint<16> hcompute_lxy_stencil(hw_uint<16>& grad_x_stencil, hw_uint<16>& grad_
 
   int16_t _grad_y_stencil_1 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _591 = _grad_x_stencil_2 * _grad_y_stencil_1;
-  int16_t _592 = (int16_t)(6);
-  int16_t _593 = _591 >> _592;
-  return _593;
+  int16_t _423 = _grad_x_stencil_2 * _grad_y_stencil_1;
+  int16_t _424 = (int16_t)(6);
+  int16_t _425 = _423 >> _424;
+  return _425;
 }
 
 //store is: lgxy.stencil(lgxy_s0_x, lgxy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgxy_stencil() {
-  int16_t _602 = (int16_t)(0);
-  return _602;
+  int16_t _434 = (int16_t)(0);
+  return _434;
 }
 
 //store is: lgxy.stencil(lgxy_s1_x, lgxy_s1_y) = (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + -1)) + (lgxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + -1)) + (lxy.stencil((lgxy_s1_x + -1), lgxy_s1_y) + (lxy.stencil(lgxy_s1_x, lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + 1), lgxy_s1_y) + (lxy.stencil((lgxy_s1_x + -1), (lgxy_s1_y + 1)) + (lxy.stencil((lgxy_s1_x + 1), (lgxy_s1_y + 1)) + lxy.stencil(lgxy_s1_x, (lgxy_s1_y + 1)))))))))))
@@ -388,32 +164,32 @@ hw_uint<16> hcompute_lgxy_stencil_1(hw_uint<16>& lgxy_stencil, hw_uint<144>& lxy
   int16_t _lxy_stencil_8 = (int16_t) lxy_stencil.extract<112, 127>();
   int16_t _lxy_stencil_9 = (int16_t) lxy_stencil.extract<128, 143>();
 
-  int16_t _605 = _lxy_stencil_8 + _lxy_stencil_9;
-  int16_t _606 = _lxy_stencil_7 + _605;
-  int16_t _607 = _lxy_stencil_6 + _606;
-  int16_t _608 = _lxy_stencil_5 + _607;
-  int16_t _609 = _lxy_stencil_4 + _608;
-  int16_t _610 = _lxy_stencil_3 + _609;
-  int16_t _611 = _lxy_stencil_2 + _610;
-  int16_t _612 = _lgxy_stencil_1 + _611;
-  int16_t _613 = _lxy_stencil_1 + _612;
-  return _613;
+  int16_t _437 = _lxy_stencil_8 + _lxy_stencil_9;
+  int16_t _438 = _lxy_stencil_7 + _437;
+  int16_t _439 = _lxy_stencil_6 + _438;
+  int16_t _440 = _lxy_stencil_5 + _439;
+  int16_t _441 = _lxy_stencil_4 + _440;
+  int16_t _442 = _lxy_stencil_3 + _441;
+  int16_t _443 = _lxy_stencil_2 + _442;
+  int16_t _444 = _lgxy_stencil_1 + _443;
+  int16_t _445 = _lxy_stencil_1 + _444;
+  return _445;
 }
 
 //store is: lyy.stencil(lyy_s0_x, lyy_s0_y) = ((grad_y.stencil(lyy_s0_x, lyy_s0_y)*grad_y.stencil(lyy_s0_x, lyy_s0_y))/(int16)64)
 hw_uint<16> hcompute_lyy_stencil(hw_uint<16>& grad_y_stencil) {
   int16_t _grad_y_stencil_2 = (int16_t) grad_y_stencil.extract<0, 15>();
 
-  int16_t _646 = _grad_y_stencil_2 * _grad_y_stencil_2;
-  int16_t _647 = (int16_t)(6);
-  int16_t _648 = _646 >> _647;
-  return _648;
+  int16_t _478 = _grad_y_stencil_2 * _grad_y_stencil_2;
+  int16_t _479 = (int16_t)(6);
+  int16_t _480 = _478 >> _479;
+  return _480;
 }
 
 //store is: lgyy.stencil(lgyy_s0_x, lgyy_s0_y) = (int16)0
 hw_uint<16> hcompute_lgyy_stencil() {
-  int16_t _656 = (int16_t)(0);
-  return _656;
+  int16_t _488 = (int16_t)(0);
+  return _488;
 }
 
 //store is: lgyy.stencil(lgyy_s1_x, lgyy_s1_y) = (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + -1)) + (lgyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + -1)) + (lyy.stencil((lgyy_s1_x + -1), lgyy_s1_y) + (lyy.stencil(lgyy_s1_x, lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + 1), lgyy_s1_y) + (lyy.stencil((lgyy_s1_x + -1), (lgyy_s1_y + 1)) + (lyy.stencil((lgyy_s1_x + 1), (lgyy_s1_y + 1)) + lyy.stencil(lgyy_s1_x, (lgyy_s1_y + 1)))))))))))
@@ -430,16 +206,16 @@ hw_uint<16> hcompute_lgyy_stencil_1(hw_uint<16>& lgyy_stencil, hw_uint<144>& lyy
   int16_t _lyy_stencil_8 = (int16_t) lyy_stencil.extract<112, 127>();
   int16_t _lyy_stencil_9 = (int16_t) lyy_stencil.extract<128, 143>();
 
-  int16_t _659 = _lyy_stencil_8 + _lyy_stencil_9;
-  int16_t _660 = _lyy_stencil_7 + _659;
-  int16_t _661 = _lyy_stencil_6 + _660;
-  int16_t _662 = _lyy_stencil_5 + _661;
-  int16_t _663 = _lyy_stencil_4 + _662;
-  int16_t _664 = _lyy_stencil_3 + _663;
-  int16_t _665 = _lyy_stencil_2 + _664;
-  int16_t _666 = _lgyy_stencil_1 + _665;
-  int16_t _667 = _lyy_stencil_1 + _666;
-  return _667;
+  int16_t _491 = _lyy_stencil_8 + _lyy_stencil_9;
+  int16_t _492 = _lyy_stencil_7 + _491;
+  int16_t _493 = _lyy_stencil_6 + _492;
+  int16_t _494 = _lyy_stencil_5 + _493;
+  int16_t _495 = _lyy_stencil_4 + _494;
+  int16_t _496 = _lyy_stencil_3 + _495;
+  int16_t _497 = _lyy_stencil_2 + _496;
+  int16_t _498 = _lgyy_stencil_1 + _497;
+  int16_t _499 = _lyy_stencil_1 + _498;
+  return _499;
 }
 
 //store is: cim.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1)) = ((((lgxx.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64)*(lgyy.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64)) - ((lgxy.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64)*(lgxy.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64))) - ((((lgxx.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64) + (lgyy.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64))*((lgxx.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64) + (lgyy.stencil((cim_s0_x_xi + -1), (cim_s0_y_yi + -1))/(int16)64)))/(int16)16))
@@ -450,18 +226,18 @@ hw_uint<16> hcompute_cim_stencil(hw_uint<16>& lgxx_stencil, hw_uint<16>& lgxy_st
 
   int16_t _lgyy_stencil_2 = (int16_t) lgyy_stencil.extract<0, 15>();
 
-  int16_t _700 = (int16_t)(6);
-  int16_t _701 = _lgxx_stencil_2 >> _700;
-  int16_t _702 = _lgyy_stencil_2 >> _700;
-  int16_t _703 = _701 * _702;
-  int16_t _704 = _lgxy_stencil_2 >> _700;
-  int16_t _705 = _704 * _704;
-  int16_t _706 = _703 - _705;
-  int16_t _707 = _701 + _702;
-  int16_t _708 = _707 * _707;
-  int16_t _709 = (int16_t)(4);
-  int16_t _710 = _708 >> _709;
-  int16_t _711 = _706 - _710;
-  return _711;
+  int16_t _532 = (int16_t)(6);
+  int16_t _533 = _lgxx_stencil_2 >> _532;
+  int16_t _534 = _lgyy_stencil_2 >> _532;
+  int16_t _535 = _533 * _534;
+  int16_t _536 = _lgxy_stencil_2 >> _532;
+  int16_t _537 = _536 * _536;
+  int16_t _538 = _535 - _537;
+  int16_t _539 = _533 + _534;
+  int16_t _540 = _539 * _539;
+  int16_t _541 = (int16_t)(4);
+  int16_t _542 = _540 >> _541;
+  int16_t _543 = _538 - _542;
+  return _543;
 }
 


### PR DESCRIPTION
- updates to schedules 5, 6, 7, 8